### PR TITLE
fix: worktreeセッションのブランチ表示を実ブランチ名に修正

### DIFF
--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -109,10 +109,15 @@ export function createSessionsRouter(
       }
     }
 
+    // worktree作成後は実際のブランチ名を取得（baseBranchは作成元であり実ブランチではない）
+    const actualBranch = worktreePath
+      ? worktreeService.getBranch(worktreePath) ?? params.baseBranch
+      : params.baseBranch
+
     const session = store.create({
       name: params.name,
       repoPath: params.repoPath,
-      baseBranch: params.baseBranch,
+      baseBranch: actualBranch,
       useWorktree: params.useWorktree,
       worktreePath,
       sshHost: params.sshHost || null,

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -47,11 +47,16 @@ async function createSessionWithClaude(
     }
   }
 
+  // worktree作成後は実際のブランチ名を取得（baseBranchは作成元であり実ブランチではない）
+  const actualBranch = worktreePath
+    ? worktreeService.getBranch(worktreePath) ?? params.baseBranch
+    : params.baseBranch
+
   // セッション作成（DB保存）
   const session = store.create({
     name: params.name,
     repoPath: params.repoPath,
-    baseBranch: params.baseBranch,
+    baseBranch: actualBranch,
     worktreePath,
     sshHost: params.sshHost ?? null,
     isRemote,

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -50,6 +50,21 @@ export class WorktreeService {
   }
 
   /**
+   * worktreeの現在のブランチ名を取得
+   */
+  getBranch(worktreePath: string): string | null {
+    try {
+      return execSync('git branch --show-current', {
+        cwd: worktreePath,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      }).trim() || null
+    } catch {
+      return null
+    }
+  }
+
+  /**
    * worktree一覧を取得
    */
   list(repoPath: string): WorktreeInfo[] {


### PR DESCRIPTION
## Summary
- worktree付きセッション作成時、baseBranch（作成元）ではなく実際のworktreeブランチ名を保存するように修正
- `WorktreeService.getBranch()` メソッドを追加し、`sessions.ts` / `workspaces.ts` の両パスで修正
- 複数Claudeセッションがすべて同じブランチ表示になるバグを解消

## Test plan
- [x] ユニットテスト全13件パス
- [x] API経由でworktree付きセッション作成 → `branch=kurimats/{name}` を確認
- [x] UIでブランチ表示（`[kurimats/ai-book-reader-main]`）をスクリーンショットで目視確認

closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)