### PR TITLE
release: CI修正（GH_TOKEN追加）

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Electronアプリビルド
         run: npm run build:electron
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: バージョン取得
         id: version


### PR DESCRIPTION
## Summary
- fix: CIでelectron-builderにGH_TOKENを渡してビルド失敗を修正

closes #120

## Test plan
- [ ] CIでElectronビルド成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)