### PR TITLE
fix: worktreeブランチ表示の完全修正+UIヘッダー追加 closes #105

### DIFF
--- a/packages/client/src/components/panes/PaneLeafView.tsx
+++ b/packages/client/src/components/panes/PaneLeafView.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import type { PaneLeaf } from '@kurimats/shared'
 import { usePaneStore } from '../../stores/pane-store'
 import { useWorkspaceStore } from '../../stores/workspace-store'
+import { useSessionStore } from '../../stores/session-store'
 import { SurfaceTabs } from './SurfaceTabs'
 import { TerminalSurface } from '../surfaces/TerminalSurface'
 import { BrowserSurface } from '../surfaces/BrowserSurface'
@@ -22,6 +23,11 @@ export function PaneLeafView({ leaf }: PaneLeafViewProps) {
   const activeWorkspace = useWorkspaceStore(s => {
     const ws = s.workspaces.find(w => w.id === s.activeWorkspaceId)
     return ws
+  })
+
+  const session = useSessionStore(s => {
+    const termSurface = leaf.surfaces.find(sf => sf.type === 'terminal')
+    return termSurface ? s.sessions.find(sess => sess.id === termSurface.target) : undefined
   })
 
   const isActive = activeWorkspace?.activePaneId === leaf.id
@@ -71,6 +77,23 @@ export function PaneLeafView({ leaf }: PaneLeafViewProps) {
         surfaces={leaf.surfaces}
         activeSurfaceIndex={leaf.activeSurfaceIndex}
       />
+
+      {/* ターミナルヘッダー（セッション名＋ブランチ） */}
+      {session && (
+        <div className={`flex items-center justify-between px-3 py-1 text-xs border-b flex-shrink-0 ${
+          isActive ? 'bg-tile-header border-accent' : 'bg-tile-header border-border'
+        }`}>
+          <div className="flex items-center gap-2 min-w-0">
+            <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
+              session.status === 'active' ? 'bg-green-500' : 'bg-gray-400'
+            }`} />
+            <span className="truncate font-medium text-text-primary">{session.name}</span>
+            {session.branch && (
+              <span className="text-text-muted truncate">[{session.branch}]</span>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* サーフェスコンテンツ */}
       <div className="flex-1 overflow-hidden">

--- a/packages/server/src/__tests__/sessions.test.ts
+++ b/packages/server/src/__tests__/sessions.test.ts
@@ -211,6 +211,61 @@ describeServer('セッションAPI', () => {
     )
   })
 
+  it('worktree付きセッション作成時にbaseBranchではなく実ブランチが保存される', async () => {
+    const worktreeService = new WorktreeService()
+    // worktreeService.create をモックして、getBranchが実ブランチを返すようにする
+    vi.spyOn(worktreeService, 'isGitRepo').mockReturnValue(true)
+    vi.spyOn(worktreeService, 'create').mockReturnValue('/tmp/worktrees/test-session')
+    vi.spyOn(worktreeService, 'getBranch').mockReturnValue('kurimats/test-session')
+
+    // worktreeServiceを差し替えたルーターで再構築
+    const sshManager = new SshManager()
+    const app2 = express()
+    app2.use(express.json())
+    app2.use('/api/sessions', createSessionsRouter(store, ptyManager, sshManager, worktreeService))
+    const server2 = createServer(app2)
+    await new Promise<void>((resolve) => {
+      server2.listen(0, '127.0.0.1', () => resolve())
+    })
+    const addr2 = server2.address()
+    const port2 = typeof addr2 === 'object' && addr2 ? addr2.port : 0
+    const baseUrl2 = `http://127.0.0.1:${port2}`
+
+    try {
+      const res = await fetch(`${baseUrl2}/api/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'test-session', repoPath: '/tmp/repo', baseBranch: 'main', useWorktree: true }),
+      })
+      const session = await res.json()
+      expect(res.status).toBe(201)
+      // baseBranch('main')ではなく、実ブランチ('kurimats/test-session')が保存される
+      expect(session.branch).toBe('kurimats/test-session')
+    } finally {
+      server2.close()
+    }
+  })
+
+  it('再接続時にworktreeのブランチが最新化される', async () => {
+    // baseBranch=nullでセッションを作成（worktreeなし）
+    const createRes = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'branch-update-test', repoPath: '/tmp', useWorktree: false }),
+    })
+    const session = await createRes.json()
+
+    // worktreePathとブランチを手動で設定（既存セッションに古いブランチが入っている状況をシミュレート）
+    store.updateBranch(session.id, 'main')
+    const updated = store.getById(session.id)
+    expect(updated?.branch).toBe('main')
+
+    // updateBranchが正しく動作することを確認
+    store.updateBranch(session.id, 'kurimats/new-branch')
+    const reupdated = store.getById(session.id)
+    expect(reupdated?.branch).toBe('kurimats/new-branch')
+  })
+
   it('セッションを削除できる', async () => {
     // 作成
     const createRes = await fetch(`${baseUrl}/api/sessions`, {

--- a/packages/server/src/__tests__/workspace.test.ts
+++ b/packages/server/src/__tests__/workspace.test.ts
@@ -344,6 +344,49 @@ describe('孤立セッションクリーンアップ', () => {
   })
 })
 
+describe('セッションブランチ更新', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('updateBranchでセッションのブランチを更新できる', () => {
+    const session = store.create({ name: 'branch-test', repoPath: '/tmp', baseBranch: 'main' })
+    expect(session.branch).toBe('main')
+
+    store.updateBranch(session.id, 'kurimats/branch-test')
+    const updated = store.getById(session.id)
+    expect(updated?.branch).toBe('kurimats/branch-test')
+  })
+
+  it('updateBranchでnullを設定できる', () => {
+    const session = store.create({ name: 'null-branch', repoPath: '/tmp', baseBranch: 'develop' })
+    expect(session.branch).toBe('develop')
+
+    store.updateBranch(session.id, null)
+    const updated = store.getById(session.id)
+    expect(updated?.branch).toBeNull()
+  })
+
+  it('baseBranchではなく実ブランチが保存されるべき（セッション作成の意図確認）', () => {
+    // baseBranch='main'で作成した場合、store.create()はそのまま保存する
+    // 呼び出し側がactualBranchを渡す責務を持つ
+    const session = store.create({
+      name: 'actual-branch',
+      repoPath: '/tmp',
+      baseBranch: 'kurimats/actual-branch', // 呼び出し側がactualBranchを渡した場合
+      worktreePath: '/tmp/worktrees/actual-branch',
+    })
+    expect(session.branch).toBe('kurimats/actual-branch')
+    expect(session.worktreePath).toBe('/tmp/worktrees/actual-branch')
+  })
+})
+
 describe('プロジェクトSSH紐付けAPI', () => {
   let store: SessionStore
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -112,6 +112,27 @@ try {
   console.error('⚠️ 孤立セッション削除中にエラー（サーバー起動は続行）:', e)
 }
 
+// サーバー起動時: worktreeセッションのブランチ名を最新化
+try {
+  const allSessionsForBranch = sessionStore.getAll()
+  let branchFixCount = 0
+  for (const s of allSessionsForBranch) {
+    if (s.worktreePath) {
+      const currentBranch = worktreeService.getBranch(s.worktreePath)
+      if (currentBranch && currentBranch !== s.branch) {
+        sessionStore.updateBranch(s.id, currentBranch)
+        console.log(`   🌿 ブランチ修正: "${s.name}" ${s.branch} → ${currentBranch}`)
+        branchFixCount++
+      }
+    }
+  }
+  if (branchFixCount > 0) {
+    console.log(`✅ ${branchFixCount}件のセッションブランチを修正`)
+  }
+} catch (e) {
+  console.error('⚠️ ブランチ修正中にエラー（サーバー起動は続行）:', e)
+}
+
 // Express設定
 const app = express()
 app.use(cors())

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -243,6 +243,16 @@ export function createSessionsRouter(
       }
 
       store.updateStatus(session.id, 'active')
+
+      // worktreeがある場合、現在のブランチ名を最新化
+      if (session.worktreePath) {
+        const currentBranch = worktreeService.getBranch(session.worktreePath)
+        if (currentBranch && currentBranch !== session.branch) {
+          store.updateBranch(session.id, currentBranch)
+          console.log(`🌿 ブランチ更新: ${session.branch} → ${currentBranch}`)
+        }
+      }
+
       console.log(`🔄 セッション "${session.name}" (${session.id.slice(0, 8)}...) を再接続しました`)
       res.json({ ok: true, session: store.getById(session.id) })
     } catch (e) {

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -103,6 +103,14 @@ export class SessionStore {
   }
 
   /**
+   * セッションのブランチ更新
+   */
+  updateBranch(id: string, branch: string | null): void {
+    this.db.prepare('UPDATE sessions SET branch = ?, last_active_at = ? WHERE id = ?')
+      .run(branch, Date.now(), id)
+  }
+
+  /**
    * セッション名変更
    */
   rename(id: string, name: string): void {


### PR DESCRIPTION
## Summary
- `SessionStore.updateBranch()` 追加でブランチの後更新を可能に
- 再接続時にworktreeの実ブランチを `getBranch()` で最新化
- サーバー起動時に既存セッションのブランチを自動修正（過去の壊れたデータも復旧）
- cmuxペインに セッション名+ブランチ名のヘッダーを追加（`PaneLeafView.tsx`）

## Test plan
- [x] 全329テスト通過
- [x] サーバー起動時にブランチ自動修正ログを確認（`null → fix/worktree-branch-display` 等）
- [x] API `/api/sessions` で正しいブランチ値を返却確認
- [x] UIスクリーンショットでブランチ表示確認（worktreeあり/なし両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)