### PR TITLE
feat: Web dev時のポート分離設定

### DIFF
--- a/packages/client/src/__tests__/v2-stack-upgrade.test.ts
+++ b/packages/client/src/__tests__/v2-stack-upgrade.test.ts
@@ -60,7 +60,7 @@ describe('v2 スタック最新化', () => {
   describe('Electron 41', () => {
     it('electron が v41 に更新されている', () => {
       const version = electronPkg.devDependencies.electron
-      expect(version).toMatch(/^\^41/)
+      expect(version).toMatch(/^[\^~]?41/)
     })
   })
 })

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -2,14 +2,17 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const serverPort = process.env.SERVER_PORT || '3001'
+const clientPort = parseInt(process.env.CLIENT_PORT || '5173', 10)
+
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   server: {
-    port: 5173,
+    port: clientPort,
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': `http://localhost:${serverPort}`,
       '/ws': {
-        target: 'ws://localhost:3001',
+        target: `ws://localhost:${serverPort}`,
         ws: true,
       },
     },

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,7 +12,7 @@
     "electron-store": "^10.0.0"
   },
   "devDependencies": {
-    "electron": "^41.0.0",
+    "electron": "41.1.1",
     "electron-builder": "^26.0.0",
     "tsx": "^4.19.0"
   },


### PR DESCRIPTION
## Summary
- vite.config.tsでSERVER_PORT/CLIENT_PORT環境変数に対応
- Electron版(デフォルト3001/5173)とWeb dev版を別ポートで並行起動可能に
- Electronバージョン固定でビルド安定化

closes #76

## 使い方
```bash
# Web dev版を別ポートで起動
SERVER_PORT=3002 CLIENT_PORT=5174 npm run dev
```

## Test plan
- [x] `npx vitest run` 全346テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)