### PR TITLE
fix: SSHセッションでSshManagerを正しく使用する

### DIFF
--- a/packages/server/src/__tests__/tab-and-board.test.ts
+++ b/packages/server/src/__tests__/tab-and-board.test.ts
@@ -3,6 +3,7 @@ import express from 'express'
 import { createServer, type Server } from 'http'
 import { SessionStore } from '../services/session-store.js'
 import { PtyManager } from '../services/pty-manager.js'
+import { SshManager } from '../services/ssh-manager.js'
 import { createTabRouter } from '../routes/tab.js'
 import { createLayoutRouter } from '../routes/layout.js'
 
@@ -11,14 +12,16 @@ describe('tabコマンドAPI', () => {
   let baseUrl: string
   let store: SessionStore
   let ptyManager: PtyManager
+  let sshManager: SshManager
 
   beforeEach(async () => {
     store = new SessionStore()
     ptyManager = new PtyManager()
+    sshManager = new SshManager()
 
     const app = express()
     app.use(express.json())
-    app.use('/api/tab', createTabRouter(store, ptyManager))
+    app.use('/api/tab', createTabRouter(store, ptyManager, sshManager))
     app.use('/api/layout', createLayoutRouter(store))
 
     server = createServer(app)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -52,7 +52,7 @@ app.use('/api/files', createFilesRouter())
 app.use('/api/worktrees', createWorktreesRouter(worktreeService))
 app.use('/api/projects', createProjectsRouter(sessionStore))
 app.use('/api/layout', createLayoutRouter(sessionStore))
-app.use('/api/tab', createTabRouter(sessionStore, ptyManager))
+app.use('/api/tab', createTabRouter(sessionStore, ptyManager, sshManager))
 app.use('/api/ssh', createSshRouter(sshManager))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -59,23 +59,16 @@ export function createSessionsRouter(
 
     try {
       if (isRemote && params.sshHost) {
-        // リモートSSHセッション: PTY経由でssh + shpool + claude-session
-        const sessionName = params.name.replace(/\s+/g, '-').toLowerCase()
-        const shpoolCmd = `~/.cargo/bin/shpool attach -f -d ${cwd} -c ~/.local/bin/claude-session ${sessionName}`
-        await ptyManager.spawn(
-          session.id,
-          process.env.HOME || '/tmp',
-          120, 30,
-          'ssh',
-          [params.sshHost, '-t', shpoolCmd],
-        )
+        // リモートSSHセッション: SshManager経由で接続・シェル起動
+        await sshManager.connect(params.sshHost)
+        await sshManager.spawn(session.id, params.sshHost, cwd, 120, 30)
       } else {
         // ローカルPTYセッション: claude を起動
         await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', [])
       }
     } catch (e) {
       store.delete(session.id)
-      res.status(500).json({ error: `${isRemote ? 'リモートシェル' : 'PTY'}起動エラー: ${e}` })
+      res.status(500).json({ error: `${isRemote ? 'SSH接続/リモートシェル' : 'PTY'}起動エラー: ${e}` })
       return
     }
 
@@ -100,8 +93,12 @@ export function createSessionsRouter(
       return
     }
 
-    // PTYマネージャーで終了（リモートもPTY経由のsshコマンド）
-    ptyManager.kill(session.id)
+    // リモートセッションはSshManager、ローカルはPtyManagerで終了
+    if (sshManager.hasSession(session.id)) {
+      sshManager.kill(session.id)
+    } else {
+      ptyManager.kill(session.id)
+    }
     store.updateStatus(session.id, 'terminated')
     res.json({ ok: true })
   })
@@ -121,7 +118,9 @@ export function createSessionsRouter(
     }
 
     const lines = parseInt(req.query.lines as string) || 5
-    const buffer = ptyManager.getBuffer(session.id)
+    const buffer = sshManager.hasSession(session.id)
+      ? sshManager.getBuffer(session.id)
+      : ptyManager.getBuffer(session.id)
 
     // ANSIエスケープシーケンスを除去して最新行を取得
     const cleanBuffer = buffer.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '')

--- a/packages/server/src/routes/tab.ts
+++ b/packages/server/src/routes/tab.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { execSync } from 'child_process'
 import type { SessionStore } from '../services/session-store.js'
 import type { PtyManager } from '../services/pty-manager.js'
+import type { SshManager } from '../services/ssh-manager.js'
 import type { TabHost, TabProject, TabListResponse, TabSyncResponse, TabBookmark, Session } from '@kurimats/shared'
 import { PROJECT_COLORS } from '@kurimats/shared'
 import { parseBookmarksToml } from '../services/bookmarks-parser.js'
@@ -41,15 +42,7 @@ function parseTabListOutput(output: string): TabHost[] {
   return hosts
 }
 
-/**
- * リモートセッション用の SSH + shpool コマンドを構築
- */
-function buildRemoteSshArgs(host: string, directory: string, sessionName: string): string[] {
-  const shpoolCmd = `~/.cargo/bin/shpool attach -f -d ${directory} -c ~/.local/bin/claude-session ${sessionName}`
-  return [host, '-t', shpoolCmd]
-}
-
-export function createTabRouter(store: SessionStore, ptyManager: PtyManager): Router {
+export function createTabRouter(store: SessionStore, ptyManager: PtyManager, sshManager: SshManager): Router {
   const router = Router()
 
   // tab同期のmutex（同時実行防止）
@@ -159,12 +152,12 @@ export function createTabRouter(store: SessionStore, ptyManager: PtyManager): Ro
               projectId: project?.id || null,
             })
 
-            // PTY起動: Claude Code を起動するコマンドを構築
+            // セッション起動: リモートはSshManager、ローカルはPtyManager
             try {
               if (isRemote && bm.host) {
-                // リモート: ssh + shpool + claude-session
-                const sshArgs = buildRemoteSshArgs(bm.host, bm.directory, bm.name)
-                await ptyManager.spawn(session.id, process.env.HOME || '/tmp', 120, 30, 'ssh', sshArgs)
+                // リモート: SshManager経由で接続・シェル起動
+                await sshManager.connect(bm.host)
+                await sshManager.spawn(session.id, bm.host, bm.directory, 120, 30)
               } else {
                 // ローカル: claude を cwd 指定で起動
                 await ptyManager.spawn(session.id, bm.directory, 120, 30, 'claude', [])
@@ -172,7 +165,7 @@ export function createTabRouter(store: SessionStore, ptyManager: PtyManager): Ro
               createdSessions.push(session)
               existingSessionNames.add(bm.name)
             } catch (e) {
-              console.error(`セッション ${bm.name} のPTY起動に失敗:`, e)
+              console.error(`セッション ${bm.name} の起動に失敗:`, e)
               store.delete(session.id)
             }
           }


### PR DESCRIPTION
closes #41

## Summary
- sessions.tsとtab.tsでSSHセッション作成時にptyManager経由のsshコマンドをsshManager.connect()+spawn()に置き換え
- セッション終了・プレビュー取得もsshManager経由に統一
- tab.tsの不要なbuildRemoteSshArgs関数を削除
- createTabRouterの引数にsshManagerを追加

## Test plan
- [x] 型チェック通過
- [x] vitest 62/63テスト通過
- [ ] 実際のSSHホストで動作確認