### PR TITLE
fix: ターミナルdimensionsエラー修正

### DIFF
--- a/packages/client/src/__tests__/terminal-safe-fit.test.ts
+++ b/packages/client/src/__tests__/terminal-safe-fit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { hasValidSize, safeFit } from '../utils/terminal-utils'
+
+describe('ターミナル safeFit ユーティリティ', () => {
+  describe('hasValidSize', () => {
+    it('幅と高さが正の値なら true を返す', () => {
+      const el = { clientWidth: 100, clientHeight: 50 } as HTMLElement
+      expect(hasValidSize(el)).toBe(true)
+    })
+
+    it('幅が0なら false を返す', () => {
+      const el = { clientWidth: 0, clientHeight: 50 } as HTMLElement
+      expect(hasValidSize(el)).toBe(false)
+    })
+
+    it('高さが0なら false を返す', () => {
+      const el = { clientWidth: 100, clientHeight: 0 } as HTMLElement
+      expect(hasValidSize(el)).toBe(false)
+    })
+
+    it('幅と高さの両方が0なら false を返す', () => {
+      const el = { clientWidth: 0, clientHeight: 0 } as HTMLElement
+      expect(hasValidSize(el)).toBe(false)
+    })
+  })
+
+  describe('safeFit', () => {
+    it('コンテナサイズが有効な場合、fit() を呼ぶ', () => {
+      const mockFitAddon = { fit: vi.fn() }
+      const container = { clientWidth: 200, clientHeight: 100 } as HTMLElement
+
+      safeFit(mockFitAddon as any, container)
+
+      expect(mockFitAddon.fit).toHaveBeenCalledOnce()
+    })
+
+    it('コンテナサイズが0の場合、fit() を呼ばない', () => {
+      const mockFitAddon = { fit: vi.fn() }
+      const container = { clientWidth: 0, clientHeight: 0 } as HTMLElement
+
+      safeFit(mockFitAddon as any, container)
+
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+    })
+
+    it('fit() がエラーを投げても例外が伝播しない', () => {
+      const mockFitAddon = {
+        fit: vi.fn().mockImplementation(() => {
+          throw new Error('dimensions エラー')
+        }),
+      }
+      const container = { clientWidth: 200, clientHeight: 100 } as HTMLElement
+
+      expect(() => safeFit(mockFitAddon as any, container)).not.toThrow()
+    })
+
+    it('幅だけ0の場合、fit() を呼ばない', () => {
+      const mockFitAddon = { fit: vi.fn() }
+      const container = { clientWidth: 0, clientHeight: 100 } as HTMLElement
+
+      safeFit(mockFitAddon as any, container)
+
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/client/src/components/terminal/Terminal.tsx
+++ b/packages/client/src/components/terminal/Terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalWs } from '../../hooks/useTerminalWs'
+import { hasValidSize, safeFit } from '../../utils/terminal-utils'
 
 interface Props {
   sessionId: string
@@ -23,6 +24,9 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
   // xterm.jsインスタンスの作成
   useEffect(() => {
     if (!containerRef.current) return
+
+    const container = containerRef.current
+    let disposed = false
 
     const term = new XTerm({
       theme: {
@@ -58,26 +62,58 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
     const webLinksAddon = new WebLinksAddon()
     term.loadAddon(fitAddon)
     term.loadAddon(webLinksAddon)
-
-    term.open(containerRef.current)
-    fitAddon.fit()
     fitAddonRef.current = fitAddon
 
-    setTerminal(term)
+    let initObserver: ResizeObserver | null = null
 
-    // リサイズ監視
-    const resizeObserver = new ResizeObserver(() => {
+    /**
+     * ターミナルの初期化を実行する
+     * open()はコンテナサイズが0だと内部のrenderServiceが未初期化となり
+     * syncScrollAreaでdimensionsエラーが発生する。
+     * さらにopen()内部でも同期的にsyncScrollAreaが呼ばれるため、
+     * requestAnimationFrameで次フレームに遅延させ、DOMレイアウト確定後に実行する。
+     */
+    const initTerminal = () => {
       requestAnimationFrame(() => {
+        if (disposed) return
+        if (!hasValidSize(container)) return
         try {
-          fitAddon.fit()
+          term.open(container)
         } catch {
-          // コンテナが非表示の場合は無視
+          // xterm.js内部のdimensionsエラーをキャッチ（初回open時の既知の問題）
+          return
+        }
+        safeFit(fitAddon, container)
+        setTerminal(term)
+      })
+    }
+
+    // コンテナサイズが有効ならすぐ初期化、そうでなければサイズ確定を待つ
+    if (hasValidSize(container)) {
+      initTerminal()
+    } else {
+      // サイズが0の場合、ResizeObserverでサイズ確定を検知してから初期化
+      initObserver = new ResizeObserver(() => {
+        if (hasValidSize(container)) {
+          initObserver?.disconnect()
+          initObserver = null
+          initTerminal()
         }
       })
+      initObserver.observe(container)
+    }
+
+    // リサイズ監視（サイズが有効な場合のみfit）
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        safeFit(fitAddon, container)
+      })
     })
-    resizeObserver.observe(containerRef.current)
+    resizeObserver.observe(container)
 
     return () => {
+      disposed = true
+      initObserver?.disconnect()
       resizeObserver.disconnect()
       term.dispose()
       setTerminal(null)

--- a/packages/client/src/utils/terminal-utils.ts
+++ b/packages/client/src/utils/terminal-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * ターミナル関連ユーティリティ
+ * xterm.js の安全な操作をサポートする
+ */
+
+/**
+ * コンテナが有効なサイズを持っているか判定する
+ * xterm.js の fit() はコンテナサイズが0だと dimensions エラーを起こすため
+ */
+export function hasValidSize(element: HTMLElement): boolean {
+  return element.clientWidth > 0 && element.clientHeight > 0
+}
+
+/**
+ * FitAddonの安全なラッパー
+ * コンテナサイズが0の場合やターミナル未初期化時のエラーを防ぐ
+ */
+export function safeFit(fitAddon: { fit: () => void }, container: HTMLElement): void {
+  if (!hasValidSize(container)) return
+  try {
+    fitAddon.fit()
+  } catch {
+    // ターミナルが未初期化またはdispose済みの場合は無視
+  }
+}


### PR DESCRIPTION
closes #21

## Summary
- xterm.js の open() がコンテナサイズ未確定時に呼ばれると dimensions エラーを起こす問題を修正
- open() を requestAnimationFrame で遅延させ DOMレイアウト確定後に実行
- コンテナサイズが0の場合は ResizeObserver でサイズ確定を待機

## Test plan
- [x] npx vitest run packages/client 全123テスト通過
- [x] Playwrightでブラウザ動作確認 dimensionsエラー0件