### PR TITLE
fix: node-pty spawn-helper実行権限付与でElectronアプリのPTY復活

### DIFF
--- a/packages/electron/scripts/bundle-app.mjs
+++ b/packages/electron/scripts/bundle-app.mjs
@@ -2,7 +2,7 @@
  * Electronビルド用バンドルスクリプト
  * クライアント・サーバーのビルド成果物を app-content/ にコピーする
  */
-import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, lstatSync } from 'fs'
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, lstatSync, chmodSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -98,6 +98,13 @@ function copyDependencyTree(depName, visited = new Set()) {
 const visited = new Set()
 for (const dep of topDeps) {
   copyDependencyTree(dep, visited)
+}
+
+// node-ptyのspawn-helperに実行権限を付与（posix_spawnp失敗防止）
+const spawnHelperPath = resolve(serverModules, 'node-pty', 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
+if (existsSync(spawnHelperPath)) {
+  chmodSync(spawnHelperPath, 0o755)
+  console.log('  実行権限付与: node-pty/spawn-helper')
 }
 
 // @kurimats/shared をnode_modulesにコピーし、mainをdistに書き換え

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -77,8 +77,8 @@ async function loadNodePty(): Promise<INodePty | null> {
     testProc.kill()
     nodePty = pty
     return nodePty
-  } catch {
-    console.warn('node-pty利用不可。child_processモードで動作します')
+  } catch (e) {
+    console.warn('node-pty利用不可。child_processモードで動作します:', e)
     return null
   }
 }


### PR DESCRIPTION
## Summary
- `bundle-app.mjs`: node-ptyの`spawn-helper`バイナリに`chmod 755`を付与
- `pty-manager.ts`: node-pty読み込み失敗時のエラー詳細をログ出力

## 原因
`cpSync`でnode-ptyをバンドルにコピーする際、`spawn-helper`の実行権限が失われ、`posix_spawnp failed`でnode-ptyが使えずchild_processモードにフォールバックしていた。

## Test plan
- [x] バンドル内のnode-ptyが`/bin/echo`を正常に起動確認
- [x] `npx vitest run -t "bundle-app"` — 全テストパス

closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)