### PR TITLE
fix: CIでelectron-builderにGH_TOKENを渡してビルド失敗を修正

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Electronアプリビルド
         run: npm run build:electron
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: バージョン取得
         id: version


### PR DESCRIPTION
## Summary
- electron-builderのpublish設定がGitHub providerのためGH_TOKENが必要
- CIワークフローのビルドステップに `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` を追加

closes #120

## Test plan
- [ ] develop→mainマージ後、CIでElectronビルド+リリース作成が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)