### PR TITLE
fix: Electron起動フローをesbuild+electronコマンドに修正 (#22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:server": "npm run dev -w packages/server",
     "dev:client": "npm run dev -w packages/client",
     "electron": "npm run dev -w packages/electron",
+    "electron:start": "npm run start -w packages/electron",
     "build:electron": "npm run build -w packages/electron"
   },
   "devDependencies": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "main": "dist/main.js",
   "scripts": {
-    "dev": "tsx src/main.ts",
-    "build": "tsc && electron-builder",
-    "electron": "electron dist/main.js"
+    "dev": "node scripts/build.mjs && electron .",
+    "build": "node scripts/build.mjs && electron-builder",
+    "start": "electron ."
   },
   "dependencies": {
     "electron-store": "^10.0.0"

--- a/packages/electron/scripts/build.mjs
+++ b/packages/electron/scripts/build.mjs
@@ -1,0 +1,20 @@
+/**
+ * Electronメインプロセスのビルドスクリプト
+ * esbuildでTypeScriptをCommonJSにバンドルする
+ * electron-store等のESMパッケージもCommonJSに変換される
+ */
+import { build } from 'esbuild'
+
+await build({
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'cjs',
+  outdir: 'dist',
+  // Electron本体は外部依存として除外
+  external: ['electron'],
+  sourcemap: true,
+})
+
+console.log('ビルド完了: dist/main.js')

--- a/packages/electron/src/__tests__/build.test.ts
+++ b/packages/electron/src/__tests__/build.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const electronDir = path.resolve(__dirname, '../..')
+
+describe('Electronビルドスクリプト', () => {
+  it('esbuildでdist/main.jsが生成される', () => {
+    // ビルド実行
+    execSync('node scripts/build.mjs', { cwd: electronDir, stdio: 'pipe' })
+
+    const outputPath = path.join(electronDir, 'dist', 'main.js')
+    expect(fs.existsSync(outputPath)).toBe(true)
+  })
+
+  it('ビルド成果物がCommonJS形式である', () => {
+    const outputPath = path.join(electronDir, 'dist', 'main.js')
+    const content = fs.readFileSync(outputPath, 'utf-8')
+
+    // CommonJSの特徴的なパターンを確認
+    expect(content).toContain('require')
+    // electronは外部依存として除外されている
+    expect(content).toContain('electron')
+  })
+
+  it('ソースマップが生成される', () => {
+    const mapPath = path.join(electronDir, 'dist', 'main.js.map')
+    expect(fs.existsSync(mapPath)).toBe(true)
+  })
+
+  it('package.jsonのmainフィールドがdist/main.jsを指している', () => {
+    const pkgPath = path.join(electronDir, 'package.json')
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+    expect(pkg.main).toBe('dist/main.js')
+  })
+})


### PR DESCRIPTION
closes #22

## Summary
- `tsx src/main.ts` での起動を廃止し、esbuildでCommonJSにバンドル後 `electron .` で起動するよう変更
- `app.isPackaged` の `TypeError` を解消
- ESM onlyの `electron-store` v10 との互換性をesbuildバンドルで確保

## 変更内容
- `packages/electron/scripts/build.mjs`: esbuildビルドスクリプトを新規作成
- `packages/electron/package.json`: `dev`/`build`/`start` スクリプトを修正
- `package.json`: `electron:start` スクリプトを追加
- `packages/electron/src/__tests__/build.test.ts`: ビルドスクリプトのテストを追加

## Test plan
- [x] `npx vitest run packages/electron` で全55テストパス
- [x] `npm run electron` でElectronアプリが正常起動（app.isPackagedエラー解消）
- [x] esbuildで `dist/main.js` がCommonJS形式で生成されることを確認