### PR TITLE
feat: ペイン上部にお気に入り★・コード表示ツールバー追加

### DIFF
--- a/packages/client/src/__tests__/pane-toolbar.test.tsx
+++ b/packages/client/src/__tests__/pane-toolbar.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PaneToolbar } from '../components/panes/PaneToolbar'
+import type { Session } from '@kurimats/shared'
+
+// AnimatedFavoriteButtonモック
+vi.mock('../components/animations/FavoriteAnimations', () => ({
+  AnimatedFavoriteButton: ({ isFavorite, onToggle }: { isFavorite: boolean; onToggle: () => void }) => (
+    <span data-testid="favorite-button" onClick={onToggle}>
+      {isFavorite ? '★' : '☆'}
+    </span>
+  ),
+}))
+
+// モックストア
+const mockToggleFavorite = vi.fn()
+const mockAddSurface = vi.fn()
+
+vi.mock('../stores/session-store', () => ({
+  useSessionStore: (selector: any) => selector({
+    toggleFavorite: mockToggleFavorite,
+  }),
+}))
+
+vi.mock('../stores/pane-store', () => ({
+  usePaneStore: (selector: any) => selector({
+    addSurface: mockAddSurface,
+  }),
+}))
+
+const baseSession: Session = {
+  id: 'session-1',
+  name: 'テストセッション',
+  repoPath: '/test/repo',
+  worktreePath: '/test/worktree',
+  branch: 'feat/test',
+  status: 'active',
+  claudeSessionId: null,
+  isFavorite: false,
+  projectId: null,
+  sshHost: null,
+  isRemote: false,
+  workspaceId: null,
+  createdAt: Date.now(),
+  lastActiveAt: Date.now(),
+}
+
+describe('PaneToolbar', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('セッション名とブランチ名を表示する', () => {
+    render(<PaneToolbar session={baseSession} paneId="pane-1" />)
+    expect(screen.getByText('テストセッション')).toBeTruthy()
+    expect(screen.getByText('[feat/test]')).toBeTruthy()
+  })
+
+  it('ブランチがnullの場合はブランチ表示を省略する', () => {
+    const session = { ...baseSession, branch: null }
+    render(<PaneToolbar session={session} paneId="pane-1" />)
+    expect(screen.getByText('テストセッション')).toBeTruthy()
+    expect(screen.queryByText(/\[/)).toBeNull()
+  })
+
+  it('お気に入りボタンクリックでtoggleFavoriteが呼ばれる', () => {
+    render(<PaneToolbar session={baseSession} paneId="pane-1" />)
+    const favButton = screen.getByTestId('favorite-button')
+    fireEvent.click(favButton)
+    expect(mockToggleFavorite).toHaveBeenCalledWith('session-1')
+  })
+
+  it('activeセッションは緑インジケータを表示する', () => {
+    const { container } = render(<PaneToolbar session={baseSession} paneId="pane-1" />)
+    const indicator = container.querySelector('.bg-green-500')
+    expect(indicator).toBeTruthy()
+  })
+
+  it('非activeセッションはグレーインジケータを表示する', () => {
+    const session = { ...baseSession, status: 'paused' as const }
+    const { container } = render(<PaneToolbar session={session} paneId="pane-1" />)
+    const indicator = container.querySelector('.bg-gray-400')
+    expect(indicator).toBeTruthy()
+  })
+})

--- a/packages/client/src/components/panes/PaneLeafView.tsx
+++ b/packages/client/src/components/panes/PaneLeafView.tsx
@@ -2,7 +2,9 @@ import { useCallback } from 'react'
 import type { PaneLeaf } from '@kurimats/shared'
 import { usePaneStore } from '../../stores/pane-store'
 import { useWorkspaceStore } from '../../stores/workspace-store'
+import { useSessionStore } from '../../stores/session-store'
 import { SurfaceTabs } from './SurfaceTabs'
+import { PaneToolbar } from './PaneToolbar'
 import { TerminalSurface } from '../surfaces/TerminalSurface'
 import { BrowserSurface } from '../surfaces/BrowserSurface'
 import { EditorSurface } from '../surfaces/EditorSurface'
@@ -27,11 +29,17 @@ export function PaneLeafView({ leaf }: PaneLeafViewProps) {
   const isActive = activeWorkspace?.activePaneId === leaf.id
   const hasAttention = attentionRings.get(leaf.id) ?? false
 
+  const sessions = useSessionStore(s => s.sessions)
+
   const handleClick = useCallback(() => {
     if (!isActive) focusPane(leaf.id)
   }, [isActive, leaf.id, focusPane])
 
   const activeSurface = leaf.surfaces[leaf.activeSurfaceIndex]
+
+  // ターミナルサーフェスの場合、対応するセッション情報を取得
+  const sessionId = activeSurface?.type === 'terminal' ? activeSurface.target : null
+  const session = sessionId ? sessions.find(s => s.id === sessionId) : null
 
   // 空のペイン表示
   if (!activeSurface) {
@@ -65,6 +73,11 @@ export function PaneLeafView({ leaf }: PaneLeafViewProps) {
       `}
       onClick={handleClick}
     >
+      {/* ペインツールバー（ターミナルセッション時のみ） */}
+      {session && (
+        <PaneToolbar session={session} paneId={leaf.id} />
+      )}
+
       {/* サーフェスタブバー */}
       <SurfaceTabs
         paneId={leaf.id}

--- a/packages/client/src/components/panes/PaneToolbar.tsx
+++ b/packages/client/src/components/panes/PaneToolbar.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from 'react'
+import type { Session } from '@kurimats/shared'
+import { useSessionStore } from '../../stores/session-store'
+import { usePaneStore } from '../../stores/pane-store'
+import { AnimatedFavoriteButton } from '../animations/FavoriteAnimations'
+
+interface PaneToolbarProps {
+  session: Session
+  paneId: string
+}
+
+/**
+ * ペイン上部のツールバー
+ * セッション名・ブランチ表示 + お気に入り★ + コード表示ボタン
+ */
+export function PaneToolbar({ session, paneId }: PaneToolbarProps) {
+  const toggleFavorite = useSessionStore(s => s.toggleFavorite)
+  const addSurface = usePaneStore(s => s.addSurface)
+
+  const handleToggleFavorite = useCallback(() => {
+    toggleFavorite(session.id)
+  }, [toggleFavorite, session.id])
+
+  const handleOpenCode = useCallback(() => {
+    // セッションのrepoPathをエディタサーフェスとして開く
+    const target = session.worktreePath || session.repoPath
+    addSurface(paneId, {
+      id: `editor-${session.id}-${Date.now()}`,
+      type: 'editor',
+      target,
+      label: session.branch ? `📂 ${session.branch}` : '📂 コード',
+    })
+  }, [addSurface, paneId, session])
+
+  return (
+    <div className="group flex items-center gap-1 bg-surface-1 border-b border-border px-2 h-6 flex-shrink-0">
+      {/* ステータスインジケータ */}
+      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+        session.status === 'active' ? 'bg-green-500' : 'bg-gray-400'
+      }`} />
+
+      {/* セッション名 */}
+      <span className="text-xs text-text-secondary truncate">
+        {session.name}
+      </span>
+
+      {/* ブランチ名 */}
+      {session.branch && (
+        <span className="text-xs text-text-muted truncate">
+          [{session.branch}]
+        </span>
+      )}
+
+      {/* 右寄せボタン群 */}
+      <div className="ml-auto flex items-center gap-1 flex-shrink-0">
+        {/* お気に入りトグル */}
+        <AnimatedFavoriteButton
+          isFavorite={session.isFavorite}
+          onToggle={handleToggleFavorite}
+        />
+
+        {/* コード表示ボタン */}
+        <button
+          onClick={(e) => { e.stopPropagation(); handleOpenCode() }}
+          className="text-xs text-transparent group-hover:text-text-muted hover:!text-accent transition-colors"
+          title="コードを表示"
+        >
+          📂
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  plugins: [react()],
   test: {
-    include: ['packages/*/src/__tests__/**/*.test.ts'],
+    include: ['packages/*/src/__tests__/**/*.test.{ts,tsx}'],
     environment: 'node',
   },
 })


### PR DESCRIPTION
## Summary
- PaneToolbarコンポーネント新規作成: セッション名・ブランチ・ステータス表示 + お気に入り★トグル + 📂コード表示ボタン
- PaneLeafViewに組み込み（ターミナルサーフェスのみ表示）
- vitest設定を.tsx + reactプラグイン対応に更新

closes #98

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `packages/client/src/components/panes/PaneToolbar.tsx` | ツールバーコンポーネント（新規） |
| `packages/client/src/components/panes/PaneLeafView.tsx` | ツールバー組み込み |
| `packages/client/src/__tests__/pane-toolbar.test.tsx` | テスト5件（新規） |
| `vitest.config.ts` | .tsx対応 + reactプラグイン追加 |

## 動作確認
- [x] ユニットテスト 5件パス
- [x] 全テスト 402件パス（既存テストへの影響なし）
- [x] Vite dev(5173)でUI表示確認（スクショ）

## UI仕様
- ツールバーはペイン上部の高さ24pxのバー
- ★ボタン: ホバーで表示、isFavorite時は黄色で常時表示（既存AnimatedFavoriteButton再利用）
- 📂ボタン: ホバーで表示、クリックでエディタサーフェスを追加
- ステータスドット: active=緑、それ以外=グレー

🤖 Generated with [Claude Code](https://claude.com/claude-code)