### PR TITLE
feat: PANE_NUMBER環境変数による開発ポート自動分離

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,15 @@ npm run build:electron   # Electron配布ビルド
 
 ### ポート分離（並列開発）
 - `PANE_NUMBER` 環境変数で全ポートを自動算出（PTYにも伝播）
-- **本番(Electron)とは帯域が分離されている**
+- **本番(Electron)とは帯域が完全に分離されている**
+- **mainブランチでは `npm run dev` しない**（本番ブランチ）
 
-| サービス | 計算式 | main(N=0) | pane1 | pane2 | pane3 | 本番(Electron) |
-|---------|--------|-----------|-------|-------|-------|---------------|
-| Server | 14000+N | 3001(default) | 14001 | 14002 | 14003 | 13001 |
-| Client | 5180+N | 5173(default) | 5181 | 5182 | 5183 | 5173 |
-| Playwright | 3550+N | 3550+連番 | 3551 | 3552 | 3553 | - |
+| サービス | 計算式 | develop(N=0) | pane1 | pane2 | pane3 | 本番(Electron) |
+|---------|--------|-------------|-------|-------|-------|---------------|
+| Server | 14000+N | 14000 | 14001 | 14002 | 14003 | 13001 |
+| Client | 5180+N | 5180 | 5181 | 5182 | 5183 | 5173 |
+| Playwright | 3550+N | 3550 | 3551 | 3552 | 3553 | - |
 
-- 起動例: `PANE_NUMBER=3 npm run dev` → Server:14003, Client:5183, Playwright:3553
-- 手動worktreeの場合: `PANE_NUMBER=3 claude` で Claude Code にもペイン番号が伝わる
+- develop起動例: `PANE_NUMBER=0 npm run dev` → Server:14000, Client:5180
+- pane起動例: `PANE_NUMBER=3 npm run dev` → Server:14003, Client:5183, Playwright:3553
 - kurimats-emulator経由の場合: PTY起動時に `PANE_NUMBER` が自動設定される

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,16 @@ npm run build:electron   # Electron配布ビルド
 - **Issueなしでブランチを切らない**
 - ブランチ名: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `test/`
 
-### Playwright（並列実行時のポート分離）
-- 複数セッションが同時にPlaywrightを使う場合、**ポートが衝突しないようにする**
-- kurimats-emulator経由の場合: PTY環境変数 `PLAYWRIGHT_MCP_PORT` が自動設定される（3551〜）
-- 手動worktreeで作業する場合: ペイン番号に応じてポートを使い分ける
-  - pane1: `3551`, pane2: `3552`, pane3: `3553`, ...
-  - 起動例: `PLAYWRIGHT_MCP_PORT=3553 claude`
+### ポート分離（並列開発）
+- `PANE_NUMBER` 環境変数で全ポートを自動算出（PTYにも伝播）
+- **本番(Electron)とは帯域が分離されている**
+
+| サービス | 計算式 | main(N=0) | pane1 | pane2 | pane3 | 本番(Electron) |
+|---------|--------|-----------|-------|-------|-------|---------------|
+| Server | 14000+N | 3001(default) | 14001 | 14002 | 14003 | 13001 |
+| Client | 5180+N | 5173(default) | 5181 | 5182 | 5183 | 5173 |
+| Playwright | 3550+N | 3550+連番 | 3551 | 3552 | 3553 | - |
+
+- 起動例: `PANE_NUMBER=3 npm run dev` → Server:14003, Client:5183, Playwright:3553
+- 手動worktreeの場合: `PANE_NUMBER=3 claude` で Claude Code にもペイン番号が伝わる
+- kurimats-emulator経由の場合: PTY起動時に `PANE_NUMBER` が自動設定される

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -2,12 +2,15 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-// ペイン番号からポートを自動算出（PANE_NUMBERが設定されていれば既存env変数より優先）
-const paneNumber = parseInt(process.env.PANE_NUMBER || '0', 10)
-const serverPort = paneNumber > 0
+// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
+// 設定時は既存env変数より優先。未設定時のみSERVER_PORT/CLIENT_PORTにフォールバック
+const paneNumber = process.env.PANE_NUMBER != null
+  ? parseInt(process.env.PANE_NUMBER, 10)
+  : null
+const serverPort = paneNumber != null
   ? String(14000 + paneNumber)
   : (process.env.SERVER_PORT || '3001')
-const clientPort = paneNumber > 0
+const clientPort = paneNumber != null
   ? 5180 + paneNumber
   : parseInt(process.env.CLIENT_PORT || '5173', 10)
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -2,10 +2,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-// ペイン番号からポートを自動算出（PANE_NUMBER未設定時はデフォルトを維持）
+// ペイン番号からポートを自動算出（PANE_NUMBERが設定されていれば既存env変数より優先）
 const paneNumber = parseInt(process.env.PANE_NUMBER || '0', 10)
-const serverPort = process.env.SERVER_PORT || String(paneNumber > 0 ? 14000 + paneNumber : 3001)
-const clientPort = parseInt(process.env.CLIENT_PORT || String(paneNumber > 0 ? 5180 + paneNumber : 5173), 10)
+const serverPort = paneNumber > 0
+  ? String(14000 + paneNumber)
+  : (process.env.SERVER_PORT || '3001')
+const clientPort = paneNumber > 0
+  ? 5180 + paneNumber
+  : parseInt(process.env.CLIENT_PORT || '5173', 10)
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],

--- a/packages/server/src/__tests__/port-allocation.test.ts
+++ b/packages/server/src/__tests__/port-allocation.test.ts
@@ -4,36 +4,44 @@ import { describe, it, expect } from 'vitest'
  * PANE_NUMBERベースのポート自動算出ロジックテスト
  *
  * ポートスキーム:
- * | サービス   | 計算式     | main(N=0)     | pane1  | pane2  | pane3  | 本番(Electron) |
- * |-----------|-----------|---------------|--------|--------|--------|---------------|
- * | Server    | 14000+N   | 3001(default) | 14001  | 14002  | 14003  | 13001         |
- * | Client    | 5180+N    | 5173(default) | 5181   | 5182   | 5183   | 5173          |
- * | Playwright| 3550+N    | 3550+連番     | 3551   | 3552   | 3553   | -             |
+ * | サービス   | 計算式     | develop(N=0) | pane1  | pane2  | pane3  | 本番(Electron) |
+ * |-----------|-----------|-------------|--------|--------|--------|---------------|
+ * | Server    | 14000+N   | 14000       | 14001  | 14002  | 14003  | 13001         |
+ * | Client    | 5180+N    | 5180        | 5181   | 5182   | 5183   | 5173          |
+ * | Playwright| 3550+N    | 3550        | 3551   | 3552   | 3553   | -             |
+ *
+ * - PANE_NUMBER設定時: 14000+N / 5180+N / 3550+N（既存env変数より優先）
+ * - PANE_NUMBER未設定: PORT / SERVER_PORT / CLIENT_PORT にフォールバック
+ * - mainブランチではnpm run devしない（本番ブランチ）
  */
 
 // サーバーポート算出ロジック（index.tsと同じ）
-function calcServerPort(paneNumber: number, envPort?: string): number {
-  return paneNumber > 0
+function calcServerPort(paneNumber: number | null, envPort?: string): number {
+  return paneNumber != null
     ? 14000 + paneNumber
     : parseInt(envPort || '3001', 10)
 }
 
 // クライアントポート算出ロジック（vite.config.tsと同じ）
-function calcClientPort(paneNumber: number, envClientPort?: string): number {
-  return paneNumber > 0
+function calcClientPort(paneNumber: number | null, envClientPort?: string): number {
+  return paneNumber != null
     ? 5180 + paneNumber
     : parseInt(envClientPort || '5173', 10)
 }
 
 // Playwrightポート算出ロジック（pty-manager.tsと同じ）
-function calcPlaywrightPort(paneNumber: number, portCounter: number): number {
-  return paneNumber > 0
+function calcPlaywrightPort(paneNumber: number | null, portCounter: number): number {
+  return paneNumber != null
     ? 3550 + paneNumber
     : 3550 + portCounter
 }
 
 describe('ポート自動算出', () => {
   describe('サーバーポート', () => {
+    it('PANE_NUMBER=0（develop）→ 14000', () => {
+      expect(calcServerPort(0)).toBe(14000)
+    })
+
     it('PANE_NUMBER=1 → 14001', () => {
       expect(calcServerPort(1)).toBe(14001)
     })
@@ -42,20 +50,28 @@ describe('ポート自動算出', () => {
       expect(calcServerPort(3)).toBe(14003)
     })
 
-    it('PANE_NUMBER=0 でPORT未設定 → デフォルト3001', () => {
-      expect(calcServerPort(0)).toBe(3001)
+    it('PANE_NUMBER未設定でPORT未設定 → デフォルト3001', () => {
+      expect(calcServerPort(null)).toBe(3001)
     })
 
-    it('PANE_NUMBER=0 でPORT=13001 → 13001（既存PORT優先）', () => {
-      expect(calcServerPort(0, '13001')).toBe(13001)
+    it('PANE_NUMBER未設定でPORT=13001 → 13001（既存PORT優先）', () => {
+      expect(calcServerPort(null, '13001')).toBe(13001)
     })
 
-    it('PANE_NUMBER > 0 の場合、既存PORTは無視される', () => {
+    it('PANE_NUMBER設定時は既存PORTより優先', () => {
       expect(calcServerPort(3, '13001')).toBe(14003)
+    })
+
+    it('PANE_NUMBER=0でもPORTより優先（develop用）', () => {
+      expect(calcServerPort(0, '13001')).toBe(14000)
     })
   })
 
   describe('クライアントポート', () => {
+    it('PANE_NUMBER=0（develop）→ 5180', () => {
+      expect(calcClientPort(0)).toBe(5180)
+    })
+
     it('PANE_NUMBER=1 → 5181', () => {
       expect(calcClientPort(1)).toBe(5181)
     })
@@ -64,16 +80,20 @@ describe('ポート自動算出', () => {
       expect(calcClientPort(3)).toBe(5183)
     })
 
-    it('PANE_NUMBER=0 → デフォルト5173', () => {
-      expect(calcClientPort(0)).toBe(5173)
+    it('PANE_NUMBER未設定 → デフォルト5173', () => {
+      expect(calcClientPort(null)).toBe(5173)
     })
 
-    it('PANE_NUMBER > 0 の場合、既存CLIENT_PORTは無視される', () => {
+    it('PANE_NUMBER設定時は既存CLIENT_PORTより優先', () => {
       expect(calcClientPort(3, '5173')).toBe(5183)
     })
   })
 
   describe('Playwrightポート', () => {
+    it('PANE_NUMBER=0（develop）→ 3550', () => {
+      expect(calcPlaywrightPort(0, 1)).toBe(3550)
+    })
+
     it('PANE_NUMBER=1 → 3551', () => {
       expect(calcPlaywrightPort(1, 1)).toBe(3551)
     })
@@ -82,9 +102,9 @@ describe('ポート自動算出', () => {
       expect(calcPlaywrightPort(3, 5)).toBe(3553)
     })
 
-    it('PANE_NUMBER=0 → 通し番号ベース（3550+counter）', () => {
-      expect(calcPlaywrightPort(0, 1)).toBe(3551)
-      expect(calcPlaywrightPort(0, 2)).toBe(3552)
+    it('PANE_NUMBER未設定 → 通し番号ベース（3550+counter）', () => {
+      expect(calcPlaywrightPort(null, 1)).toBe(3551)
+      expect(calcPlaywrightPort(null, 2)).toBe(3552)
     })
   })
 
@@ -92,22 +112,22 @@ describe('ポート自動算出', () => {
     const PRODUCTION_SERVER_PORT = 13001
     const PRODUCTION_CLIENT_PORT = 5173
 
-    it('全ペインのサーバーポートが本番と衝突しない', () => {
-      for (let n = 1; n <= 10; n++) {
+    it('develop・全ペインのサーバーポートが本番と衝突しない', () => {
+      for (let n = 0; n <= 10; n++) {
         expect(calcServerPort(n)).not.toBe(PRODUCTION_SERVER_PORT)
       }
     })
 
-    it('全ペインのクライアントポートが本番と衝突しない', () => {
-      for (let n = 1; n <= 10; n++) {
+    it('develop・全ペインのクライアントポートが本番と衝突しない', () => {
+      for (let n = 0; n <= 10; n++) {
         expect(calcClientPort(n)).not.toBe(PRODUCTION_CLIENT_PORT)
       }
     })
 
-    it('ペイン間でポートが衝突しない', () => {
+    it('develop含むペイン間でポートが衝突しない', () => {
       const serverPorts = new Set<number>()
       const clientPorts = new Set<number>()
-      for (let n = 1; n <= 10; n++) {
+      for (let n = 0; n <= 10; n++) {
         const sp = calcServerPort(n)
         const cp = calcClientPort(n)
         expect(serverPorts.has(sp)).toBe(false)

--- a/packages/server/src/__tests__/port-allocation.test.ts
+++ b/packages/server/src/__tests__/port-allocation.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * PANE_NUMBERベースのポート自動算出ロジックテスト
+ *
+ * ポートスキーム:
+ * | サービス   | 計算式     | main(N=0)     | pane1  | pane2  | pane3  | 本番(Electron) |
+ * |-----------|-----------|---------------|--------|--------|--------|---------------|
+ * | Server    | 14000+N   | 3001(default) | 14001  | 14002  | 14003  | 13001         |
+ * | Client    | 5180+N    | 5173(default) | 5181   | 5182   | 5183   | 5173          |
+ * | Playwright| 3550+N    | 3550+連番     | 3551   | 3552   | 3553   | -             |
+ */
+
+// サーバーポート算出ロジック（index.tsと同じ）
+function calcServerPort(paneNumber: number, envPort?: string): number {
+  return paneNumber > 0
+    ? 14000 + paneNumber
+    : parseInt(envPort || '3001', 10)
+}
+
+// クライアントポート算出ロジック（vite.config.tsと同じ）
+function calcClientPort(paneNumber: number, envClientPort?: string): number {
+  return paneNumber > 0
+    ? 5180 + paneNumber
+    : parseInt(envClientPort || '5173', 10)
+}
+
+// Playwrightポート算出ロジック（pty-manager.tsと同じ）
+function calcPlaywrightPort(paneNumber: number, portCounter: number): number {
+  return paneNumber > 0
+    ? 3550 + paneNumber
+    : 3550 + portCounter
+}
+
+describe('ポート自動算出', () => {
+  describe('サーバーポート', () => {
+    it('PANE_NUMBER=1 → 14001', () => {
+      expect(calcServerPort(1)).toBe(14001)
+    })
+
+    it('PANE_NUMBER=3 → 14003', () => {
+      expect(calcServerPort(3)).toBe(14003)
+    })
+
+    it('PANE_NUMBER=0 でPORT未設定 → デフォルト3001', () => {
+      expect(calcServerPort(0)).toBe(3001)
+    })
+
+    it('PANE_NUMBER=0 でPORT=13001 → 13001（既存PORT優先）', () => {
+      expect(calcServerPort(0, '13001')).toBe(13001)
+    })
+
+    it('PANE_NUMBER > 0 の場合、既存PORTは無視される', () => {
+      expect(calcServerPort(3, '13001')).toBe(14003)
+    })
+  })
+
+  describe('クライアントポート', () => {
+    it('PANE_NUMBER=1 → 5181', () => {
+      expect(calcClientPort(1)).toBe(5181)
+    })
+
+    it('PANE_NUMBER=3 → 5183', () => {
+      expect(calcClientPort(3)).toBe(5183)
+    })
+
+    it('PANE_NUMBER=0 → デフォルト5173', () => {
+      expect(calcClientPort(0)).toBe(5173)
+    })
+
+    it('PANE_NUMBER > 0 の場合、既存CLIENT_PORTは無視される', () => {
+      expect(calcClientPort(3, '5173')).toBe(5183)
+    })
+  })
+
+  describe('Playwrightポート', () => {
+    it('PANE_NUMBER=1 → 3551', () => {
+      expect(calcPlaywrightPort(1, 1)).toBe(3551)
+    })
+
+    it('PANE_NUMBER=3 → 3553', () => {
+      expect(calcPlaywrightPort(3, 5)).toBe(3553)
+    })
+
+    it('PANE_NUMBER=0 → 通し番号ベース（3550+counter）', () => {
+      expect(calcPlaywrightPort(0, 1)).toBe(3551)
+      expect(calcPlaywrightPort(0, 2)).toBe(3552)
+    })
+  })
+
+  describe('本番ポートとの衝突なし', () => {
+    const PRODUCTION_SERVER_PORT = 13001
+    const PRODUCTION_CLIENT_PORT = 5173
+
+    it('全ペインのサーバーポートが本番と衝突しない', () => {
+      for (let n = 1; n <= 10; n++) {
+        expect(calcServerPort(n)).not.toBe(PRODUCTION_SERVER_PORT)
+      }
+    })
+
+    it('全ペインのクライアントポートが本番と衝突しない', () => {
+      for (let n = 1; n <= 10; n++) {
+        expect(calcClientPort(n)).not.toBe(PRODUCTION_CLIENT_PORT)
+      }
+    })
+
+    it('ペイン間でポートが衝突しない', () => {
+      const serverPorts = new Set<number>()
+      const clientPorts = new Set<number>()
+      for (let n = 1; n <= 10; n++) {
+        const sp = calcServerPort(n)
+        const cp = calcClientPort(n)
+        expect(serverPorts.has(sp)).toBe(false)
+        expect(clientPorts.has(cp)).toBe(false)
+        serverPorts.add(sp)
+        clientPorts.add(cp)
+      }
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,9 +19,11 @@ import { createFeedbackRouter } from './routes/feedback.js'
 import { createWorkspacesRouter } from './routes/workspaces.js'
 import { CanvasStore } from './services/canvas-store.js'
 
-// ペイン番号からポートを自動算出（PANE_NUMBER未設定時はデフォルト3001を維持）
+// ペイン番号からポートを自動算出（PANE_NUMBERが設定されていれば既存PORTより優先）
 const PANE_NUMBER = parseInt(process.env.PANE_NUMBER || '0', 10)
-const PORT = parseInt(process.env.PORT || String(PANE_NUMBER > 0 ? 14000 + PANE_NUMBER : 3001), 10)
+const PORT = PANE_NUMBER > 0
+  ? 14000 + PANE_NUMBER
+  : parseInt(process.env.PORT || '3001', 10)
 const HOST = process.env.HOST || 'localhost'
 
 // トークン認証（リモートアクセス用、オプション）

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,9 +19,12 @@ import { createFeedbackRouter } from './routes/feedback.js'
 import { createWorkspacesRouter } from './routes/workspaces.js'
 import { CanvasStore } from './services/canvas-store.js'
 
-// ペイン番号からポートを自動算出（PANE_NUMBERが設定されていれば既存PORTより優先）
-const PANE_NUMBER = parseInt(process.env.PANE_NUMBER || '0', 10)
-const PORT = PANE_NUMBER > 0
+// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
+// 設定時は既存PORT環境変数より優先。未設定時のみPORTにフォールバック
+const PANE_NUMBER = process.env.PANE_NUMBER != null
+  ? parseInt(process.env.PANE_NUMBER, 10)
+  : null
+const PORT = PANE_NUMBER != null
   ? 14000 + PANE_NUMBER
   : parseInt(process.env.PORT || '3001', 10)
 const HOST = process.env.HOST || 'localhost'

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -53,8 +53,10 @@ interface PtySession {
 
 const RING_BUFFER_SIZE = 50 * 1024 // 50KB
 
-/** Playwright MCPポートのベース値。セッションごとにインクリメントして割当 */
+/** Playwright MCPポートのベース値。ペイン番号 or セッション通し番号で割当 */
 const PLAYWRIGHT_PORT_BASE = 3550
+/** ペイン番号（環境変数から取得、0=main） */
+const PANE_NUMBER = parseInt(process.env.PANE_NUMBER || '0', 10)
 
 // node-ptyの動的読み込み結果をキャッシュ
 let nodePty: INodePty | null = null
@@ -147,9 +149,12 @@ export class PtyManager extends EventEmitter {
 
     await this.initialize()
 
-    // セッションごとにPlaywright MCPポートを割当
+    // Playwright MCPポートを割当
+    // PANE_NUMBER が設定されている場合はペイン番号ベース、なければ通し番号
     this._portCounter++
-    const playwrightPort = PLAYWRIGHT_PORT_BASE + this._portCounter
+    const playwrightPort = PANE_NUMBER > 0
+      ? PLAYWRIGHT_PORT_BASE + PANE_NUMBER
+      : PLAYWRIGHT_PORT_BASE + this._portCounter
 
     if (this._backend === 'node-pty' && nodePty) {
       try {
@@ -188,6 +193,7 @@ export class PtyManager extends EventEmitter {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
+        ...(PANE_NUMBER > 0 ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
       } as Record<string, string>,
     })
 
@@ -252,6 +258,7 @@ export class PtyManager extends EventEmitter {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
+        ...(PANE_NUMBER > 0 ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
         COLUMNS: String(cols),
         LINES: String(rows),
         PTY_CWD: cwd,

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -55,8 +55,10 @@ const RING_BUFFER_SIZE = 50 * 1024 // 50KB
 
 /** Playwright MCPポートのベース値。ペイン番号 or セッション通し番号で割当 */
 const PLAYWRIGHT_PORT_BASE = 3550
-/** ペイン番号（環境変数から取得、0=main） */
-const PANE_NUMBER = parseInt(process.env.PANE_NUMBER || '0', 10)
+/** ペイン番号（環境変数から取得、0=develop, N=paneN, null=未設定） */
+const PANE_NUMBER = process.env.PANE_NUMBER != null
+  ? parseInt(process.env.PANE_NUMBER, 10)
+  : null
 
 // node-ptyの動的読み込み結果をキャッシュ
 let nodePty: INodePty | null = null
@@ -152,7 +154,7 @@ export class PtyManager extends EventEmitter {
     // Playwright MCPポートを割当
     // PANE_NUMBER が設定されている場合はペイン番号ベース、なければ通し番号
     this._portCounter++
-    const playwrightPort = PANE_NUMBER > 0
+    const playwrightPort = PANE_NUMBER != null
       ? PLAYWRIGHT_PORT_BASE + PANE_NUMBER
       : PLAYWRIGHT_PORT_BASE + this._portCounter
 
@@ -193,7 +195,7 @@ export class PtyManager extends EventEmitter {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
-        ...(PANE_NUMBER > 0 ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
+        ...(PANE_NUMBER != null ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
       } as Record<string, string>,
     })
 
@@ -258,7 +260,7 @@ export class PtyManager extends EventEmitter {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
-        ...(PANE_NUMBER > 0 ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
+        ...(PANE_NUMBER != null ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
         COLUMNS: String(cols),
         LINES: String(rows),
         PTY_CWD: cwd,


### PR DESCRIPTION
## Summary
- `PANE_NUMBER` 環境変数でServer/Client/Playwrightの全ポートを自動算出
- develop(N=0), pane1〜N, 本番(Electron)の帯域を完全分離
- `PANE_NUMBER`設定時は既存PORT等の環境変数より優先

closes #98

## Test plan
- [x] `PANE_NUMBER=0` → Server:14000 で起動確認済み
- [x] `PANE_NUMBER=3` → Server:14003, Client:5183 で起動確認済み
- [x] ポート算出ロジックのユニットテスト19件合格
- [x] サーバー全131テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)