### PR TITLE
fix: Electron本番ビルドで白画面を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+app-content/
 .turbo/
 *.db
 *.db-journal

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:client": "npm run dev -w packages/client",
     "electron": "npm run dev -w packages/electron",
     "electron:start": "npm run start -w packages/electron",
-    "build:electron": "npm run build -w packages/electron"
+    "build:electron": "npm run build -w packages/shared && npm run build -w packages/server && npm run build -w packages/client && npm run build -w packages/electron"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/client/src/__tests__/pane-tree-utils.test.ts
+++ b/packages/client/src/__tests__/pane-tree-utils.test.ts
@@ -23,8 +23,8 @@ function makeLeaf(id: string, ratio = 0.5, surfaces: Surface[] = []): PaneLeaf {
   return { kind: 'leaf', id, surfaces, activeSurfaceIndex: 0, ratio }
 }
 
-function makeSplit(id: string, direction: 'horizontal' | 'vertical', children: [PaneNode, PaneNode]): PaneSplit {
-  return { kind: 'split', id, direction, children }
+function makeSplit(id: string, direction: 'horizontal' | 'vertical', children: [PaneNode, PaneNode], ratio = 0.5): PaneSplit {
+  return { kind: 'split', id, direction, children, ratio }
 }
 
 function makeTerminalSurface(id: string, sessionId: string): Surface {

--- a/packages/client/src/components/board/BoardCanvas.tsx
+++ b/packages/client/src/components/board/BoardCanvas.tsx
@@ -209,7 +209,7 @@ function BoardCanvasInner() {
         continue
       }
 
-      isResizingRef.current = change.resizing
+      isResizingRef.current = change.resizing ?? false
       if (change.resizing || !change.dimensions?.width || !change.dimensions?.height) {
         continue
       }

--- a/packages/client/src/components/board/board-canvas-elements.ts
+++ b/packages/client/src/components/board/board-canvas-elements.ts
@@ -6,11 +6,12 @@ import { SessionNode, type SessionNodeData } from './SessionNode'
 
 export const GROUP_PADDING = 40
 
-export const boardNodeTypes: NodeTypes = {
+// react-flow の NodeTypes ジェネリクスとの型不一致を回避
+export const boardNodeTypes = {
   session: SessionNode,
   projectGroup: ProjectGroupNode,
   file: FileNode,
-}
+} as NodeTypes
 
 export interface CanvasFilter {
   favoritesOnly: boolean

--- a/packages/client/src/lib/pane-tree-utils.ts
+++ b/packages/client/src/lib/pane-tree-utils.ts
@@ -156,6 +156,7 @@ export function splitLeaf(
     const split: PaneSplit = {
       kind: 'split',
       id: generateSplitId(),
+      ratio: 0.5,
       direction,
       children: [originalLeaf, newLeaf],
     }

--- a/packages/client/src/stores/layout-store.ts
+++ b/packages/client/src/stores/layout-store.ts
@@ -423,8 +423,9 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 }))
 
-if (import.meta.vitest) {
-  import.meta.vitest.afterEach(() => {
+// vitest のインラインテスト用クリーンアップ
+if ((import.meta as any).vitest) {
+  ;(import.meta as any).vitest.afterEach(() => {
     clearLayoutPersistenceTimers()
   })
 }

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "dev": "node scripts/build.mjs && electron .",
-    "build": "node scripts/build.mjs && electron-builder",
+    "build": "node scripts/build.mjs && node scripts/bundle-app.mjs && electron-builder",
     "start": "electron ."
   },
   "dependencies": {
@@ -28,6 +28,14 @@
       "dist/**/*",
       "resources/**/*",
       "node_modules/**/*"
-    ]
+    ],
+    "extraResources": [
+      {
+        "from": "app-content",
+        "to": "app-content",
+        "filter": ["**/*"]
+      }
+    ],
+    "asarUnpack": []
   }
 }

--- a/packages/electron/scripts/bundle-app.mjs
+++ b/packages/electron/scripts/bundle-app.mjs
@@ -1,0 +1,77 @@
+/**
+ * Electronビルド用バンドルスクリプト
+ * クライアント・サーバーのビルド成果物を app-content/ にコピーする
+ */
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const electronRoot = resolve(__dirname, '..')
+const repoRoot = resolve(electronRoot, '../..')
+const appContent = resolve(electronRoot, 'app-content')
+
+// クリーンアップ
+rmSync(appContent, { recursive: true, force: true })
+mkdirSync(appContent, { recursive: true })
+
+// クライアントのビルド成果物をコピー
+cpSync(
+  resolve(repoRoot, 'packages/client/dist'),
+  resolve(appContent, 'client'),
+  { recursive: true },
+)
+console.log('コピー完了: client/dist → app-content/client')
+
+// サーバーのビルド成果物をコピー
+cpSync(
+  resolve(repoRoot, 'packages/server/dist'),
+  resolve(appContent, 'server'),
+  { recursive: true },
+)
+
+// sharedのビルド成果物もコピー（サーバーが参照する）
+mkdirSync(resolve(appContent, 'shared', 'dist'), { recursive: true })
+cpSync(
+  resolve(repoRoot, 'packages/shared/dist'),
+  resolve(appContent, 'shared', 'dist'),
+  { recursive: true },
+)
+cpSync(
+  resolve(repoRoot, 'packages/shared/package.json'),
+  resolve(appContent, 'shared', 'package.json'),
+)
+
+// サーバーの依存関係をルートのnode_modulesから直接コピー
+const serverPkg = JSON.parse(readFileSync(resolve(repoRoot, 'packages/server/package.json'), 'utf-8'))
+const deps = Object.keys(serverPkg.dependencies || {})
+const serverModules = resolve(appContent, 'server', 'node_modules')
+mkdirSync(serverModules, { recursive: true })
+
+for (const dep of deps) {
+  if (dep.startsWith('@kurimats/')) continue // workspace参照はスキップ
+  const src = resolve(repoRoot, 'node_modules', dep)
+  const dst = resolve(serverModules, dep)
+  try {
+    cpSync(src, dst, { recursive: true })
+    console.log(`  コピー: ${dep}`)
+  } catch {
+    console.warn(`  スキップ（見つからない）: ${dep}`)
+  }
+}
+
+// @kurimats/shared をnode_modulesにコピーし、mainをdistに書き換え
+mkdirSync(resolve(serverModules, '@kurimats'), { recursive: true })
+cpSync(
+  resolve(appContent, 'shared'),
+  resolve(serverModules, '@kurimats', 'shared'),
+  { recursive: true },
+)
+// package.json の main を dist 向けに書き換え
+const sharedPkgPath = resolve(serverModules, '@kurimats', 'shared', 'package.json')
+const sharedPkg = JSON.parse(readFileSync(sharedPkgPath, 'utf-8'))
+sharedPkg.main = './dist/index.js'
+sharedPkg.types = './dist/index.d.ts'
+writeFileSync(sharedPkgPath, JSON.stringify(sharedPkg, null, 2) + '\n')
+
+console.log('バンドル完了: app-content/')

--- a/packages/electron/src/__tests__/server-process.test.ts
+++ b/packages/electron/src/__tests__/server-process.test.ts
@@ -211,8 +211,8 @@ describe('resolveServerDir', () => {
     expect(result).toContain('server')
   })
 
-  it('ビルドモードではappPath配下のパスを返す', () => {
-    const result = resolveServerDir(false, '/Applications/kurimats.app')
-    expect(result).toBe('/Applications/kurimats.app/packages/server')
+  it('ビルドモードではresourcesPath配下のパスを返す', () => {
+    const result = resolveServerDir(false, '/Applications/kurimats.app/Contents/Resources')
+    expect(result).toBe('/Applications/kurimats.app/Contents/Resources/app-content/server')
   })
 })

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -94,7 +94,9 @@ const store = new Store()
 // サーバープロセス管理
 const serverManager = new ServerProcessManager({
   spawnFn: spawn as any,
-  serverDir: resolveServerDir(IS_DEV, app.getAppPath()),
+  serverDir: resolveServerDir(IS_DEV, process.resourcesPath),
+  clientDir: IS_DEV ? undefined : path.join(process.resourcesPath, 'app-content', 'client'),
+  isDev: IS_DEV,
 })
 
 let mainWindow: BrowserWindow | null = null
@@ -130,12 +132,9 @@ function createWindow(): void {
   }
 
   // クライアントURLをロード
-  if (IS_DEV) {
-    mainWindow.loadURL(DEV_CLIENT_URL)
-  } else {
-    // ビルド後はローカルファイルを読み込む
-    mainWindow.loadFile('../client/dist/index.html')
-  }
+  // 本番でもサーバー経由でロード（APIが相対パスのため file:// では動かない）
+  const clientUrl = IS_DEV ? DEV_CLIENT_URL : `http://localhost:${SERVER_PORT}`
+  mainWindow.loadURL(clientUrl)
 
   // 外部リンクをブラウザで開く
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -181,14 +180,23 @@ app.whenReady().then(async () => {
   // サーバーを自動起動
   serverManager.start(SERVER_PORT)
 
-  // dev時はViteクライアントも起動して準備完了を待つ
   if (IS_DEV) {
+    // dev時はViteクライアントも起動して準備完了を待つ
     console.log('Vite devサーバーを起動中...')
     try {
       await startViteDevServer()
       console.log('Vite devサーバー準備完了')
     } catch (err) {
       console.error('Vite起動に失敗:', err)
+    }
+  } else {
+    // 本番時はサーバーの起動を待つ
+    console.log('サーバーの起動を待機中...')
+    try {
+      await waitForUrl(`http://localhost:${SERVER_PORT}/api/health`, 30, 1000)
+      console.log('サーバー準備完了')
+    } catch (err) {
+      console.error('サーバー起動待機に失敗:', err)
     }
   }
 

--- a/packages/electron/src/server-process.ts
+++ b/packages/electron/src/server-process.ts
@@ -22,10 +22,14 @@ export class ServerProcessManager {
   private _status: ServerStatus = 'stopped'
   private spawnFn: SpawnFunction
   private serverDir: string
+  private clientDir: string | null
+  private isDev: boolean
 
-  constructor(options: { spawnFn: SpawnFunction; serverDir?: string }) {
+  constructor(options: { spawnFn: SpawnFunction; serverDir?: string; clientDir?: string; isDev?: boolean }) {
     this.spawnFn = options.spawnFn
     this.serverDir = options.serverDir || path.resolve(__dirname, '../../server')
+    this.clientDir = options.clientDir || null
+    this.isDev = options.isDev ?? true
   }
 
   /** 現在の状態を取得 */
@@ -52,13 +56,25 @@ export class ServerProcessManager {
     console.log(`サーバーを起動中... (ポート: ${port})`)
 
     try {
+      const command = this.isDev ? 'npx' : 'node'
+      const args = this.isDev ? ['tsx', 'watch', 'src/index.ts'] : ['index.js']
+
+      // 本番時はクライアント静的ファイルのパスを渡す
+      const env: Record<string, string | undefined> = {
+        ...process.env,
+        PORT: String(port),
+      }
+      if (!this.isDev && this.clientDir) {
+        env.STATIC_DIR = this.clientDir
+      }
+
       this.process = this.spawnFn(
-        'npx',
-        ['tsx', 'watch', 'src/index.ts'],
+        command,
+        args,
         {
           cwd: this.serverDir,
           stdio: 'pipe',
-          env: { ...process.env, PORT: String(port) },
+          env,
         }
       )
 
@@ -129,10 +145,10 @@ export class ServerProcessManager {
  * サーバーディレクトリのパスを解決する
  * 開発時とビルド後で異なるパスに対応
  */
-export function resolveServerDir(isDev: boolean, appPath: string): string {
+export function resolveServerDir(isDev: boolean, resourcesPath: string): string {
   if (isDev) {
     return path.resolve(__dirname, '../../server')
   }
-  // ビルド後はアプリバンドル内のパスを使用
-  return path.join(appPath, 'packages', 'server')
+  // ビルド後はextraResources内のサーバーを使用
+  return path.join(resourcesPath, 'app-content', 'server')
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -88,6 +88,21 @@ app.use('/api/ssh', createSshRouter(sshManager, sessionStore))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
 app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService))
 
+// 本番時: 静的ファイル配信（Electronビルド or スタンドアロン）
+const STATIC_DIR = process.env.STATIC_DIR
+if (STATIC_DIR) {
+  const { resolve } = await import('path')
+  const staticPath = resolve(STATIC_DIR)
+  app.use(express.static(staticPath))
+  // SPA フォールバック: API/WS以外のリクエストをindex.htmlに転送
+  app.get('/{*path}', (req, res, next) => {
+    if (req.path.startsWith('/api') || req.path.startsWith('/ws')) {
+      return next()
+    }
+    res.sendFile(resolve(staticPath, 'index.html'))
+  })
+}
+
 // ヘルスチェック
 app.get('/api/health', (_req, res) => {
   res.json({

--- a/packages/server/src/routes/layout.ts
+++ b/packages/server/src/routes/layout.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import type { SessionStore } from '../services/session-store.js'
 import type { CanvasStore } from '../services/canvas-store.js'
-import type { LayoutState, BoardLayoutState, CreateWorkspaceParams, BoardNodePosition, FileTilePosition, BoardEdge } from '@kurimats/shared'
+import type { LayoutState, BoardLayoutState } from '@kurimats/shared'
 
 export function createLayoutRouter(store: SessionStore, canvasStore?: CanvasStore): Router {
   const router = Router()
@@ -41,52 +41,6 @@ export function createLayoutRouter(store: SessionStore, canvasStore?: CanvasStor
     }
     // SQLiteにもバックアップ保存
     store.saveBoardLayout(state)
-    res.json({ ok: true })
-  })
-
-  // ==================== ワークスペース ====================
-
-  /** ワークスペース一覧 */
-  router.get('/workspaces', (_req, res) => {
-    res.json(store.getAllWorkspaces())
-  })
-
-  /** ワークスペース保存（現在のキャンバス状態をスナップショット） */
-  router.post('/workspaces', (req, res) => {
-    const { name, boardNodes, fileTiles, edges, viewport } = req.body as CreateWorkspaceParams & {
-      boardNodes: unknown[]; fileTiles: unknown[]; edges: unknown[]; viewport: { x: number; y: number; zoom: number }
-    }
-    if (!name) {
-      res.status(400).json({ error: 'name は必須です' })
-      return
-    }
-    const workspace = store.createWorkspace(
-      { name },
-      (boardNodes || []) as BoardNodePosition[],
-      (fileTiles || []) as FileTilePosition[],
-      (edges || []) as BoardEdge[],
-      viewport || { x: 0, y: 0, zoom: 1 },
-    )
-    res.status(201).json(workspace)
-  })
-
-  /** ワークスペース取得 */
-  router.get('/workspaces/:id', (req, res) => {
-    const workspace = store.getWorkspace(req.params.id)
-    if (!workspace) {
-      res.status(404).json({ error: 'ワークスペースが見つかりません' })
-      return
-    }
-    res.json(workspace)
-  })
-
-  /** ワークスペース削除 */
-  router.delete('/workspaces/:id', (req, res) => {
-    const deleted = store.deleteWorkspace(req.params.id)
-    if (!deleted) {
-      res.status(404).json({ error: 'ワークスペースが見つかりません' })
-      return
-    }
     res.json({ ok: true })
   })
 


### PR DESCRIPTION
## Summary
- Electronビルド後のアプリが白画面だった問題を修正
- client/server/sharedをextraResourcesとしてasar外にバンドル
- サーバーで静的ファイル配信（STATIC_DIR環境変数）
- Express 5ワイルドカード対応、レガシーAPI削除

closes #78

## Test plan
- [x] `npx vitest run` 全346テストパス
- [x] `npm run build:electron` ビルド成功
- [x] ビルド後アプリ起動 → UI正常表示確認（スクリーンショット確認済み）
- [x] `/api/health` レスポンス正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)