### PR TITLE
feat: ボードノードにお気に入り星＋プレビュー表示

### DIFF
--- a/packages/client/src/__tests__/board-canvas.test.ts
+++ b/packages/client/src/__tests__/board-canvas.test.ts
@@ -34,7 +34,7 @@ describe('ボードキャンバスストア', () => {
     expect(state.boardNodes).toHaveLength(1)
     expect(state.boardNodes[0].sessionId).toBe('session-1')
     expect(state.boardNodes[0].width).toBe(600)
-    expect(state.boardNodes[0].height).toBe(400)
+    expect(state.boardNodes[0].height).toBe(480)
     expect(state.activeSessionId).toBe('session-1')
   })
 

--- a/packages/client/src/components/board/BoardCanvas.tsx
+++ b/packages/client/src/components/board/BoardCanvas.tsx
@@ -36,7 +36,7 @@ export function BoardCanvas() {
     setBoardNodes,
   } = useLayoutStore()
 
-  const { sessions, projects, deleteSession } = useSessionStore()
+  const { sessions, projects, deleteSession, toggleFavorite } = useSessionStore()
 
   // セッションからプロジェクトカラーを取得
   const getProjectColor = useCallback((projectId: string | null) => {
@@ -64,6 +64,7 @@ export function BoardCanvas() {
             removeBoardNode(session.id)
           },
           onFocus: () => setActiveSession(session.id),
+          onToggleFavorite: () => toggleFavorite(session.id),
         } as SessionNodeData,
         style: {
           width: node.width,
@@ -73,7 +74,7 @@ export function BoardCanvas() {
       })
     }
     return result
-  }, [boardNodes, sessions, activeSessionId, projects, getProjectColor, deleteSession, removeBoardNode, setActiveSession])
+  }, [boardNodes, sessions, activeSessionId, projects, getProjectColor, deleteSession, removeBoardNode, setActiveSession, toggleFavorite])
 
   const [nodes, setNodes] = useNodesState(flowNodes)
 

--- a/packages/client/src/components/board/SessionNode.tsx
+++ b/packages/client/src/components/board/SessionNode.tsx
@@ -1,8 +1,9 @@
-import { memo } from 'react'
+import { memo, useEffect, useState, useCallback, useRef } from 'react'
 import { Handle, Position, type NodeProps } from '@xyflow/react'
 import type { Session } from '@kurimats/shared'
 import { TerminalComponent } from '../terminal/Terminal'
 import { TerminalHeader } from '../terminal/TerminalHeader'
+import { sessionsApi } from '../../lib/api'
 
 export interface SessionNodeData {
   session: Session
@@ -10,15 +11,42 @@ export interface SessionNodeData {
   projectColor: string | null
   onClose: () => void
   onFocus: () => void
+  onToggleFavorite: () => void
   [key: string]: unknown
 }
 
+/** プレビューの最大行数 */
+const PREVIEW_LINES = 5
+/** プレビュー更新間隔（ミリ秒） */
+const PREVIEW_INTERVAL = 3000
+
 /**
  * React Flowカスタムノード: セッションターミナルカード
- * ターミナルヘッダー + xterm.jsターミナルを内包
+ * ターミナルヘッダー + お気に入り★ + プレビュー + xterm.jsターミナルを内包
  */
 function SessionNodeComponent({ data }: NodeProps) {
-  const { session, isActive, projectColor, onClose, onFocus } = data as unknown as SessionNodeData
+  const { session, isActive, projectColor, onClose, onFocus, onToggleFavorite } = data as unknown as SessionNodeData
+  const [previewLines, setPreviewLines] = useState<string[]>([])
+  const intervalRef = useRef<ReturnType<typeof setInterval>>()
+
+  // プレビュー取得
+  const fetchPreview = useCallback(async () => {
+    try {
+      const result = await sessionsApi.getPreview(session.id, PREVIEW_LINES)
+      setPreviewLines(result.lines)
+    } catch {
+      // プレビュー取得失敗は静かに無視
+    }
+  }, [session.id])
+
+  // 定期的にプレビューを更新
+  useEffect(() => {
+    fetchPreview()
+    intervalRef.current = setInterval(fetchPreview, PREVIEW_INTERVAL)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetchPreview])
 
   return (
     <div
@@ -35,11 +63,27 @@ function SessionNodeComponent({ data }: NodeProps) {
     >
       {/* ドラッグハンドル兼ヘッダー */}
       <div className="drag-handle cursor-grab active:cursor-grabbing">
-        <TerminalHeader
-          session={session}
-          isActive={isActive}
-          onClose={onClose}
-        />
+        <div className="flex items-center">
+          {/* お気に入り★ボタン */}
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggleFavorite() }}
+            className={`flex-shrink-0 px-1.5 py-1.5 text-sm transition-colors hover:scale-110 ${
+              session.isFavorite
+                ? 'text-yellow-400 hover:text-yellow-300'
+                : 'text-gray-400 hover:text-yellow-400'
+            }`}
+            title={session.isFavorite ? 'お気に入り解除' : 'お気に入りに追加'}
+          >
+            {session.isFavorite ? '★' : '☆'}
+          </button>
+          <div className="flex-1 min-w-0">
+            <TerminalHeader
+              session={session}
+              isActive={isActive}
+              onClose={onClose}
+            />
+          </div>
+        </div>
         {/* プロジェクトカラーバー */}
         {projectColor && (
           <div
@@ -48,6 +92,16 @@ function SessionNodeComponent({ data }: NodeProps) {
           />
         )}
       </div>
+
+      {/* ターミナルプレビュー */}
+      {previewLines.length > 0 && (
+        <div className="bg-[#252526] border-b border-[#3c3c3c] px-2 py-1 max-h-24 overflow-hidden">
+          <div className="text-[10px] text-gray-500 mb-0.5">プレビュー</div>
+          <pre className="text-[11px] text-gray-300 font-mono leading-tight whitespace-pre-wrap break-all">
+            {previewLines.join('\n')}
+          </pre>
+        </div>
+      )}
 
       {/* ターミナル本体 */}
       <div className="flex-1 min-h-0 bg-[#1e1e1e]">

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -32,6 +32,8 @@ export const sessionsApi = {
       method: 'POST',
       body: JSON.stringify({ projectId }),
     }),
+  getPreview: (id: string, lines = 5) =>
+    request<{ sessionId: string; lines: string[] }>(`/sessions/${id}/preview?lines=${lines}`),
 }
 
 // ファイルAPI

--- a/packages/client/src/stores/layout-store.ts
+++ b/packages/client/src/stores/layout-store.ts
@@ -10,7 +10,7 @@ interface PanelInfo {
 
 // ボードノードのデフォルトサイズ
 const DEFAULT_NODE_WIDTH = 600
-const DEFAULT_NODE_HEIGHT = 400
+const DEFAULT_NODE_HEIGHT = 480
 
 interface LayoutState {
   mode: LayoutMode

--- a/packages/server/src/__tests__/sessions.test.ts
+++ b/packages/server/src/__tests__/sessions.test.ts
@@ -71,6 +71,49 @@ describe('セッションAPI', () => {
     expect(res.status).toBe(400)
   })
 
+  it('お気に入りをトグルできる', async () => {
+    // セッション作成
+    const createRes = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'fav-test', repoPath: '/tmp', useWorktree: false }),
+    })
+    const session = await createRes.json()
+
+    // お気に入りトグル（false → true）
+    const toggleRes = await fetch(`${baseUrl}/api/sessions/${session.id}/favorite`, { method: 'POST' })
+    const toggleResult = await toggleRes.json()
+    expect(toggleRes.status).toBe(200)
+    expect(toggleResult.isFavorite).toBe(true)
+
+    // もう一度トグル（true → false）
+    const toggleRes2 = await fetch(`${baseUrl}/api/sessions/${session.id}/favorite`, { method: 'POST' })
+    const toggleResult2 = await toggleRes2.json()
+    expect(toggleResult2.isFavorite).toBe(false)
+  })
+
+  it('ターミナルプレビューを取得できる', async () => {
+    // セッション作成
+    const createRes = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'preview-test', repoPath: '/tmp', useWorktree: false }),
+    })
+    const session = await createRes.json()
+
+    // プレビュー取得（バッファが空でも正常に返る）
+    const previewRes = await fetch(`${baseUrl}/api/sessions/${session.id}/preview?lines=3`)
+    const preview = await previewRes.json()
+    expect(previewRes.status).toBe(200)
+    expect(preview.sessionId).toBe(session.id)
+    expect(Array.isArray(preview.lines)).toBe(true)
+  })
+
+  it('存在しないセッションのプレビューは404', async () => {
+    const previewRes = await fetch(`${baseUrl}/api/sessions/nonexistent/preview`)
+    expect(previewRes.status).toBe(404)
+  })
+
   it('セッションを削除できる', async () => {
     // 作成
     const createRes = await fetch(`${baseUrl}/api/sessions`, {

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -112,6 +112,25 @@ export function createSessionsRouter(
     res.json({ isFavorite })
   })
 
+  // ターミナルプレビュー取得（最新出力の数行）
+  router.get('/:id/preview', (req, res) => {
+    const session = store.getById(req.params.id)
+    if (!session) {
+      res.status(404).json({ error: 'セッションが見つかりません' })
+      return
+    }
+
+    const lines = parseInt(req.query.lines as string) || 5
+    const buffer = ptyManager.getBuffer(session.id)
+
+    // ANSIエスケープシーケンスを除去して最新行を取得
+    const cleanBuffer = buffer.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '')
+    const allLines = cleanBuffer.split('\n').filter(l => l.trim().length > 0)
+    const previewLines = allLines.slice(-lines)
+
+    res.json({ sessionId: session.id, lines: previewLines })
+  })
+
   // プロジェクト割り当て
   router.post('/:id/project', (req, res) => {
     const { projectId } = req.body as { projectId: string | null }


### PR DESCRIPTION
closes #24

## Summary
- ボードノードにお気に入りトグルボタンを追加
- ターミナルプレビュー表示を追加
- サーバーにプレビューAPIを追加

## Test plan
- [x] 全220テスト通過
- [x] お気に入りトグル・プレビューAPIテスト追加