### PR TITLE
ci: mainプッシュ時のElectron Macアプリ自動ビルド+更新通知

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -1,0 +1,61 @@
+name: Electron Mac ビルド
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: 依存関係インストール
+        run: npm ci
+
+      - name: Electronアプリビルド
+        run: npm run build:electron
+
+      - name: バージョン取得
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "バージョン: v${VERSION}-${SHORT_SHA}"
+
+      - name: GitHub Release 作成
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: kurimats ${{ steps.version.outputs.tag }}
+          body: |
+            ## kurimats ${{ steps.version.outputs.tag }}
+
+            mainブランチ `${{ github.sha }}` からの自動ビルドです。
+
+            ### インストール方法
+            1. `kurimats-*-mac-arm64.dmg` をダウンロード
+            2. DMGを開いてアプリをApplicationsにドラッグ
+            3. 初回起動時: `xattr -cr /Applications/kurimats.app` を実行
+
+            ### 注意
+            このビルドはコード署名されていません。macOS Gatekeeperの警告が表示された場合は上記コマンドで解除してください。
+          files: |
+            packages/electron/dist/*.dmg
+            packages/electron/dist/*.zip
+          draft: false
+          prerelease: false

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -22,10 +22,17 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": ["dmg", "zip"],
-      "icon": "resources/icon.icns"
+      "icon": "resources/icon.icns",
+      "artifactName": "kurimats-${version}-mac-${arch}.${ext}"
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "AkiraNagasawa365",
+      "repo": "kurimats-emulator"
     },
     "files": [
-      "dist/**/*",
+      "dist/main.js",
+      "dist/main.js.map",
       "resources/**/*",
       "!node_modules"
     ],

--- a/packages/electron/src/__tests__/update-checker.test.ts
+++ b/packages/electron/src/__tests__/update-checker.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { extractVersion, compareVersions } from '../update-checker'
+
+describe('update-checker', () => {
+  describe('extractVersion', () => {
+    it('タグからバージョンを抽出する', () => {
+      expect(extractVersion('v0.2.0-abc1234')).toBe('0.2.0')
+    })
+
+    it('vプレフィックスのみのタグ', () => {
+      expect(extractVersion('v1.0.0')).toBe('1.0.0')
+    })
+
+    it('プレフィックスなしのタグ', () => {
+      expect(extractVersion('0.3.1')).toBe('0.3.1')
+    })
+
+    it('SHA付きタグ', () => {
+      expect(extractVersion('v0.1.0-a1b2c3d')).toBe('0.1.0')
+    })
+  })
+
+  describe('compareVersions', () => {
+    it('同一バージョンは0を返す', () => {
+      expect(compareVersions('0.1.0', '0.1.0')).toBe(0)
+    })
+
+    it('メジャーバージョンが大きい場合は正を返す', () => {
+      expect(compareVersions('1.0.0', '0.9.9')).toBeGreaterThan(0)
+    })
+
+    it('マイナーバージョンが大きい場合は正を返す', () => {
+      expect(compareVersions('0.2.0', '0.1.0')).toBeGreaterThan(0)
+    })
+
+    it('パッチバージョンが大きい場合は正を返す', () => {
+      expect(compareVersions('0.1.1', '0.1.0')).toBeGreaterThan(0)
+    })
+
+    it('古いバージョンは負を返す', () => {
+      expect(compareVersions('0.1.0', '0.2.0')).toBeLessThan(0)
+    })
+
+    it('桁数が異なる場合も比較できる', () => {
+      expect(compareVersions('1.0', '0.9.9')).toBeGreaterThan(0)
+    })
+  })
+})

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -11,6 +11,7 @@ import Store from 'electron-store'
 import { loadWindowState, saveWindowState, extractWindowState } from './window-state'
 import { buildMenuTemplate } from './menu'
 import { ServerProcessManager, resolveServerDir } from './server-process'
+import { checkForUpdates } from './update-checker'
 
 const APP_NAME = 'kurimats'
 const DEV_CLIENT_URL = 'http://localhost:5173'
@@ -216,6 +217,13 @@ app.whenReady().then(async () => {
 
   // メインウインドウを作成
   createWindow()
+
+  // 更新チェック（本番のみ、バックグラウンドで実行）
+  if (!IS_DEV) {
+    checkForUpdates().catch((err) => {
+      console.error('更新チェックに失敗:', err)
+    })
+  }
 
   // macOS: ドックアイコンクリックでウインドウ再作成
   app.on('activate', () => {

--- a/packages/electron/src/update-checker.ts
+++ b/packages/electron/src/update-checker.ts
@@ -1,0 +1,101 @@
+/**
+ * GitHub Releasesベースの更新チェッカー
+ * 起動時に最新リリースを確認し、新バージョンがあればダイアログで通知する
+ */
+
+import { app, dialog, shell } from 'electron'
+import * as https from 'https'
+
+const GITHUB_OWNER = 'AkiraNagasawa365'
+const GITHUB_REPO = 'kurimats-emulator'
+const RELEASES_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases`
+
+interface GitHubRelease {
+  tag_name: string
+  html_url: string
+  name: string
+  draft: boolean
+  prerelease: boolean
+}
+
+/**
+ * GitHub APIから最新リリースを取得
+ */
+function fetchLatestRelease(): Promise<GitHubRelease | null> {
+  return new Promise((resolve) => {
+    const options = {
+      hostname: 'api.github.com',
+      path: `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`,
+      headers: { 'User-Agent': `kurimats/${app.getVersion()}` },
+    }
+
+    https.get(options, (res) => {
+      if (res.statusCode !== 200) {
+        resolve(null)
+        return
+      }
+
+      let data = ''
+      res.on('data', (chunk: Buffer) => { data += chunk })
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data))
+        } catch {
+          resolve(null)
+        }
+      })
+    }).on('error', () => {
+      resolve(null)
+    })
+  })
+}
+
+/**
+ * タグ名からバージョン部分を抽出（例: "v0.2.0-abc1234" → "0.2.0"）
+ */
+export function extractVersion(tag: string): string {
+  return tag.replace(/^v/, '').replace(/-[a-f0-9]+$/, '')
+}
+
+/**
+ * セマンティックバージョン比較（a > b なら正、a < b なら負）
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0
+    const nb = pb[i] || 0
+    if (na !== nb) return na - nb
+  }
+  return 0
+}
+
+/**
+ * 更新チェックを実行し、新バージョンがあればダイアログ表示
+ */
+export async function checkForUpdates(): Promise<void> {
+  const release = await fetchLatestRelease()
+  if (!release || release.draft || release.prerelease) return
+
+  const currentVersion = app.getVersion()
+  const latestVersion = extractVersion(release.tag_name)
+
+  if (compareVersions(latestVersion, currentVersion) <= 0) return
+
+  console.log(`新バージョン検出: ${currentVersion} → ${latestVersion}`)
+
+  const { response } = await dialog.showMessageBox({
+    type: 'info',
+    title: '新しいバージョンがあります',
+    message: `kurimats ${latestVersion} が利用可能です`,
+    detail: `現在のバージョン: ${currentVersion}\n\nリリースページからダウンロードしてください。`,
+    buttons: ['ダウンロード', '後で'],
+    defaultId: 0,
+    cancelId: 1,
+  })
+
+  if (response === 0) {
+    shell.openExternal(release.html_url || RELEASES_URL)
+  }
+}


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフロー追加: mainプッシュでmacOS上でElectronアプリをビルドし、GitHub Releaseを自動作成（DMG/ZIP）
- アプリ内更新チェック: 起動時にGitHub Releases APIで最新版を検知→ダイアログで通知→リリースページへ遷移
- electron-builderのfiles設定修正: `dist/**/*` → `dist/main.js` に限定し、旧ビルド成果物混入を防止（3.5GB→135MBに削減）

closes #87

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `.github/workflows/build-electron.yml` | mainプッシュ時のCI/CDワークフロー |
| `packages/electron/src/update-checker.ts` | GitHub Releases APIベースの更新チェッカー |
| `packages/electron/src/__tests__/update-checker.test.ts` | バージョン比較ロジックのテスト（10件） |
| `packages/electron/src/main.ts` | update-checker呼び出し追加 |
| `packages/electron/package.json` | publish設定・artifactName・files修正 |

## 動作確認
- [x] ユニットテスト 10件パス
- [x] actionlint YAML構文チェック パス
- [x] フルelectron-builderビルド 成功
- [x] 成果物サイズ確認（DMG 135MB / ZIP 130MB、GitHub Releases 2GB制限内）
- [x] アプリ起動・UI表示 スクショ確認済み
- [x] ヘルスチェックAPI 応答正常

## 注意事項
- コード署名なし（Apple Developer未加入）。ユーザーは初回起動時に `xattr -cr` が必要
- GitHub リポジトリの Settings > Actions > General > Workflow permissions を **Read and write** に変更済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)