### PR TITLE
fix: ペイン削除後のratio均等化

### DIFF
--- a/packages/client/src/__tests__/pane-tree-utils.test.ts
+++ b/packages/client/src/__tests__/pane-tree-utils.test.ts
@@ -189,6 +189,14 @@ describe('closeLeaf', () => {
     }
   })
 
+  it('リーフ削除後にratioが均等化される', () => {
+    const result = closeLeaf(splitRoot, 'leaf-B')!
+    expect(result.kind).toBe('split')
+    if (result.kind === 'split') {
+      expect(result.ratio).toBe(0.5)
+    }
+  })
+
   it('最後のリーフは閉じない（nullを返す）', () => {
     const single = makeLeaf('only')
     expect(closeLeaf(single, 'only')).toBeNull()

--- a/packages/client/src/lib/pane-tree-utils.ts
+++ b/packages/client/src/lib/pane-tree-utils.ts
@@ -180,13 +180,13 @@ export function closeLeaf(tree: PaneNode, leafId: string): PaneNode | null {
   // 再帰的に探索
   const newFirst = closeLeaf(first, leafId)
   if (newFirst !== first) {
-    // first側で変更があった
-    return newFirst === null ? second : { ...tree, children: [newFirst, second] }
+    // first側で変更があった — ratioを均等化
+    return newFirst === null ? second : { ...tree, children: [newFirst, second], ratio: 0.5 }
   }
 
   const newSecond = closeLeaf(second, leafId)
   if (newSecond !== second) {
-    return newSecond === null ? first : { ...tree, children: [first, newSecond] }
+    return newSecond === null ? first : { ...tree, children: [first, newSecond], ratio: 0.5 }
   }
 
   return tree


### PR DESCRIPTION
## Summary
- `closeLeaf`でツリー構造変化時にratioを0.5にリセット

## Test plan
- [x] `npx vitest run -t "closeLeaf"` — 5テストパス（新規1件追加）

closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)