### PR TITLE
fix: ペイン削除後のleaf ratio均等化（v2）

### DIFF
--- a/packages/client/src/__tests__/pane-tree-utils.test.ts
+++ b/packages/client/src/__tests__/pane-tree-utils.test.ts
@@ -194,6 +194,12 @@ describe('closeLeaf', () => {
     expect(result.kind).toBe('split')
     if (result.kind === 'split') {
       expect(result.ratio).toBe(0.5)
+      // 昇格した子leafのratioも0.5にリセット
+      for (const child of result.children) {
+        if (child.kind === 'leaf') {
+          expect(child.ratio).toBe(0.5)
+        }
+      }
     }
   })
 

--- a/packages/client/src/lib/pane-tree-utils.ts
+++ b/packages/client/src/lib/pane-tree-utils.ts
@@ -173,20 +173,25 @@ export function closeLeaf(tree: PaneNode, leafId: string): PaneNode | null {
 
   const [first, second] = tree.children
 
-  // 直接の子が対象なら兄弟を返す
-  if (first.id === leafId) return second
-  if (second.id === leafId) return first
+  // 直接の子が対象なら兄弟を返す（leafならratioを0.5にリセット）
+  if (first.id === leafId) return second.kind === 'leaf' ? { ...second, ratio: 0.5 } : second
+  if (second.id === leafId) return first.kind === 'leaf' ? { ...first, ratio: 0.5 } : first
 
   // 再帰的に探索
   const newFirst = closeLeaf(first, leafId)
   if (newFirst !== first) {
-    // first側で変更があった — ratioを均等化
-    return newFirst === null ? second : { ...tree, children: [newFirst, second], ratio: 0.5 }
+    if (newFirst === null) return second.kind === 'leaf' ? { ...second, ratio: 0.5 } : second
+    const resetFirst = newFirst.kind === 'leaf' ? { ...newFirst, ratio: 0.5 } : newFirst
+    const resetSecond = second.kind === 'leaf' ? { ...second, ratio: 0.5 } : second
+    return { ...tree, children: [resetFirst, resetSecond], ratio: 0.5 }
   }
 
   const newSecond = closeLeaf(second, leafId)
   if (newSecond !== second) {
-    return newSecond === null ? first : { ...tree, children: [first, newSecond], ratio: 0.5 }
+    if (newSecond === null) return first.kind === 'leaf' ? { ...first, ratio: 0.5 } : first
+    const resetFirst = first.kind === 'leaf' ? { ...first, ratio: 0.5 } : first
+    const resetSecond = newSecond.kind === 'leaf' ? { ...newSecond, ratio: 0.5 } : newSecond
+    return { ...tree, children: [resetFirst, resetSecond], ratio: 0.5 }
   }
 
   return tree


### PR DESCRIPTION
## Summary
- `closeLeaf`で昇格するleafの`ratio`も0.5にリセット
- 前回の修正(#85)ではsplit.ratioのみ修正していたが、レイアウト計算は**leaf.ratio**を参照していた

## Test plan
- [x] `npx vitest run -t "closeLeaf"` — 5テストパス

closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)