### PR TITLE
feat: UI全面強化 - 白テーマ・コマンドパレット・オーバーレイ・お気に入り

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "esbuild": "^0.27.4"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -338,7 +341,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -543,6 +545,422 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -1292,6 +1710,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1303,8 +1730,16 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -1331,11 +1766,35 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1352,7 +1811,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -1373,7 +1831,6 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1388,6 +1845,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/send": {
@@ -1411,6 +1878,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -1427,6 +1900,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1709,6 +2188,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1960,6 +2449,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1968,6 +2467,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -1990,6 +2529,16 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2103,7 +2652,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2144,6 +2692,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -2181,7 +2742,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2194,6 +2754,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -2317,7 +2890,6 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2370,6 +2942,28 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -2452,6 +3046,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -2492,6 +3092,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -2530,6 +3143,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/forwarded": {
@@ -2709,6 +3330,136 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/hastscript/node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2720,6 +3471,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -2800,6 +3561,12 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2807,6 +3574,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -2838,6 +3629,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2861,6 +3662,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2869,6 +3680,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2997,6 +3820,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3007,6 +3840,20 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -3040,6 +3887,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3047,6 +3904,276 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -3086,6 +4213,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3334,6 +5024,31 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -3627,6 +5342,25 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3768,6 +5502,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3776,6 +5537,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.6",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.6.tgz",
+      "integrity": "sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/read-cache": {
@@ -3827,6 +5605,188 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -4209,6 +6169,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4241,6 +6211,20 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4261,6 +6245,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -4589,6 +6591,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -4691,6 +6713,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4757,6 +6866,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -5553,6 +7690,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -5589,6 +7735,16 @@
         }
       }
     },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/client": {
       "name": "@kurimats/client",
       "version": "0.1.0",
@@ -5599,11 +7755,15 @@
         "@xterm/xterm": "^5.5.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-markdown": "^9.0.0",
+        "react-syntax-highlighter": "^15.6.1",
+        "remark-gfm": "^4.0.0",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "turbo": "^2.4.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.2"
+  },
+  "dependencies": {
+    "esbuild": "^0.27.4"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,11 +15,15 @@
     "@xterm/addon-web-links": "^0.11.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-markdown": "^9.0.0",
+    "react-syntax-highlighter": "^15.6.1",
+    "remark-gfm": "^4.0.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -2,17 +2,29 @@ import { useEffect } from 'react'
 import { Sidebar } from './components/layout/Sidebar'
 import { PanelContainer } from './components/layout/PanelContainer'
 import { StatusBar } from './components/layout/StatusBar'
+import { CommandPalette } from './components/command-palette/CommandPalette'
+import { FileTreeOverlay } from './components/overlays/FileTreeOverlay'
+import { CodeViewerOverlay } from './components/overlays/CodeViewerOverlay'
+import { MarkdownOverlay } from './components/overlays/MarkdownOverlay'
 import { useSessionStore } from './stores/session-store'
+import { useOverlayStore } from './stores/overlay-store'
+import { useCommandPaletteStore } from './stores/command-palette-store'
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 
 export default function App() {
-  const { fetchSessions } = useSessionStore()
+  const { fetchSessions, fetchProjects } = useSessionStore()
+  const { activeOverlay, closeOverlay, overlayProps } = useOverlayStore()
+  const { isOpen: isPaletteOpen } = useCommandPaletteStore()
+
+  useKeyboardShortcuts()
 
   useEffect(() => {
     fetchSessions()
-  }, [fetchSessions])
+    fetchProjects()
+  }, [fetchSessions, fetchProjects])
 
   return (
-    <div className="h-screen flex flex-col bg-surface-0 text-white">
+    <div className="h-screen flex flex-col bg-white text-text-primary">
       {/* メインエリア: サイドバー + パネル */}
       <div className="flex-1 flex min-h-0">
         <Sidebar />
@@ -23,6 +35,26 @@ export default function App() {
 
       {/* ステータスバー */}
       <StatusBar />
+
+      {/* コマンドパレット */}
+      {isPaletteOpen && <CommandPalette />}
+
+      {/* オーバーレイ */}
+      {activeOverlay === 'file-tree' && (
+        <FileTreeOverlay onClose={closeOverlay} />
+      )}
+      {activeOverlay === 'code-viewer' && (
+        <CodeViewerOverlay
+          filePath={overlayProps.filePath as string}
+          onClose={closeOverlay}
+        />
+      )}
+      {activeOverlay === 'markdown' && (
+        <MarkdownOverlay
+          filePath={overlayProps.filePath as string | undefined}
+          onClose={closeOverlay}
+        />
+      )}
     </div>
   )
 }

--- a/packages/client/src/__tests__/overlays.test.ts
+++ b/packages/client/src/__tests__/overlays.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useOverlayStore } from '../stores/overlay-store'
+import { useCommandPaletteStore } from '../stores/command-palette-store'
+
+describe('オーバーレイストア', () => {
+  beforeEach(() => {
+    useOverlayStore.setState({ activeOverlay: null, overlayProps: {} })
+  })
+
+  it('初期状態ではオーバーレイなし', () => {
+    const state = useOverlayStore.getState()
+    expect(state.activeOverlay).toBeNull()
+    expect(state.overlayProps).toEqual({})
+  })
+
+  it('ファイルツリーオーバーレイを開ける', () => {
+    useOverlayStore.getState().openOverlay('file-tree')
+    const state = useOverlayStore.getState()
+    expect(state.activeOverlay).toBe('file-tree')
+  })
+
+  it('コードビューアをprops付きで開ける', () => {
+    useOverlayStore.getState().openOverlay('code-viewer', { filePath: '/test/file.ts' })
+    const state = useOverlayStore.getState()
+    expect(state.activeOverlay).toBe('code-viewer')
+    expect(state.overlayProps.filePath).toBe('/test/file.ts')
+  })
+
+  it('Markdownオーバーレイを開ける', () => {
+    useOverlayStore.getState().openOverlay('markdown')
+    expect(useOverlayStore.getState().activeOverlay).toBe('markdown')
+  })
+
+  it('オーバーレイを閉じるとnullに戻る', () => {
+    useOverlayStore.getState().openOverlay('file-tree')
+    useOverlayStore.getState().closeOverlay()
+    const state = useOverlayStore.getState()
+    expect(state.activeOverlay).toBeNull()
+    expect(state.overlayProps).toEqual({})
+  })
+
+  it('別のオーバーレイに切り替えできる', () => {
+    useOverlayStore.getState().openOverlay('file-tree')
+    useOverlayStore.getState().openOverlay('markdown')
+    expect(useOverlayStore.getState().activeOverlay).toBe('markdown')
+  })
+})
+
+describe('コマンドパレットストア', () => {
+  beforeEach(() => {
+    useCommandPaletteStore.setState({ isOpen: false, search: '' })
+  })
+
+  it('初期状態では閉じている', () => {
+    const state = useCommandPaletteStore.getState()
+    expect(state.isOpen).toBe(false)
+    expect(state.search).toBe('')
+  })
+
+  it('openで開いてsearchがリセットされる', () => {
+    useCommandPaletteStore.getState().setSearch('テスト')
+    useCommandPaletteStore.getState().open()
+    const state = useCommandPaletteStore.getState()
+    expect(state.isOpen).toBe(true)
+    expect(state.search).toBe('')
+  })
+
+  it('closeで閉じてsearchがリセットされる', () => {
+    useCommandPaletteStore.getState().open()
+    useCommandPaletteStore.getState().setSearch('検索語')
+    useCommandPaletteStore.getState().close()
+    const state = useCommandPaletteStore.getState()
+    expect(state.isOpen).toBe(false)
+    expect(state.search).toBe('')
+  })
+
+  it('検索テキストを設定できる', () => {
+    useCommandPaletteStore.getState().setSearch('レイアウト')
+    expect(useCommandPaletteStore.getState().search).toBe('レイアウト')
+  })
+})

--- a/packages/client/src/components/command-palette/CommandPalette.tsx
+++ b/packages/client/src/components/command-palette/CommandPalette.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef, useState, useMemo } from 'react'
+import { createPortal } from 'react-dom'
+import { useCommandPaletteStore, type Command } from '../../stores/command-palette-store'
+import { useSessionStore } from '../../stores/session-store'
+import { useLayoutStore } from '../../stores/layout-store'
+import { useOverlayStore } from '../../stores/overlay-store'
+import type { LayoutMode } from '@kurimats/shared'
+
+/**
+ * コマンドパレット
+ * Ctrl+Shift+P / Ctrl+K で開く
+ * コマンド検索・実行
+ */
+export function CommandPalette() {
+  const { search, setSearch, close } = useCommandPaletteStore()
+  const { sessions } = useSessionStore()
+  const { setMode, addPanel, setActivePanel, panels } = useLayoutStore()
+  const { openOverlay } = useOverlayStore()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  // コマンド一覧の構築
+  const commands: Command[] = useMemo(() => {
+    const cmds: Command[] = [
+      // レイアウトコマンド
+      { id: 'layout-1x1', label: 'レイアウト: 1列', shortcut: '', category: 'レイアウト', action: () => { setMode('1x1' as LayoutMode); close() } },
+      { id: 'layout-2x1', label: 'レイアウト: 2列', shortcut: '', category: 'レイアウト', action: () => { setMode('2x1' as LayoutMode); close() } },
+      { id: 'layout-1x2', label: 'レイアウト: 2段', shortcut: '', category: 'レイアウト', action: () => { setMode('1x2' as LayoutMode); close() } },
+      { id: 'layout-2x2', label: 'レイアウト: 4分割', shortcut: '', category: 'レイアウト', action: () => { setMode('2x2' as LayoutMode); close() } },
+      { id: 'layout-3x1', label: 'レイアウト: 3列', shortcut: '', category: 'レイアウト', action: () => { setMode('3x1' as LayoutMode); close() } },
+      // オーバーレイコマンド
+      { id: 'file-tree', label: 'ファイルツリーを開く', shortcut: '⌘E', category: 'ツール', action: () => { openOverlay('file-tree'); close() } },
+      { id: 'markdown', label: 'Markdownプレビュー', shortcut: '⌘M', category: 'ツール', action: () => { openOverlay('markdown'); close() } },
+    ]
+
+    // セッションコマンド
+    sessions.forEach(session => {
+      const panelIndex = panels.findIndex(p => p.sessionId === session.id)
+      const isInPanel = panelIndex >= 0
+
+      cmds.push({
+        id: `session-${session.id}`,
+        label: `セッションに移動: ${session.name}`,
+        shortcut: '',
+        category: 'セッション',
+        action: () => {
+          if (isInPanel) {
+            setActivePanel(panelIndex)
+          } else {
+            addPanel(session.id)
+          }
+          close()
+        },
+      })
+    })
+
+    return cmds
+  }, [sessions, panels, setMode, openOverlay, close, setActivePanel, addPanel])
+
+  // 検索フィルタ
+  const filteredCommands = useMemo(() => {
+    if (!search.trim()) return commands
+    const query = search.toLowerCase()
+    return commands.filter(cmd =>
+      cmd.label.toLowerCase().includes(query) ||
+      cmd.category.toLowerCase().includes(query)
+    )
+  }, [commands, search])
+
+  // 選択インデックスのリセット
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [search])
+
+  // 初期フォーカス
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // 選択項目のスクロール追従
+  useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const selected = list.children[selectedIndex] as HTMLElement
+    if (selected) {
+      selected.scrollIntoView({ block: 'nearest' })
+    }
+  }, [selectedIndex])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelectedIndex(prev => Math.min(prev + 1, filteredCommands.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelectedIndex(prev => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (filteredCommands[selectedIndex]) {
+        filteredCommands[selectedIndex].action()
+      }
+    } else if (e.key === 'Escape') {
+      close()
+    }
+  }
+
+  // テキストハイライト
+  const highlightMatch = (text: string) => {
+    if (!search.trim()) return text
+    const query = search.toLowerCase()
+    const idx = text.toLowerCase().indexOf(query)
+    if (idx < 0) return text
+    return (
+      <>
+        {text.slice(0, idx)}
+        <span className="text-accent font-semibold">{text.slice(idx, idx + search.length)}</span>
+        {text.slice(idx + search.length)}
+      </>
+    )
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex justify-center pt-[15vh] animate-fade-in"
+      onClick={close}
+    >
+      {/* 背景オーバーレイ */}
+      <div className="absolute inset-0 bg-black/10" />
+
+      {/* パレット本体 */}
+      <div
+        className="relative w-full max-w-[600px] bg-white rounded-lg shadow-2xl border border-border overflow-hidden animate-slide-down"
+        style={{ maxHeight: '60vh' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* 検索入力 */}
+        <div className="flex items-center px-4 py-3 border-b border-border">
+          <span className="text-text-secondary mr-2">{'>'}</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="コマンドを検索..."
+            className="flex-1 bg-transparent text-text-primary text-sm outline-none placeholder-text-muted"
+          />
+        </div>
+
+        {/* コマンドリスト */}
+        <div ref={listRef} className="overflow-y-auto custom-scrollbar" style={{ maxHeight: 'calc(60vh - 52px)' }}>
+          {filteredCommands.length === 0 ? (
+            <div className="px-4 py-6 text-center text-text-muted text-sm">
+              一致するコマンドがありません
+            </div>
+          ) : (
+            filteredCommands.map((cmd, idx) => (
+              <button
+                key={cmd.id}
+                onClick={() => cmd.action()}
+                className={`w-full text-left px-4 py-2 flex items-center justify-between text-sm transition-colors ${
+                  idx === selectedIndex
+                    ? 'bg-accent-light text-text-primary'
+                    : 'text-text-primary hover:bg-surface-2'
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-text-muted text-xs">{cmd.category}</span>
+                  <span className="truncate">{highlightMatch(cmd.label)}</span>
+                </div>
+                {cmd.shortcut && (
+                  <span className="text-xs text-text-muted ml-4 flex-shrink-0 bg-surface-2 px-1.5 py-0.5 rounded">
+                    {cmd.shortcut}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/packages/client/src/components/layout/PanelContainer.tsx
+++ b/packages/client/src/components/layout/PanelContainer.tsx
@@ -24,7 +24,7 @@ export function PanelContainer() {
           <div
             key={index}
             className={`flex flex-col min-h-0 min-w-0 border ${
-              isActive ? 'border-accent/50' : 'border-border/30'
+              isActive ? 'border-accent' : 'border-border'
             }`}
             onClick={() => setActivePanel(index)}
           >
@@ -38,7 +38,7 @@ export function PanelContainer() {
                     removeSession(session.id)
                   }}
                 />
-                <div className="flex-1 min-h-0 bg-surface-0">
+                <div className="flex-1 min-h-0">
                   <TerminalComponent
                     sessionId={session.id}
                     isActive={isActive}
@@ -47,10 +47,10 @@ export function PanelContainer() {
                 </div>
               </>
             ) : (
-              <div className="flex-1 flex items-center justify-center bg-surface-0 text-gray-600">
+              <div className="flex-1 flex items-center justify-center bg-white text-text-muted">
                 <div className="text-center">
                   <p className="text-sm">空のパネル</p>
-                  <p className="text-xs mt-1">サイドバーからセッションを作成</p>
+                  <p className="text-xs mt-1 text-text-muted">サイドバーからセッションを作成</p>
                 </div>
               </div>
             )}

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
-import type { LayoutMode } from '@kurimats/shared'
+import { useState, useMemo } from 'react'
+import type { LayoutMode, Session } from '@kurimats/shared'
+import { PROJECT_COLORS } from '@kurimats/shared'
 import { useSessionStore } from '../../stores/session-store'
 import { useLayoutStore } from '../../stores/layout-store'
 
@@ -13,40 +14,97 @@ const LAYOUT_OPTIONS: { mode: LayoutMode; label: string; icon: string }[] = [
 
 /**
  * サイドバー
- * セッション一覧、新規作成、レイアウト変更
+ * セッション一覧、お気に入り、プロジェクト管理、レイアウト変更
  */
 export function Sidebar() {
-  const { sessions, createSession } = useSessionStore()
+  const { sessions, projects, createSession, toggleFavorite, assignProject, createProject } = useSessionStore()
   const { mode, setMode, addPanel, setActivePanel, panels } = useLayoutStore()
   const [showNewForm, setShowNewForm] = useState(false)
   const [newName, setNewName] = useState('')
   const [newRepoPath, setNewRepoPath] = useState('')
+  const [newProjectId, setNewProjectId] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [favoritesCollapsed, setFavoritesCollapsed] = useState(false)
+  const [projectsCollapsed, setProjectsCollapsed] = useState(false)
+  const [showProjectForm, setShowProjectForm] = useState(false)
+  const [newProjectName, setNewProjectName] = useState('')
+  const [newProjectColor, setNewProjectColor] = useState<string>(PROJECT_COLORS[0])
+
+  // お気に入りセッション
+  const favoriteSessions = useMemo(() =>
+    sessions.filter(s => s.isFavorite),
+    [sessions]
+  )
+
+  // 検索フィルタリング
+  const filteredSessions = useMemo(() => {
+    if (!searchQuery.trim()) return sessions
+    const q = searchQuery.toLowerCase()
+    return sessions.filter(s =>
+      s.name.toLowerCase().includes(q) ||
+      s.branch?.toLowerCase().includes(q) ||
+      s.repoPath.toLowerCase().includes(q)
+    )
+  }, [sessions, searchQuery])
 
   const handleCreate = async () => {
     if (!newName.trim() || !newRepoPath.trim()) return
-
     try {
       const session = await createSession({
         name: newName.trim(),
         repoPath: newRepoPath.trim(),
       })
+      if (newProjectId) {
+        await assignProject(session.id, newProjectId)
+      }
       addPanel(session.id)
       setNewName('')
       setNewRepoPath('')
+      setNewProjectId(null)
       setShowNewForm(false)
     } catch (e) {
       alert(`作成エラー: ${e}`)
     }
   }
 
+  const handleCreateProject = async () => {
+    if (!newProjectName.trim()) return
+    try {
+      await createProject({
+        name: newProjectName.trim(),
+        color: newProjectColor,
+        repoPath: '',
+      })
+      setNewProjectName('')
+      setNewProjectColor(PROJECT_COLORS[0])
+      setShowProjectForm(false)
+    } catch (e) {
+      alert(`プロジェクト作成エラー: ${e}`)
+    }
+  }
+
+  const handleSessionClick = (session: Session) => {
+    const panelIndex = panels.findIndex(p => p.sessionId === session.id)
+    if (panelIndex >= 0) {
+      setActivePanel(panelIndex)
+    } else {
+      addPanel(session.id)
+    }
+  }
+
+  const getProjectColor = (projectId: string | null) => {
+    if (!projectId) return null
+    return projects.find(p => p.id === projectId)?.color ?? null
+  }
+
   return (
-    <div className="w-56 bg-surface-1 border-r border-border flex flex-col h-full">
+    <div className="w-60 bg-surface-1 border-r border-border flex flex-col h-full">
       {/* ヘッダー */}
-      <div className="px-3 py-2 border-b border-border flex items-center justify-between">
-        <h1 className="text-sm font-bold text-gray-300">Kurimats</h1>
+      <div className="px-3 py-2.5 border-b border-border flex items-center justify-between">
+        <h1 className="text-sm font-bold text-text-primary">Kurimats</h1>
         <button
           onClick={() => setShowNewForm(!showNewForm)}
-          className="text-lg text-gray-400 hover:text-white leading-none"
+          className="w-6 h-6 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-2 rounded transition-colors text-lg leading-none"
           title="新規セッション"
         >
           +
@@ -55,13 +113,13 @@ export function Sidebar() {
 
       {/* 新規セッション作成フォーム */}
       {showNewForm && (
-        <div className="p-2 border-b border-border space-y-2">
+        <div className="p-3 border-b border-border space-y-2 bg-surface-0">
           <input
             type="text"
             placeholder="セッション名"
             value={newName}
             onChange={e => setNewName(e.target.value)}
-            className="w-full px-2 py-1 text-xs bg-surface-0 border border-border rounded text-white placeholder-gray-500 focus:border-accent outline-none"
+            className="w-full px-2.5 py-1.5 text-xs bg-white border border-border rounded text-text-primary placeholder-text-muted focus:border-accent outline-none"
             autoFocus
           />
           <input
@@ -69,65 +127,180 @@ export function Sidebar() {
             placeholder="リポジトリパス"
             value={newRepoPath}
             onChange={e => setNewRepoPath(e.target.value)}
-            className="w-full px-2 py-1 text-xs bg-surface-0 border border-border rounded text-white placeholder-gray-500 focus:border-accent outline-none"
+            className="w-full px-2.5 py-1.5 text-xs bg-white border border-border rounded text-text-primary placeholder-text-muted focus:border-accent outline-none"
             onKeyDown={e => e.key === 'Enter' && handleCreate()}
           />
+          {/* プロジェクト選択 */}
+          {projects.length > 0 && (
+            <select
+              value={newProjectId || ''}
+              onChange={e => setNewProjectId(e.target.value || null)}
+              className="w-full px-2.5 py-1.5 text-xs bg-white border border-border rounded text-text-primary outline-none focus:border-accent"
+            >
+              <option value="">プロジェクトなし</option>
+              {projects.map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
           <button
             onClick={handleCreate}
-            className="w-full px-2 py-1 text-xs bg-accent hover:bg-accent-hover text-white rounded transition-colors"
+            className="w-full px-2 py-1.5 text-xs bg-accent hover:bg-accent-hover text-white rounded transition-colors font-medium"
           >
             作成
           </button>
         </div>
       )}
 
-      {/* セッション一覧 */}
-      <div className="flex-1 overflow-y-auto py-1">
-        {sessions.length === 0 ? (
-          <p className="px-3 py-4 text-xs text-gray-500 text-center">
-            セッションなし
-          </p>
-        ) : (
-          sessions.map(session => {
-            const panelIndex = panels.findIndex(p => p.sessionId === session.id)
-            const isInPanel = panelIndex >= 0
+      {/* セッション検索 */}
+      <div className="px-3 py-2 border-b border-border">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="セッションを検索..."
+          className="w-full px-2.5 py-1.5 text-xs bg-white border border-border rounded text-text-primary placeholder-text-muted focus:border-accent outline-none"
+        />
+      </div>
 
-            return (
-              <button
-                key={session.id}
-                onClick={() => {
-                  if (isInPanel) {
-                    setActivePanel(panelIndex)
-                  } else {
-                    addPanel(session.id)
-                  }
-                }}
-                className={`w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-surface-2 transition-colors ${
-                  isInPanel ? 'text-white' : 'text-gray-400'
-                }`}
-              >
-                <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-                  session.status === 'active' ? 'bg-green-500' : 'bg-gray-500'
-                }`} />
-                <span className="truncate">{session.name}</span>
-              </button>
-            )
-          })
+      {/* セッション一覧エリア */}
+      <div className="flex-1 overflow-y-auto custom-scrollbar">
+        {/* お気に入りセクション */}
+        {favoriteSessions.length > 0 && (
+          <div>
+            <button
+              onClick={() => setFavoritesCollapsed(!favoritesCollapsed)}
+              className="w-full text-left px-3 py-1.5 text-[10px] font-semibold text-text-secondary uppercase tracking-wider hover:bg-surface-2 transition-colors flex items-center gap-1"
+            >
+              <span className="text-[8px]">{favoritesCollapsed ? '▶' : '▼'}</span>
+              お気に入り
+              <span className="text-text-muted ml-auto">{favoriteSessions.length}</span>
+            </button>
+            {!favoritesCollapsed && favoriteSessions.map(session => (
+              <SessionItem
+                key={`fav-${session.id}`}
+                session={session}
+                isInPanel={panels.some(p => p.sessionId === session.id)}
+                projectColor={getProjectColor(session.projectId)}
+                onClick={() => handleSessionClick(session)}
+                onToggleFavorite={() => toggleFavorite(session.id)}
+              />
+            ))}
+          </div>
         )}
+
+        {/* 全セッションセクション */}
+        <div>
+          <div className="px-3 py-1.5 text-[10px] font-semibold text-text-secondary uppercase tracking-wider">
+            全セッション
+            <span className="text-text-muted ml-1">{filteredSessions.length}</span>
+          </div>
+          {filteredSessions.length === 0 ? (
+            <p className="px-3 py-4 text-xs text-text-muted text-center">
+              {searchQuery ? '一致するセッションなし' : 'セッションなし'}
+            </p>
+          ) : (
+            filteredSessions.map(session => (
+              <SessionItem
+                key={session.id}
+                session={session}
+                isInPanel={panels.some(p => p.sessionId === session.id)}
+                projectColor={getProjectColor(session.projectId)}
+                onClick={() => handleSessionClick(session)}
+                onToggleFavorite={() => toggleFavorite(session.id)}
+              />
+            ))
+          )}
+        </div>
+
+        {/* プロジェクトセクション */}
+        <div className="border-t border-border mt-1">
+          <button
+            onClick={() => setProjectsCollapsed(!projectsCollapsed)}
+            className="w-full text-left px-3 py-1.5 text-[10px] font-semibold text-text-secondary uppercase tracking-wider hover:bg-surface-2 transition-colors flex items-center gap-1"
+          >
+            <span className="text-[8px]">{projectsCollapsed ? '▶' : '▼'}</span>
+            プロジェクト
+            <span className="text-text-muted ml-auto">{projects.length}</span>
+          </button>
+          {!projectsCollapsed && (
+            <>
+              {projects.map(project => (
+                <div
+                  key={project.id}
+                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-text-primary hover:bg-surface-2 transition-colors"
+                >
+                  <span
+                    className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                    style={{ backgroundColor: project.color }}
+                  />
+                  <span className="truncate">{project.name}</span>
+                </div>
+              ))}
+              {/* 新規プロジェクト */}
+              {showProjectForm ? (
+                <div className="px-3 py-2 space-y-2">
+                  <input
+                    type="text"
+                    placeholder="プロジェクト名"
+                    value={newProjectName}
+                    onChange={e => setNewProjectName(e.target.value)}
+                    className="w-full px-2 py-1 text-xs bg-white border border-border rounded text-text-primary placeholder-text-muted focus:border-accent outline-none"
+                    autoFocus
+                    onKeyDown={e => e.key === 'Enter' && handleCreateProject()}
+                  />
+                  <div className="flex gap-1 flex-wrap">
+                    {PROJECT_COLORS.map(color => (
+                      <button
+                        key={color}
+                        onClick={() => setNewProjectColor(color)}
+                        className={`w-5 h-5 rounded-sm transition-transform ${
+                          newProjectColor === color ? 'ring-2 ring-accent ring-offset-1 scale-110' : ''
+                        }`}
+                        style={{ backgroundColor: color }}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex gap-1">
+                    <button
+                      onClick={handleCreateProject}
+                      className="flex-1 px-2 py-1 text-xs bg-accent hover:bg-accent-hover text-white rounded transition-colors"
+                    >
+                      作成
+                    </button>
+                    <button
+                      onClick={() => setShowProjectForm(false)}
+                      className="px-2 py-1 text-xs bg-surface-2 text-text-secondary hover:bg-surface-3 rounded transition-colors"
+                    >
+                      取消
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setShowProjectForm(true)}
+                  className="w-full text-left px-3 py-1.5 text-xs text-accent hover:bg-surface-2 transition-colors"
+                >
+                  + 新規プロジェクト
+                </button>
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       {/* レイアウト切り替え */}
-      <div className="px-2 py-2 border-t border-border">
-        <p className="text-[10px] text-gray-500 mb-1 px-1">レイアウト</p>
+      <div className="px-3 py-2.5 border-t border-border">
+        <p className="text-[10px] text-text-secondary mb-1.5 font-medium">レイアウト</p>
         <div className="flex gap-1">
           {LAYOUT_OPTIONS.map(opt => (
             <button
               key={opt.mode}
               onClick={() => setMode(opt.mode)}
-              className={`flex-1 py-1 text-xs rounded transition-colors ${
+              className={`flex-1 py-1.5 text-xs rounded transition-colors ${
                 mode === opt.mode
                   ? 'bg-accent text-white'
-                  : 'bg-surface-2 text-gray-400 hover:bg-surface-3'
+                  : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
               }`}
               title={opt.label}
             >
@@ -137,5 +310,60 @@ export function Sidebar() {
         </div>
       </div>
     </div>
+  )
+}
+
+/**
+ * セッションリストアイテム
+ */
+function SessionItem({
+  session,
+  isInPanel,
+  projectColor,
+  onClick,
+  onToggleFavorite,
+}: {
+  session: Session
+  isInPanel: boolean
+  projectColor: string | null
+  onClick: () => void
+  onToggleFavorite: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-surface-2 transition-colors group ${
+        isInPanel ? 'text-text-primary font-medium' : 'text-text-secondary'
+      }`}
+    >
+      {/* ステータスドット */}
+      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+        session.status === 'active' ? 'bg-green-500' : 'bg-gray-400'
+      }`} />
+
+      {/* プロジェクトカラードット */}
+      {projectColor && (
+        <span
+          className="w-1.5 h-1.5 rounded-sm flex-shrink-0"
+          style={{ backgroundColor: projectColor }}
+        />
+      )}
+
+      {/* セッション名 */}
+      <span className="truncate flex-1">{session.name}</span>
+
+      {/* お気に入りボタン */}
+      <span
+        onClick={(e) => { e.stopPropagation(); onToggleFavorite() }}
+        className={`flex-shrink-0 transition-colors cursor-pointer ${
+          session.isFavorite
+            ? 'text-yellow-500'
+            : 'text-transparent group-hover:text-text-muted'
+        }`}
+        title={session.isFavorite ? 'お気に入り解除' : 'お気に入りに追加'}
+      >
+        ★
+      </span>
+    </button>
   )
 }

--- a/packages/client/src/components/layout/StatusBar.tsx
+++ b/packages/client/src/components/layout/StatusBar.tsx
@@ -10,12 +10,18 @@ export function StatusBar() {
   const activeSessions = sessions.filter(s => s.status === 'active')
 
   return (
-    <div className="h-6 bg-accent flex items-center px-3 text-[11px] text-white/90 gap-4">
-      <span>Kurimats Emulator</span>
-      <span>セッション: {activeSessions.length}</span>
+    <div className="h-7 bg-white border-t border-border flex items-center px-3 text-[11px] text-text-secondary gap-4">
+      <span className="font-medium text-text-primary">Kurimats Emulator</span>
+      <span>セッション: {activeSessions.length}/{sessions.length}</span>
       <span>レイアウト: {mode}</span>
       <div className="flex-1" />
-      <span>Ctrl+E: ファイル | Ctrl+M: MD | Ctrl+P: 検索</span>
+      <span className="text-text-muted">
+        <kbd className="px-1 py-0.5 bg-surface-2 rounded text-[10px]">⌘⇧P</kbd> コマンド
+        <span className="mx-1.5">|</span>
+        <kbd className="px-1 py-0.5 bg-surface-2 rounded text-[10px]">⌘E</kbd> ファイル
+        <span className="mx-1.5">|</span>
+        <kbd className="px-1 py-0.5 bg-surface-2 rounded text-[10px]">⌘M</kbd> MD
+      </span>
     </div>
   )
 }

--- a/packages/client/src/components/overlays/CodeViewerOverlay.tsx
+++ b/packages/client/src/components/overlays/CodeViewerOverlay.tsx
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { filesApi } from '../../lib/api'
+import { OverlayContainer } from './OverlayContainer'
+
+interface Props {
+  filePath: string
+  onClose: () => void
+}
+
+// 拡張子から言語を推定
+function getLanguage(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() || ''
+  const map: Record<string, string> = {
+    ts: 'typescript', tsx: 'tsx', js: 'javascript', jsx: 'jsx',
+    json: 'json', css: 'css', html: 'html', md: 'markdown',
+    py: 'python', rs: 'rust', go: 'go', sh: 'bash', bash: 'bash',
+    yml: 'yaml', yaml: 'yaml', toml: 'toml', sql: 'sql',
+    dockerfile: 'docker', makefile: 'makefile',
+  }
+  return map[ext] || 'text'
+}
+
+/**
+ * コードビューアオーバーレイ
+ * ファイル内容をシンタックスハイライト付きで表示
+ */
+export function CodeViewerOverlay({ filePath, onClose }: Props) {
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [wordWrap, setWordWrap] = useState(true)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!filePath) return
+    setLoading(true)
+    setError(null)
+    filesApi.content(filePath)
+      .then(data => {
+        setContent(data.content)
+        setLoading(false)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }, [filePath])
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(content).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }, [content])
+
+  const language = getLanguage(filePath)
+  const fileName = filePath.split('/').pop() || filePath
+
+  return (
+    <OverlayContainer isOpen={true} onClose={onClose} title={fileName}>
+      <div className="flex flex-col h-full">
+        {/* ツールバー */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-surface-1">
+          <span className="text-xs text-text-muted truncate flex-1">{filePath}</span>
+          <div className="flex items-center gap-2 ml-4">
+            <button
+              onClick={() => setWordWrap(!wordWrap)}
+              className={`text-xs px-2 py-1 rounded transition-colors ${
+                wordWrap
+                  ? 'bg-accent text-white'
+                  : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
+              }`}
+              title="折り返し切り替え"
+            >
+              折り返し
+            </button>
+            <button
+              onClick={handleCopy}
+              className="text-xs px-2 py-1 rounded bg-surface-2 text-text-secondary hover:bg-surface-3 transition-colors"
+              title="コピー"
+            >
+              {copied ? '✓ コピー済み' : 'コピー'}
+            </button>
+          </div>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="flex-1 overflow-auto custom-scrollbar">
+          {loading && (
+            <div className="flex items-center justify-center py-8 text-text-muted text-sm">
+              読み込み中...
+            </div>
+          )}
+          {error && (
+            <div className="flex items-center justify-center py-8 text-red-500 text-sm">
+              {error}
+            </div>
+          )}
+          {!loading && !error && (
+            <SyntaxHighlighter
+              language={language}
+              style={oneLight}
+              showLineNumbers
+              wrapLines={wordWrap}
+              wrapLongLines={wordWrap}
+              customStyle={{
+                margin: 0,
+                padding: '12px',
+                fontSize: '13px',
+                lineHeight: '1.5',
+                background: '#ffffff',
+                minHeight: '100%',
+              }}
+              lineNumberStyle={{
+                minWidth: '3em',
+                paddingRight: '1em',
+                color: '#9ca3af',
+                userSelect: 'none',
+              }}
+            >
+              {content}
+            </SyntaxHighlighter>
+          )}
+        </div>
+      </div>
+    </OverlayContainer>
+  )
+}

--- a/packages/client/src/components/overlays/FileTreeOverlay.tsx
+++ b/packages/client/src/components/overlays/FileTreeOverlay.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { FileNode } from '@kurimats/shared'
+import { filesApi } from '../../lib/api'
+import { useOverlayStore } from '../../stores/overlay-store'
+import { useSessionStore } from '../../stores/session-store'
+import { useLayoutStore } from '../../stores/layout-store'
+import { OverlayContainer } from './OverlayContainer'
+
+interface Props {
+  onClose: () => void
+}
+
+/**
+ * ファイルツリーオーバーレイ
+ * リポジトリのファイル構造を表示
+ */
+export function FileTreeOverlay({ onClose }: Props) {
+  const { sessions } = useSessionStore()
+  const { panels, activePanelIndex } = useLayoutStore()
+  const { openOverlay } = useOverlayStore()
+  const [tree, setTree] = useState<FileNode[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+  const [workingDir, setWorkingDir] = useState('')
+
+  // アクティブなセッションのリポジトリパスを取得
+  useEffect(() => {
+    const activePanel = panels[activePanelIndex]
+    const activeSession = activePanel?.sessionId
+      ? sessions.find(s => s.id === activePanel.sessionId)
+      : sessions[0]
+
+    const root = activeSession?.worktreePath || activeSession?.repoPath || ''
+    setWorkingDir(root)
+
+    if (!root) {
+      setLoading(false)
+      setError('セッションが選択されていません')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    filesApi.tree(root)
+      .then(nodes => {
+        setTree(nodes)
+        setLoading(false)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }, [sessions, panels, activePanelIndex])
+
+  const handleFileClick = useCallback((path: string) => {
+    // Markdownファイルならmarkdownオーバーレイ、それ以外はコードビューア
+    if (path.endsWith('.md')) {
+      openOverlay('markdown', { filePath: path })
+    } else {
+      openOverlay('code-viewer', { filePath: path })
+    }
+  }, [openOverlay])
+
+  return (
+    <OverlayContainer isOpen={true} onClose={onClose} title="ファイルツリー">
+      <div className="flex flex-col h-full">
+        {/* 作業ディレクトリ表示 */}
+        {workingDir && (
+          <div className="px-4 py-2 text-xs text-text-muted bg-surface-1 border-b border-border truncate">
+            {workingDir}
+          </div>
+        )}
+
+        {/* フィルター入力 */}
+        <div className="px-4 py-2 border-b border-border">
+          <input
+            type="text"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            placeholder="ファイルを検索..."
+            className="w-full px-3 py-1.5 text-sm bg-surface-1 border border-border rounded text-text-primary placeholder-text-muted outline-none focus:border-accent"
+            autoFocus
+          />
+        </div>
+
+        {/* ツリー表示 */}
+        <div className="flex-1 overflow-y-auto custom-scrollbar px-2 py-2">
+          {loading && (
+            <div className="flex items-center justify-center py-8 text-text-muted text-sm">
+              読み込み中...
+            </div>
+          )}
+          {error && (
+            <div className="flex items-center justify-center py-8 text-red-500 text-sm">
+              {error}
+            </div>
+          )}
+          {!loading && !error && tree.length === 0 && (
+            <div className="flex items-center justify-center py-8 text-text-muted text-sm">
+              ファイルがありません
+            </div>
+          )}
+          {!loading && !error && tree.map(node => (
+            <FileTreeNode
+              key={node.path}
+              node={node}
+              depth={0}
+              filter={filter}
+              onFileClick={handleFileClick}
+            />
+          ))}
+        </div>
+      </div>
+    </OverlayContainer>
+  )
+}
+
+interface FileTreeNodeProps {
+  node: FileNode
+  depth: number
+  filter: string
+  onFileClick: (path: string) => void
+}
+
+function FileTreeNode({ node, depth, filter, onFileClick }: FileTreeNodeProps) {
+  const [expanded, setExpanded] = useState(depth < 1)
+
+  // フィルター適用
+  const matchesFilter = !filter.trim() || node.name.toLowerCase().includes(filter.toLowerCase())
+  const hasMatchingChildren = node.children?.some(child =>
+    matchesFilter || child.name.toLowerCase().includes(filter.toLowerCase()) ||
+    (child.isDirectory && hasDescendantMatch(child, filter))
+  )
+
+  if (!matchesFilter && !hasMatchingChildren && !node.isDirectory) return null
+  if (node.isDirectory && !matchesFilter && !hasMatchingChildren) return null
+
+  const paddingLeft = depth * 16 + 8
+
+  if (node.isDirectory) {
+    return (
+      <>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-left flex items-center gap-1.5 py-1 px-2 text-sm text-text-primary hover:bg-surface-2 rounded transition-colors"
+          style={{ paddingLeft }}
+        >
+          <span className="text-xs text-text-muted w-4 text-center flex-shrink-0">
+            {expanded ? '▼' : '▶'}
+          </span>
+          <span className="text-text-secondary">📁</span>
+          <span className="truncate">{node.name}</span>
+        </button>
+        {expanded && node.children?.map(child => (
+          <FileTreeNode
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            filter={filter}
+            onFileClick={onFileClick}
+          />
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <button
+      onClick={() => onFileClick(node.path)}
+      className="w-full text-left flex items-center gap-1.5 py-1 px-2 text-sm text-text-primary hover:bg-surface-2 rounded transition-colors"
+      style={{ paddingLeft: paddingLeft + 16 }}
+    >
+      <span className="text-text-secondary">📄</span>
+      <span className="truncate">{node.name}</span>
+    </button>
+  )
+}
+
+function hasDescendantMatch(node: FileNode, filter: string): boolean {
+  if (!filter.trim()) return true
+  const query = filter.toLowerCase()
+  if (node.name.toLowerCase().includes(query)) return true
+  return node.children?.some(child => hasDescendantMatch(child, query)) ?? false
+}

--- a/packages/client/src/components/overlays/MarkdownOverlay.tsx
+++ b/packages/client/src/components/overlays/MarkdownOverlay.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { filesApi } from '../../lib/api'
+import { useSessionStore } from '../../stores/session-store'
+import { useLayoutStore } from '../../stores/layout-store'
+import { OverlayContainer } from './OverlayContainer'
+
+interface Props {
+  onClose: () => void
+  filePath?: string
+}
+
+/**
+ * Markdownオーバーレイ
+ * マークダウンファイルの編集・プレビュー
+ */
+export function MarkdownOverlay({ onClose, filePath: initialPath }: Props) {
+  const { sessions } = useSessionStore()
+  const { panels, activePanelIndex } = useLayoutStore()
+  const [filePath, setFilePath] = useState(initialPath || '')
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showEditor, setShowEditor] = useState(false)
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // ファイルパスが指定されていない場合、README.mdを検索
+  useEffect(() => {
+    if (initialPath) {
+      loadFile(initialPath)
+      return
+    }
+
+    // アクティブセッションのリポジトリからREADME.mdを探す
+    const activePanel = panels[activePanelIndex]
+    const activeSession = activePanel?.sessionId
+      ? sessions.find(s => s.id === activePanel.sessionId)
+      : sessions[0]
+    const root = activeSession?.worktreePath || activeSession?.repoPath
+    if (root) {
+      const readmePath = `${root}/README.md`
+      setFilePath(readmePath)
+      loadFile(readmePath)
+    }
+  }, [initialPath, sessions, panels, activePanelIndex])
+
+  const loadFile = useCallback((path: string) => {
+    if (!path) return
+    setLoading(true)
+    setError(null)
+    filesApi.content(path)
+      .then(data => {
+        setContent(data.content)
+        setLoading(false)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }, [])
+
+  // デバウンス付き自動保存
+  const handleContentChange = useCallback((newContent: string) => {
+    setContent(newContent)
+    if (!filePath) return
+
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+    saveTimeoutRef.current = setTimeout(() => {
+      filesApi.save(filePath, newContent).catch(e => {
+        console.error('保存エラー:', e)
+      })
+    }, 1000)
+  }, [filePath])
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+    }
+  }, [])
+
+  const handlePathChange = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      const target = e.target as HTMLInputElement
+      setFilePath(target.value)
+      loadFile(target.value)
+    }
+  }, [loadFile])
+
+  return (
+    <OverlayContainer isOpen={true} onClose={onClose} title="Markdown プレビュー">
+      <div className="flex flex-col h-full">
+        {/* ファイルパス入力 */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-1">
+          <input
+            type="text"
+            value={filePath}
+            onChange={e => setFilePath(e.target.value)}
+            onKeyDown={handlePathChange}
+            placeholder=".md ファイルのパスを入力 (Enterで読み込み)"
+            className="flex-1 px-3 py-1.5 text-xs bg-white border border-border rounded text-text-primary placeholder-text-muted outline-none focus:border-accent"
+          />
+          <button
+            onClick={() => setShowEditor(!showEditor)}
+            className={`text-xs px-2 py-1.5 rounded transition-colors ${
+              showEditor
+                ? 'bg-accent text-white'
+                : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
+            }`}
+          >
+            {showEditor ? 'プレビューのみ' : '編集'}
+          </button>
+        </div>
+
+        {/* コンテンツエリア */}
+        <div className="flex-1 flex min-h-0">
+          {loading && (
+            <div className="flex-1 flex items-center justify-center text-text-muted text-sm">
+              読み込み中...
+            </div>
+          )}
+          {error && (
+            <div className="flex-1 flex items-center justify-center text-red-500 text-sm">
+              {error}
+            </div>
+          )}
+          {!loading && !error && (
+            <>
+              {/* エディター */}
+              {showEditor && (
+                <div className="flex-1 border-r border-border">
+                  <textarea
+                    value={content}
+                    onChange={e => handleContentChange(e.target.value)}
+                    className="w-full h-full p-4 text-sm font-mono text-text-primary bg-surface-1 resize-none outline-none custom-scrollbar"
+                    spellCheck={false}
+                  />
+                </div>
+              )}
+
+              {/* プレビュー */}
+              <div className="flex-1 overflow-y-auto custom-scrollbar p-6">
+                <div className="prose prose-sm max-w-none
+                  prose-headings:text-text-primary prose-headings:font-semibold
+                  prose-p:text-text-primary prose-p:leading-relaxed
+                  prose-a:text-accent prose-a:no-underline hover:prose-a:underline
+                  prose-code:text-accent prose-code:bg-surface-1 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+                  prose-pre:bg-surface-1 prose-pre:border prose-pre:border-border
+                  prose-blockquote:border-accent prose-blockquote:text-text-secondary
+                  prose-strong:text-text-primary
+                  prose-li:text-text-primary
+                  prose-th:text-text-primary prose-td:text-text-primary
+                  prose-hr:border-border
+                ">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {content || '_ファイルを選択してください_'}
+                  </ReactMarkdown>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </OverlayContainer>
+  )
+}

--- a/packages/client/src/components/overlays/OverlayContainer.tsx
+++ b/packages/client/src/components/overlays/OverlayContainer.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+}
+
+/**
+ * オーバーレイコンテナ
+ * 右側からスライドインするパネル
+ */
+export function OverlayContainer({ isOpen, onClose, title, children }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Escapeキーで閉じる
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    if (isOpen) {
+      window.addEventListener('keydown', handler)
+    }
+    return () => window.removeEventListener('keydown', handler)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end animate-fade-in">
+      {/* 背景 */}
+      <div
+        className="absolute inset-0 bg-black/20 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* パネル */}
+      <div
+        ref={panelRef}
+        className="relative w-1/2 max-w-[700px] min-w-[400px] h-full bg-white shadow-2xl flex flex-col animate-slide-in"
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-2 rounded transition-colors"
+            title="閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="flex-1 overflow-hidden">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/src/components/terminal/TerminalHeader.tsx
+++ b/packages/client/src/components/terminal/TerminalHeader.tsx
@@ -13,26 +13,26 @@ interface Props {
 export function TerminalHeader({ session, isActive, onClose }: Props) {
   return (
     <div
-      className={`flex items-center justify-between px-3 py-1 text-xs border-b ${
+      className={`flex items-center justify-between px-3 py-1.5 text-xs border-b transition-colors ${
         isActive
-          ? 'bg-surface-2 border-accent text-white'
-          : 'bg-surface-1 border-border text-gray-400'
+          ? 'bg-surface-1 border-accent text-text-primary'
+          : 'bg-surface-0 border-border text-text-secondary'
       }`}
     >
       <div className="flex items-center gap-2 min-w-0">
         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-          session.status === 'active' ? 'bg-green-500' : 'bg-gray-500'
+          session.status === 'active' ? 'bg-green-500' : 'bg-gray-400'
         }`} />
         <span className="truncate font-medium">{session.name}</span>
         {session.branch && (
-          <span className="text-gray-500 truncate">
+          <span className="text-text-muted truncate">
             [{session.branch}]
           </span>
         )}
       </div>
       <button
         onClick={(e) => { e.stopPropagation(); onClose() }}
-        className="text-gray-500 hover:text-white px-1 rounded hover:bg-surface-3 transition-colors"
+        className="text-text-muted hover:text-text-primary px-1 rounded hover:bg-surface-2 transition-colors"
         title="セッション終了"
       >
         ×

--- a/packages/client/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/client/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+import { useCommandPaletteStore } from '../stores/command-palette-store'
+import { useOverlayStore } from '../stores/overlay-store'
+
+export function useKeyboardShortcuts() {
+  const { open: openPalette } = useCommandPaletteStore()
+  const { openOverlay, closeOverlay, activeOverlay } = useOverlayStore()
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Escape → オーバーレイ/パレット閉じる
+      if (e.key === 'Escape') {
+        closeOverlay()
+        useCommandPaletteStore.getState().close()
+        return
+      }
+
+      // コマンドパレットが開いている場合はショートカットを無効化
+      if (useCommandPaletteStore.getState().isOpen) return
+      // オーバーレイが開いている場合も無効化
+      if (activeOverlay) return
+
+      // Ctrl/Cmd+Shift+P → コマンドパレット
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'p') {
+        e.preventDefault()
+        openPalette()
+        return
+      }
+
+      // Ctrl/Cmd+K → 検索（コマンドパレットを検索モードで開く）
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault()
+        openPalette()
+        return
+      }
+
+      // Ctrl/Cmd+E → ファイルツリー
+      if ((e.ctrlKey || e.metaKey) && e.key === 'e') {
+        e.preventDefault()
+        openOverlay('file-tree')
+        return
+      }
+
+      // Ctrl/Cmd+M → Markdownプレビュー
+      if ((e.ctrlKey || e.metaKey) && e.key === 'm') {
+        e.preventDefault()
+        openOverlay('markdown')
+        return
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [openPalette, openOverlay, closeOverlay, activeOverlay])
+}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -11,7 +11,9 @@
 html, body, #root {
   height: 100%;
   overflow: hidden;
-  font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  font-family: -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background: #ffffff;
+  color: #1a1a1a;
 }
 
 /* xterm.jsのスクロールバースタイリング */
@@ -27,4 +29,45 @@ html, body, #root {
 }
 .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: #555;
+}
+
+/* コマンドパレットのアニメーション */
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-slide-down {
+  animation: slideDown 0.15s ease-out;
+}
+
+/* オーバーレイのアニメーション */
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(20px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.animate-slide-in {
+  animation: slideIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-fade-in {
+  animation: fadeIn 0.15s ease-out;
+}
+
+/* カスタムスクロールバー（白テーマ用） */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 3px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
 }

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Session, CreateSessionParams, FileNode } from '@kurimats/shared'
+import type { Session, CreateSessionParams, FileNode, Project, CreateProjectParams, LayoutState } from '@kurimats/shared'
 
 const BASE = '/api'
 
@@ -25,6 +25,13 @@ export const sessionsApi = {
     }),
   delete: (id: string) =>
     request<{ ok: boolean }>(`/sessions/${id}`, { method: 'DELETE' }),
+  toggleFavorite: (id: string) =>
+    request<{ isFavorite: boolean }>(`/sessions/${id}/favorite`, { method: 'POST' }),
+  assignProject: (id: string, projectId: string | null) =>
+    request<{ ok: boolean }>(`/sessions/${id}/project`, {
+      method: 'POST',
+      body: JSON.stringify({ projectId }),
+    }),
 }
 
 // ファイルAPI
@@ -36,4 +43,22 @@ export const filesApi = {
       method: 'PUT',
       body: JSON.stringify({ path, content }),
     }),
+}
+
+// プロジェクトAPI
+export const projectsApi = {
+  list: () => request<Project[]>('/projects'),
+  create: (params: CreateProjectParams) =>
+    request<Project>('/projects', { method: 'POST', body: JSON.stringify(params) }),
+  update: (id: string, updates: Partial<CreateProjectParams>) =>
+    request<{ ok: boolean }>(`/projects/${id}`, { method: 'PATCH', body: JSON.stringify(updates) }),
+  delete: (id: string) =>
+    request<{ ok: boolean }>(`/projects/${id}`, { method: 'DELETE' }),
+}
+
+// レイアウトAPI
+export const layoutApi = {
+  get: () => request<LayoutState | null>('/layout'),
+  save: (state: LayoutState) =>
+    request<{ ok: boolean }>('/layout', { method: 'PUT', body: JSON.stringify(state) }),
 }

--- a/packages/client/src/stores/command-palette-store.ts
+++ b/packages/client/src/stores/command-palette-store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand'
+
+export interface Command {
+  id: string
+  label: string
+  shortcut?: string
+  category: string
+  action: () => void
+}
+
+interface CommandPaletteState {
+  isOpen: boolean
+  search: string
+  open: () => void
+  close: () => void
+  setSearch: (s: string) => void
+}
+
+export const useCommandPaletteStore = create<CommandPaletteState>((set) => ({
+  isOpen: false,
+  search: '',
+  open: () => set({ isOpen: true, search: '' }),
+  close: () => set({ isOpen: false, search: '' }),
+  setSearch: (search) => set({ search }),
+}))

--- a/packages/client/src/stores/layout-store.ts
+++ b/packages/client/src/stores/layout-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { LayoutMode } from '@kurimats/shared'
+import { layoutApi } from '../lib/api'
 
 interface PanelInfo {
   sessionId: string | null
@@ -16,7 +17,10 @@ interface LayoutState {
   removeSession: (sessionId: string) => void
   setActivePanel: (index: number) => void
   addPanel: (sessionId: string) => void
+  loadSavedLayout: () => Promise<void>
 }
+
+const STORAGE_KEY = 'kurimats-layout'
 
 function panelCountForMode(mode: LayoutMode): number {
   switch (mode) {
@@ -28,10 +32,57 @@ function panelCountForMode(mode: LayoutMode): number {
   }
 }
 
+// レイアウト状態の永続化（デバウンス付き）
+let saveTimeout: ReturnType<typeof setTimeout> | null = null
+
+function persistLayout(state: { mode: LayoutMode; panels: PanelInfo[]; activePanelIndex: number }) {
+  const layoutData = {
+    mode: state.mode,
+    panels: state.panels,
+    activePanelIndex: state.activePanelIndex,
+    savedAt: Date.now(),
+  }
+
+  // localStorageに即座に保存
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layoutData))
+  } catch {
+    // localStorage利用不可の場合は無視
+  }
+
+  // サーバーへの保存はデバウンス
+  if (saveTimeout) clearTimeout(saveTimeout)
+  saveTimeout = setTimeout(() => {
+    layoutApi.save(layoutData).catch(() => {
+      // サーバー保存失敗は無視（localStorageがバックアップ）
+    })
+  }, 1000)
+}
+
+function loadFromStorage(): Partial<LayoutState> | null {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      const data = JSON.parse(saved)
+      return {
+        mode: data.mode,
+        panels: data.panels,
+        activePanelIndex: data.activePanelIndex,
+      }
+    }
+  } catch {
+    // パースエラーは無視
+  }
+  return null
+}
+
+// 初期状態をlocalStorageから復元
+const savedState = loadFromStorage()
+
 export const useLayoutStore = create<LayoutState>((set, get) => ({
-  mode: '1x1',
-  panels: [{ sessionId: null, position: 0 }],
-  activePanelIndex: 0,
+  mode: savedState?.mode ?? '1x1',
+  panels: savedState?.panels ?? [{ sessionId: null, position: 0 }],
+  activePanelIndex: savedState?.activePanelIndex ?? 0,
 
   setMode: (mode) => {
     const count = panelCountForMode(mode)
@@ -40,7 +91,9 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       sessionId: current[i]?.sessionId ?? null,
       position: i,
     }))
-    set({ mode, panels, activePanelIndex: Math.min(get().activePanelIndex, count - 1) })
+    const newState = { mode, panels, activePanelIndex: Math.min(get().activePanelIndex, count - 1) }
+    set(newState)
+    persistLayout(newState)
   },
 
   assignSession: (panelIndex, sessionId) => {
@@ -49,6 +102,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       panels[panelIndex] = { ...panels[panelIndex], sessionId }
     }
     set({ panels })
+    persistLayout({ ...get(), panels })
   },
 
   removeSession: (sessionId) => {
@@ -56,10 +110,12 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       p.sessionId === sessionId ? { ...p, sessionId: null } : p
     )
     set({ panels })
+    persistLayout({ ...get(), panels })
   },
 
   setActivePanel: (index) => {
     set({ activePanelIndex: index })
+    persistLayout({ ...get(), activePanelIndex: index })
   },
 
   addPanel: (sessionId) => {
@@ -70,6 +126,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       const newPanels = [...panels]
       newPanels[emptyIndex] = { ...newPanels[emptyIndex], sessionId }
       set({ panels: newPanels, activePanelIndex: emptyIndex })
+      persistLayout({ ...get(), panels: newPanels, activePanelIndex: emptyIndex })
       return
     }
     // 空きがなければレイアウト拡張
@@ -87,7 +144,29 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       if (firstEmpty >= 0) {
         newPanels[firstEmpty] = { ...newPanels[firstEmpty], sessionId }
       }
-      set({ mode: newMode, panels: newPanels, activePanelIndex: firstEmpty >= 0 ? firstEmpty : 0 })
+      const newState = { mode: newMode, panels: newPanels, activePanelIndex: firstEmpty >= 0 ? firstEmpty : 0 }
+      set(newState)
+      persistLayout(newState)
+    }
+  },
+
+  loadSavedLayout: async () => {
+    try {
+      const serverLayout = await layoutApi.get()
+      if (serverLayout) {
+        const localSaved = loadFromStorage()
+        // サーバーの方が新しい場合はサーバーのデータを使用
+        const localSavedAt = localSaved ? (JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}').savedAt || 0) : 0
+        if (serverLayout.savedAt > localSavedAt) {
+          set({
+            mode: serverLayout.mode,
+            panels: serverLayout.panels,
+            activePanelIndex: serverLayout.activePanelIndex,
+          })
+        }
+      }
+    } catch {
+      // サーバー取得失敗はlocalStorageの状態を維持
     }
   },
 }))

--- a/packages/client/src/stores/overlay-store.ts
+++ b/packages/client/src/stores/overlay-store.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+type OverlayType = 'file-tree' | 'code-viewer' | 'markdown' | null
+
+interface OverlayState {
+  activeOverlay: OverlayType
+  overlayProps: Record<string, unknown>
+  openOverlay: (type: OverlayType, props?: Record<string, unknown>) => void
+  closeOverlay: () => void
+}
+
+export const useOverlayStore = create<OverlayState>((set) => ({
+  activeOverlay: null,
+  overlayProps: {},
+  openOverlay: (type, props = {}) => set({ activeOverlay: type, overlayProps: props }),
+  closeOverlay: () => set({ activeOverlay: null, overlayProps: {} }),
+}))

--- a/packages/client/src/stores/session-store.ts
+++ b/packages/client/src/stores/session-store.ts
@@ -1,19 +1,27 @@
 import { create } from 'zustand'
-import type { Session, CreateSessionParams } from '@kurimats/shared'
-import { sessionsApi } from '../lib/api'
+import type { Session, CreateSessionParams, Project, CreateProjectParams } from '@kurimats/shared'
+import { sessionsApi, projectsApi } from '../lib/api'
 
 interface SessionState {
   sessions: Session[]
+  projects: Project[]
   loading: boolean
   error: string | null
 
   fetchSessions: () => Promise<void>
   createSession: (params: CreateSessionParams) => Promise<Session>
   deleteSession: (id: string) => Promise<void>
+  toggleFavorite: (id: string) => Promise<void>
+  assignProject: (sessionId: string, projectId: string | null) => Promise<void>
+
+  fetchProjects: () => Promise<void>
+  createProject: (params: CreateProjectParams) => Promise<Project>
+  deleteProject: (id: string) => Promise<void>
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
   sessions: [],
+  projects: [],
   loading: false,
   error: null,
 
@@ -36,5 +44,51 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   deleteSession: async (id) => {
     await sessionsApi.delete(id)
     set({ sessions: get().sessions.filter(s => s.id !== id) })
+  },
+
+  toggleFavorite: async (id) => {
+    try {
+      const { isFavorite } = await sessionsApi.toggleFavorite(id)
+      set({
+        sessions: get().sessions.map(s =>
+          s.id === id ? { ...s, isFavorite } : s
+        ),
+      })
+    } catch (e) {
+      console.error('お気に入り切り替えエラー:', e)
+    }
+  },
+
+  assignProject: async (sessionId, projectId) => {
+    try {
+      await sessionsApi.assignProject(sessionId, projectId)
+      set({
+        sessions: get().sessions.map(s =>
+          s.id === sessionId ? { ...s, projectId } : s
+        ),
+      })
+    } catch (e) {
+      console.error('プロジェクト割り当てエラー:', e)
+    }
+  },
+
+  fetchProjects: async () => {
+    try {
+      const projects = await projectsApi.list()
+      set({ projects })
+    } catch (e) {
+      console.error('プロジェクト取得エラー:', e)
+    }
+  },
+
+  createProject: async (params) => {
+    const project = await projectsApi.create(params)
+    set({ projects: [...get().projects, project] })
+    return project
+  },
+
+  deleteProject: async (id) => {
+    await projectsApi.delete(id)
+    set({ projects: get().projects.filter(p => p.id !== id) })
   },
 }))

--- a/packages/client/tailwind.config.js
+++ b/packages/client/tailwind.config.js
@@ -5,16 +5,20 @@ export default {
     extend: {
       colors: {
         surface: {
-          0: '#1e1e1e',
-          1: '#252526',
-          2: '#2d2d30',
-          3: '#3e3e42',
+          0: '#ffffff',       // メイン背景
+          1: '#f8f9fa',       // サイドバー
+          2: '#e9ecef',       // ホバー
+          3: '#dee2e6',       // アクティブ
         },
         accent: {
-          DEFAULT: '#007acc',
-          hover: '#1a8ad4',
+          DEFAULT: '#0066cc',
+          hover: '#0052a3',
+          light: '#e6f0ff',
         },
-        border: '#404040',
+        border: '#e0e0e0',
+        'text-primary': '#1a1a1a',
+        'text-secondary': '#6b7280',
+        'text-muted': '#9ca3af',
       },
     },
   },

--- a/packages/server/src/__tests__/projects-and-favorites.test.ts
+++ b/packages/server/src/__tests__/projects-and-favorites.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import { createServer, type Server } from 'http'
+import { SessionStore } from '../services/session-store.js'
+import { PtyManager } from '../services/pty-manager.js'
+import { WorktreeService } from '../services/worktree-service.js'
+import { createSessionsRouter } from '../routes/sessions.js'
+import { createProjectsRouter } from '../routes/projects.js'
+import { createLayoutRouter } from '../routes/layout.js'
+
+describe('プロジェクト・お気に入り・レイアウトAPI', () => {
+  let server: Server
+  let baseUrl: string
+  let store: SessionStore
+  let ptyManager: PtyManager
+
+  beforeEach(async () => {
+    store = new SessionStore()
+    ptyManager = new PtyManager()
+    const worktreeService = new WorktreeService()
+
+    const app = express()
+    app.use(express.json())
+    app.use('/api/sessions', createSessionsRouter(store, ptyManager, worktreeService))
+    app.use('/api/projects', createProjectsRouter(store))
+    app.use('/api/layout', createLayoutRouter(store))
+
+    server = createServer(app)
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve())
+    })
+    const addr = server.address()
+    const port = typeof addr === 'object' && addr ? addr.port : 0
+    baseUrl = `http://localhost:${port}`
+  })
+
+  afterEach(() => {
+    ptyManager.killAll()
+    store.close()
+    server.close()
+  })
+
+  // プロジェクトCRUD
+  describe('プロジェクト', () => {
+    it('プロジェクトを作成・一覧取得できる', async () => {
+      const createRes = await fetch(`${baseUrl}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'テストPJ', color: '#3b82f6', repoPath: '/tmp' }),
+      })
+      expect(createRes.status).toBe(201)
+      const project = await createRes.json()
+      expect(project.name).toBe('テストPJ')
+      expect(project.color).toBe('#3b82f6')
+
+      const listRes = await fetch(`${baseUrl}/api/projects`)
+      const projects = await listRes.json()
+      const found = projects.find((p: { id: string }) => p.id === project.id)
+      expect(found).toBeTruthy()
+      expect(found.name).toBe('テストPJ')
+    })
+
+    it('プロジェクトを更新できる', async () => {
+      const createRes = await fetch(`${baseUrl}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: '更新前', color: '#ef4444', repoPath: '/tmp' }),
+      })
+      const project = await createRes.json()
+
+      const updateRes = await fetch(`${baseUrl}/api/projects/${project.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: '更新後', color: '#10b981' }),
+      })
+      expect(updateRes.status).toBe(200)
+
+      const listRes = await fetch(`${baseUrl}/api/projects`)
+      const projects = await listRes.json()
+      expect(projects[0].name).toBe('更新後')
+      expect(projects[0].color).toBe('#10b981')
+    })
+
+    it('プロジェクトを削除できる', async () => {
+      const createRes = await fetch(`${baseUrl}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: '削除用', color: '#3b82f6', repoPath: '/tmp' }),
+      })
+      const project = await createRes.json()
+
+      const delRes = await fetch(`${baseUrl}/api/projects/${project.id}`, { method: 'DELETE' })
+      expect(delRes.status).toBe(200)
+
+      // 削除後に再取得して確認
+      const getRes = await fetch(`${baseUrl}/api/projects`)
+      const remaining = await getRes.json()
+      const found = remaining.find((p: { id: string }) => p.id === project.id)
+      expect(found).toBeUndefined()
+    })
+  })
+
+  // お気に入り
+  describe('お気に入り', () => {
+    it('お気に入りをトグルできる', async () => {
+      // セッション作成
+      const createRes = await fetch(`${baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'fav-test', repoPath: '/tmp', useWorktree: false }),
+      })
+      const session = await createRes.json()
+      expect(session.isFavorite).toBe(false)
+
+      // お気に入りON
+      const favRes1 = await fetch(`${baseUrl}/api/sessions/${session.id}/favorite`, { method: 'POST' })
+      const fav1 = await favRes1.json()
+      expect(fav1.isFavorite).toBe(true)
+
+      // お気に入りOFF
+      const favRes2 = await fetch(`${baseUrl}/api/sessions/${session.id}/favorite`, { method: 'POST' })
+      const fav2 = await favRes2.json()
+      expect(fav2.isFavorite).toBe(false)
+    })
+
+    it('プロジェクトをセッションに割り当てできる', async () => {
+      // プロジェクト作成
+      const projRes = await fetch(`${baseUrl}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'PJ1', color: '#3b82f6', repoPath: '/tmp' }),
+      })
+      const project = await projRes.json()
+
+      // セッション作成
+      const sessRes = await fetch(`${baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'proj-test', repoPath: '/tmp', useWorktree: false }),
+      })
+      const session = await sessRes.json()
+
+      // プロジェクト割り当て
+      const assignRes = await fetch(`${baseUrl}/api/sessions/${session.id}/project`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId: project.id }),
+      })
+      expect(assignRes.status).toBe(200)
+
+      // セッション取得して確認
+      const getRes = await fetch(`${baseUrl}/api/sessions/${session.id}`)
+      const updated = await getRes.json()
+      expect(updated.projectId).toBe(project.id)
+    })
+  })
+
+  // レイアウト永続化
+  describe('レイアウト', () => {
+    it('レイアウトを保存・取得できる', async () => {
+      const layout = {
+        mode: '2x2',
+        panels: [
+          { sessionId: null, position: 0 },
+          { sessionId: null, position: 1 },
+          { sessionId: null, position: 2 },
+          { sessionId: null, position: 3 },
+        ],
+        activePanelIndex: 1,
+        savedAt: Date.now(),
+      }
+
+      const saveRes = await fetch(`${baseUrl}/api/layout`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(layout),
+      })
+      expect(saveRes.status).toBe(200)
+
+      const getRes = await fetch(`${baseUrl}/api/layout`)
+      const saved = await getRes.json()
+      expect(saved.mode).toBe('2x2')
+      expect(saved.panels).toHaveLength(4)
+      expect(saved.activePanelIndex).toBe(1)
+    })
+
+    it('レイアウトを上書き保存できる', async () => {
+      const layout1 = {
+        mode: '1x1',
+        panels: [{ sessionId: null, position: 0 }],
+        activePanelIndex: 0,
+        savedAt: Date.now(),
+      }
+
+      await fetch(`${baseUrl}/api/layout`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(layout1),
+      })
+
+      const getRes = await fetch(`${baseUrl}/api/layout`)
+      const saved = await getRes.json()
+      expect(saved.mode).toBe('1x1')
+      expect(saved.panels).toHaveLength(1)
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,8 @@ import { setupTerminalWs } from './ws/terminal-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
 import { createFilesRouter } from './routes/files.js'
 import { createWorktreesRouter } from './routes/worktrees.js'
+import { createProjectsRouter } from './routes/projects.js'
+import { createLayoutRouter } from './routes/layout.js'
 
 const PORT = parseInt(process.env.PORT || '3001', 10)
 
@@ -26,6 +28,8 @@ app.use(express.json())
 app.use('/api/sessions', createSessionsRouter(sessionStore, ptyManager, worktreeService))
 app.use('/api/files', createFilesRouter())
 app.use('/api/worktrees', createWorktreesRouter(worktreeService))
+app.use('/api/projects', createProjectsRouter(sessionStore))
+app.use('/api/layout', createLayoutRouter(sessionStore))
 
 // ヘルスチェック
 app.get('/api/health', (_req, res) => {

--- a/packages/server/src/routes/layout.ts
+++ b/packages/server/src/routes/layout.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express'
+import type { SessionStore } from '../services/session-store.js'
+import type { LayoutState } from '@kurimats/shared'
+
+export function createLayoutRouter(store: SessionStore): Router {
+  const router = Router()
+
+  // レイアウト取得
+  router.get('/', (_req, res) => {
+    const layout = store.getLayout()
+    res.json(layout)
+  })
+
+  // レイアウト保存
+  router.put('/', (req, res) => {
+    const state = req.body as LayoutState
+    store.saveLayout(state)
+    res.json({ ok: true })
+  })
+
+  return router
+}

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express'
+import type { SessionStore } from '../services/session-store.js'
+import type { CreateProjectParams } from '@kurimats/shared'
+
+export function createProjectsRouter(store: SessionStore): Router {
+  const router = Router()
+
+  // プロジェクト一覧
+  router.get('/', (_req, res) => {
+    const projects = store.getAllProjects()
+    res.json(projects)
+  })
+
+  // プロジェクト作成
+  router.post('/', (req, res) => {
+    const params = req.body as CreateProjectParams
+    if (!params.name || !params.repoPath) {
+      res.status(400).json({ error: 'name と repoPath は必須です' })
+      return
+    }
+    const project = store.createProject(params)
+    res.status(201).json(project)
+  })
+
+  // プロジェクト更新
+  router.patch('/:id', (req, res) => {
+    const updates = req.body as Partial<CreateProjectParams>
+    store.updateProject(req.params.id, updates)
+    res.json({ ok: true })
+  })
+
+  // プロジェクト削除
+  router.delete('/:id', (req, res) => {
+    store.deleteProject(req.params.id)
+    res.json({ ok: true })
+  })
+
+  return router
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -83,5 +83,18 @@ export function createSessionsRouter(
     res.json({ ok: true })
   })
 
+  // お気に入りトグル
+  router.post('/:id/favorite', (req, res) => {
+    const isFavorite = store.toggleFavorite(req.params.id)
+    res.json({ isFavorite })
+  })
+
+  // プロジェクト割り当て
+  router.post('/:id/project', (req, res) => {
+    const { projectId } = req.body as { projectId: string | null }
+    store.assignProject(req.params.id, projectId)
+    res.json({ ok: true })
+  })
+
   return router
 }

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -1,7 +1,8 @@
 import Database from 'better-sqlite3'
 import path from 'path'
+import { mkdirSync } from 'fs'
 import { fileURLToPath } from 'url'
-import type { Session, CreateSessionParams } from '@kurimats/shared'
+import type { Session, CreateSessionParams, Project, CreateProjectParams, LayoutState } from '@kurimats/shared'
 import { v4 as uuidv4 } from 'uuid'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -16,7 +17,7 @@ export class SessionStore {
   constructor() {
     // dataディレクトリを確保
     const dir = path.dirname(DB_PATH)
-    import('fs').then(fs => fs.mkdirSync(dir, { recursive: true }))
+    mkdirSync(dir, { recursive: true })
 
     this.db = new Database(DB_PATH)
     this.db.pragma('journal_mode = WAL')
@@ -33,6 +34,8 @@ export class SessionStore {
         branch TEXT,
         status TEXT NOT NULL DEFAULT 'active',
         claude_session_id TEXT,
+        is_favorite INTEGER NOT NULL DEFAULT 0,
+        project_id TEXT,
         created_at INTEGER NOT NULL,
         last_active_at INTEGER NOT NULL
       );
@@ -50,13 +53,35 @@ export class SessionStore {
         created_at INTEGER NOT NULL,
         FOREIGN KEY (session_id) REFERENCES sessions(id)
       );
+
+      CREATE TABLE IF NOT EXISTS projects (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        color TEXT NOT NULL DEFAULT '#3b82f6',
+        repo_path TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS layout_state (
+        id TEXT PRIMARY KEY DEFAULT 'default',
+        mode TEXT NOT NULL DEFAULT '1x1',
+        panels TEXT NOT NULL DEFAULT '[]',
+        active_panel_index INTEGER NOT NULL DEFAULT 0,
+        saved_at INTEGER NOT NULL
+      );
     `)
+
+    // 既存テーブルへのカラム追加（既にあればスキップ）
+    try { this.db.exec('ALTER TABLE sessions ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0') } catch { /* カラム既存 */ }
+    try { this.db.exec('ALTER TABLE sessions ADD COLUMN project_id TEXT') } catch { /* カラム既存 */ }
   }
+
+  // ==================== セッション ====================
 
   /**
    * セッション作成
    */
-  create(params: CreateSessionParams & { worktreePath?: string | null }): Session {
+  create(params: CreateSessionParams & { worktreePath?: string | null; projectId?: string | null }): Session {
     const now = Date.now()
     const session: Session = {
       id: uuidv4(),
@@ -66,16 +91,19 @@ export class SessionStore {
       branch: params.baseBranch ?? null,
       status: 'active',
       claudeSessionId: null,
+      isFavorite: false,
+      projectId: params.projectId ?? null,
       createdAt: now,
       lastActiveAt: now,
     }
 
     this.db.prepare(`
-      INSERT INTO sessions (id, name, repo_path, worktree_path, branch, status, claude_session_id, created_at, last_active_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (id, name, repo_path, worktree_path, branch, status, claude_session_id, is_favorite, project_id, created_at, last_active_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       session.id, session.name, session.repoPath, session.worktreePath,
       session.branch, session.status, session.claudeSessionId,
+      session.isFavorite ? 1 : 0, session.projectId,
       session.createdAt, session.lastActiveAt
     )
 
@@ -86,7 +114,7 @@ export class SessionStore {
    * 全セッション取得
    */
   getAll(): Session[] {
-    return this.db.prepare('SELECT * FROM sessions ORDER BY last_active_at DESC').all().map(this.mapRow)
+    return (this.db.prepare('SELECT * FROM sessions ORDER BY last_active_at DESC').all() as Record<string, unknown>[]).map(this.mapRow)
   }
 
   /**
@@ -114,6 +142,116 @@ export class SessionStore {
   }
 
   /**
+   * お気に入りトグル
+   */
+  toggleFavorite(id: string): boolean {
+    const session = this.getById(id)
+    if (!session) return false
+    const newVal = session.isFavorite ? 0 : 1
+    this.db.prepare('UPDATE sessions SET is_favorite = ? WHERE id = ?').run(newVal, id)
+    return !session.isFavorite
+  }
+
+  /**
+   * プロジェクト割り当て
+   */
+  assignProject(sessionId: string, projectId: string | null): void {
+    this.db.prepare('UPDATE sessions SET project_id = ? WHERE id = ?').run(projectId, sessionId)
+  }
+
+  // ==================== プロジェクト ====================
+
+  /**
+   * プロジェクト作成
+   */
+  createProject(params: CreateProjectParams): Project {
+    const project: Project = {
+      id: uuidv4(),
+      name: params.name,
+      color: params.color,
+      repoPath: params.repoPath,
+      createdAt: Date.now(),
+    }
+
+    this.db.prepare(`
+      INSERT INTO projects (id, name, color, repo_path, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(project.id, project.name, project.color, project.repoPath, project.createdAt)
+
+    return project
+  }
+
+  /**
+   * 全プロジェクト取得
+   */
+  getAllProjects(): Project[] {
+    return (this.db.prepare('SELECT * FROM projects ORDER BY created_at DESC').all() as Record<string, unknown>[])
+      .map(this.mapProjectRow)
+  }
+
+  /**
+   * IDでプロジェクト取得
+   */
+  getProjectById(id: string): Project | null {
+    const row = this.db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Record<string, unknown> | undefined
+    return row ? this.mapProjectRow(row) : null
+  }
+
+  /**
+   * プロジェクト更新
+   */
+  updateProject(id: string, updates: Partial<CreateProjectParams>): void {
+    const fields: string[] = []
+    const values: unknown[] = []
+
+    if (updates.name !== undefined) { fields.push('name = ?'); values.push(updates.name) }
+    if (updates.color !== undefined) { fields.push('color = ?'); values.push(updates.color) }
+    if (updates.repoPath !== undefined) { fields.push('repo_path = ?'); values.push(updates.repoPath) }
+
+    if (fields.length === 0) return
+
+    values.push(id)
+    this.db.prepare(`UPDATE projects SET ${fields.join(', ')} WHERE id = ?`).run(...values)
+  }
+
+  /**
+   * プロジェクト削除
+   */
+  deleteProject(id: string): void {
+    // 関連セッションのproject_idをnullに
+    this.db.prepare('UPDATE sessions SET project_id = NULL WHERE project_id = ?').run(id)
+    this.db.prepare('DELETE FROM projects WHERE id = ?').run(id)
+  }
+
+  // ==================== レイアウト ====================
+
+  /**
+   * レイアウト保存
+   */
+  saveLayout(state: LayoutState): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO layout_state (id, mode, panels, active_panel_index, saved_at)
+      VALUES ('default', ?, ?, ?, ?)
+    `).run(state.mode, JSON.stringify(state.panels), state.activePanelIndex, state.savedAt)
+  }
+
+  /**
+   * レイアウト取得
+   */
+  getLayout(): LayoutState | null {
+    const row = this.db.prepare('SELECT * FROM layout_state WHERE id = ?').get('default') as Record<string, unknown> | undefined
+    if (!row) return null
+    return {
+      mode: row.mode as LayoutState['mode'],
+      panels: JSON.parse(row.panels as string),
+      activePanelIndex: row.active_panel_index as number,
+      savedAt: row.saved_at as number,
+    }
+  }
+
+  // ==================== マッピング ====================
+
+  /**
    * DBの行をSession型にマッピング
    */
   private mapRow(row: Record<string, unknown>): Session {
@@ -125,8 +263,23 @@ export class SessionStore {
       branch: row.branch as string | null,
       status: row.status as Session['status'],
       claudeSessionId: row.claude_session_id as string | null,
+      isFavorite: Boolean(row.is_favorite),
+      projectId: row.project_id as string | null,
       createdAt: row.created_at as number,
       lastActiveAt: row.last_active_at as number,
+    }
+  }
+
+  /**
+   * DBの行をProject型にマッピング
+   */
+  private mapProjectRow(row: Record<string, unknown>): Project {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      color: row.color as string,
+      repoPath: row.repo_path as string,
+      createdAt: row.created_at as number,
     }
   }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -18,6 +18,12 @@ export type BoardMessage =
   | { type: 'card_updated'; card: import('./types.js').BoardCard }
   | { type: 'card_removed'; cardId: string }
 
+// プロジェクトWebSocketメッセージ
+export type ProjectMessage =
+  | { type: 'project_created'; project: import('./types.js').Project }
+  | { type: 'project_updated'; project: import('./types.js').Project }
+  | { type: 'project_deleted'; projectId: string }
+
 // ファイルウォッチWebSocketメッセージ
 export type FileWatchMessage =
   | { type: 'file_changed'; path: string; event: 'add' | 'change' | 'unlink' }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -10,6 +10,8 @@ export interface Session {
   branch: string | null
   status: SessionStatus
   claudeSessionId: string | null
+  isFavorite: boolean
+  projectId: string | null
   createdAt: number
   lastActiveAt: number
 }
@@ -55,6 +57,36 @@ export interface PanelLayout {
     position: number
   }>
 }
+
+// プロジェクト
+export interface Project {
+  id: string
+  name: string
+  color: string // hex color like '#3b82f6'
+  repoPath: string
+  createdAt: number
+}
+
+// プロジェクト作成パラメータ
+export interface CreateProjectParams {
+  name: string
+  color: string
+  repoPath: string
+}
+
+// レイアウト永続化
+export interface LayoutState {
+  mode: LayoutMode
+  panels: Array<{ sessionId: string | null; position: number }>
+  activePanelIndex: number
+  savedAt: number
+}
+
+// プロジェクトカラー定数
+export const PROJECT_COLORS = [
+  '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6',
+  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
+] as const
 
 // ファイルツリーノード
 export interface FileNode {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
closes #2 closes #3 closes #4 closes #5

## Summary
- 白背景テーマに全面刷新（ターミナルはダーク維持）
- コマンドパレット（⌘⇧P）でセッション操作・レイアウト変更・ツール起動
- ファイルツリーオーバーレイ（⌘E）でリポジトリ構造を閲覧
- コードビューア（シンタックスハイライト・行番号・コピー機能）
- Markdownプレビュー/エディタ（⌘M、分割表示・自動保存）
- セッションお気に入り（★トグル・セクション表示）
- プロジェクト管理（カラーコード・セッション割り当て）
- レイアウト永続化（localStorage + サーバーAPI）
- セッション検索フィルター
- キーボードショートカット統合

## Test plan
- [x] TypeScript型チェックパス（shared/server/client全パッケージ）
- [x] Viteビルド成功
- [x] サーバーAPI動作確認（セッション・プロジェクト・お気に入り・レイアウト）
- [x] Playwrightでの動作確認（白テーマ・セッション作成・お気に入り・コマンドパレット・ファイルツリー・コードビューア・Markdownプレビュー・レイアウト切り替え）
- [x] vitest 27テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)