### PR TITLE
fix: オーバーレイのセッション解決をワークスペースベースに統一

### DIFF
--- a/packages/client/src/components/overlays/FileTreeOverlay.tsx
+++ b/packages/client/src/components/overlays/FileTreeOverlay.tsx
@@ -2,22 +2,19 @@ import { useState, useEffect, useCallback } from 'react'
 import type { FileNode } from '@kurimats/shared'
 import { filesApi } from '../../lib/api'
 import { useOverlayStore } from '../../stores/overlay-store'
-import { useSessionStore } from '../../stores/session-store'
-import { useLayoutStore } from '../../stores/layout-store'
+import { useWorkspaceStore } from '../../stores/workspace-store'
 import { OverlayContainer } from './OverlayContainer'
 
 interface Props {
   onClose: () => void
-  sessionId?: string
 }
 
 /**
  * ファイルツリーオーバーレイ
  * リポジトリのファイル構造を表示
  */
-export function FileTreeOverlay({ onClose, sessionId }: Props) {
-  const { sessions } = useSessionStore()
-  const { panels, activePanelIndex } = useLayoutStore()
+export function FileTreeOverlay({ onClose }: Props) {
+  const { workspaces, activeWorkspaceId } = useWorkspaceStore()
   const { openOverlay } = useOverlayStore()
   const [tree, setTree] = useState<FileNode[]>([])
   const [loading, setLoading] = useState(true)
@@ -25,21 +22,10 @@ export function FileTreeOverlay({ onClose, sessionId }: Props) {
   const [filter, setFilter] = useState('')
   const [workingDir, setWorkingDir] = useState('')
 
-  // セッションのリポジトリパスを取得（sessionId指定時はそのセッション優先）
+  // アクティブワークスペースのrepoPathを使用
   useEffect(() => {
-    let activeSession
-    if (sessionId) {
-      activeSession = sessions.find(s => s.id === sessionId)
-    } else {
-      const activePanel = panels[activePanelIndex]
-      activeSession = activePanel?.sessionId
-        ? sessions.find(s => s.id === activePanel.sessionId)
-        : sessions[0]
-    }
-
-    // ファイルツリーではrepoPath（元リポジトリ）を優先
-    // worktreePathはgit管理ファイルのみで不完全なため
-    const root = activeSession?.repoPath || ''
+    const activeWs = workspaces.find(w => w.id === activeWorkspaceId)
+    const root = activeWs?.repoPath || ''
     setWorkingDir(root)
 
     if (!root) {
@@ -59,7 +45,7 @@ export function FileTreeOverlay({ onClose, sessionId }: Props) {
         setError(String(e))
         setLoading(false)
       })
-  }, [sessions, panels, activePanelIndex])
+  }, [workspaces, activeWorkspaceId])
 
   const handleFileClick = useCallback((path: string) => {
     if (path.endsWith('.md')) {

--- a/packages/client/src/components/overlays/MarkdownOverlay.tsx
+++ b/packages/client/src/components/overlays/MarkdownOverlay.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { filesApi } from '../../lib/api'
-import { useSessionStore } from '../../stores/session-store'
-import { useLayoutStore } from '../../stores/layout-store'
+import { useWorkspaceStore } from '../../stores/workspace-store'
 import { OverlayContainer } from './OverlayContainer'
 
 interface Props {
@@ -17,8 +16,7 @@ interface Props {
  * マークダウンファイルの編集・プレビュー
  */
 export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: Props) {
-  const { sessions } = useSessionStore()
-  const { panels, activePanelIndex } = useLayoutStore()
+  const { workspaces, activeWorkspaceId } = useWorkspaceStore()
   const [filePath, setFilePath] = useState(initialPath || '')
   const [content, setContent] = useState('')
   const [loading, setLoading] = useState(false)
@@ -33,19 +31,14 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: 
       return
     }
 
-    // アクティブセッションのリポジトリからREADME.mdを探す
-    const activePanel = panels[activePanelIndex]
-    const activeSession = activePanel?.sessionId
-      ? sessions.find(s => s.id === activePanel.sessionId)
-      : sessions[0]
-    // repoPath（元リポジトリ）を優先。worktreePathはREADME.mdが存在しない場合がある
-    const root = activeSession?.repoPath || activeSession?.worktreePath
+    // アクティブワークスペースのrepoPathからREADME.md/CLAUDE.mdを探す
+    const activeWs = workspaces.find(w => w.id === activeWorkspaceId)
+    const root = activeWs?.repoPath
     if (root) {
-      // README.md → CLAUDE.md の順で試行
       const candidates = [`${root}/README.md`, `${root}/CLAUDE.md`]
       tryLoadFirst(candidates)
     }
-  }, [initialPath, sessions, panels, activePanelIndex])
+  }, [initialPath, workspaces, activeWorkspaceId])
 
   // 候補パスを順に試行し、最初に見つかったファイルを読み込む
   const tryLoadFirst = useCallback(async (candidates: string[]) => {

--- a/packages/client/src/components/overlays/OverlayRenderer.tsx
+++ b/packages/client/src/components/overlays/OverlayRenderer.tsx
@@ -17,7 +17,6 @@ export function OverlayRenderer() {
       return (
         <FileTreeOverlay
           onClose={closeOverlay}
-          sessionId={overlayProps.sessionId as string | undefined}
         />
       )
     case 'markdown':


### PR DESCRIPTION
## Summary
- FileTreeOverlay/MarkdownOverlayが旧layout-storeのpanelsを参照していた → workspace-storeのactiveWorkspaceId/repoPathに統一
- ワークスペース切替時に正しいリポジトリのファイルツリー/Markdownが表示されるよう修正
- README.md不在時はCLAUDE.mdにフォールバック

closes #88

## Test plan
- [x] ユニットテスト14件通過
- [x] Playwrightでローカル/SSHワークスペース切替後のファイルツリー・Markdown表示確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)