### PR TITLE
fix: CIワークフローのpathsトリガーにworkflowファイルを追加

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/**'
       - 'package.json'
       - 'package-lock.json'
+      - '.github/workflows/build-electron.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `.github/workflows/build-electron.yml` をpathsトリガーに追加
- ワークフローファイルのみの変更でもCIが起動するようにする

closes #120

## Test plan
- [ ] mainマージ後にCIがトリガーされること
- [ ] Electronビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)