### PR TITLE
fix: ローカルセッションのPTY起動コマンドを修正

### DIFF
--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -70,11 +70,17 @@ export function createSessionsRouter(
           [params.sshHost, '-t', shpoolCmd],
         )
       } else {
-        // ローカルPTYセッション: claude を起動
-        await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', [])
+        // ローカルPTYセッション: シェルを起動
+        const shell = process.env.SHELL || '/bin/zsh'
+        await ptyManager.spawn(session.id, cwd, 120, 30, shell, [])
       }
     } catch (e) {
-      store.delete(session.id)
+      console.error('PTY起動エラー:', e)
+      try {
+        store.delete(session.id)
+      } catch (deleteErr) {
+        console.error('セッション削除エラー:', deleteErr)
+      }
       res.status(500).json({ error: `${isRemote ? 'リモートシェル' : 'PTY'}起動エラー: ${e}` })
       return
     }

--- a/packages/server/src/routes/tab.ts
+++ b/packages/server/src/routes/tab.ts
@@ -166,8 +166,9 @@ export function createTabRouter(store: SessionStore, ptyManager: PtyManager): Ro
                 const sshArgs = buildRemoteSshArgs(bm.host, bm.directory, bm.name)
                 await ptyManager.spawn(session.id, process.env.HOME || '/tmp', 120, 30, 'ssh', sshArgs)
               } else {
-                // ローカル: claude を cwd 指定で起動
-                await ptyManager.spawn(session.id, bm.directory, 120, 30, 'claude', [])
+                // ローカル: シェルを cwd 指定で起動
+                const shell = process.env.SHELL || '/bin/zsh'
+                await ptyManager.spawn(session.id, bm.directory, 120, 30, shell, [])
               }
               createdSessions.push(session)
               existingSessionNames.add(bm.name)


### PR DESCRIPTION
closes #40

## Summary
- ローカルセッション作成時のPTY起動コマンドを `claude` から `process.env.SHELL || '/bin/zsh'` に変更
- `sessions.ts` と `tab.ts` の両方を修正
- PTY起動失敗時のエラーハンドリングを改善（セッション削除の確実な実行）

## Test plan
- [x] `npx vitest run packages/server` 全63テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)