### PR TITLE
fix: Node.jsバンドルでCIビルドの白画面を解消

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: 依存関係インストール

--- a/packages/electron/scripts/bundle-app.mjs
+++ b/packages/electron/scripts/bundle-app.mjs
@@ -121,4 +121,12 @@ sharedPkg.main = './dist/index.js'
 sharedPkg.types = './dist/index.d.ts'
 writeFileSync(sharedPkgPath, JSON.stringify(sharedPkg, null, 2) + '\n')
 
+// Node.jsランタイムをバンドル（ユーザー環境のNodeバージョンに依存しないため）
+const nodeRuntimeDir = resolve(appContent, 'node-runtime')
+mkdirSync(nodeRuntimeDir, { recursive: true })
+cpSync(process.execPath, resolve(nodeRuntimeDir, 'node'))
+chmodSync(resolve(nodeRuntimeDir, 'node'), 0o755)
+writeFileSync(resolve(nodeRuntimeDir, 'NODE_VERSION'), process.version + '\n')
+console.log(`  Node.jsバンドル: ${process.version} (${process.execPath})`)
+
 console.log('バンドル完了: app-content/')

--- a/packages/electron/src/server-process.ts
+++ b/packages/electron/src/server-process.ts
@@ -4,6 +4,7 @@
  */
 
 import { ChildProcess, execSync } from 'child_process'
+import { existsSync } from 'fs'
 import * as path from 'path'
 
 /** サーバープロセスの状態 */
@@ -43,6 +44,20 @@ export class ServerProcessManager {
   }
 
   /**
+   * バンドル済みNode.jsバイナリのパスを解決する
+   * 本番ビルドではapp-content/node-runtime/nodeを使用し、
+   * ユーザー環境のNodeバージョンに依存しない
+   */
+  private resolveBundledNode(): string {
+    const bundledNode = path.join(path.dirname(this.serverDir), 'node-runtime', 'node')
+    if (!existsSync(bundledNode)) {
+      console.warn(`⚠️ バンドル済みNode.jsが見つかりません: ${bundledNode}（システムのnodeにフォールバック）`)
+      return 'node'
+    }
+    return bundledNode
+  }
+
+  /**
    * サーバープロセスを起動する
    * 既に起動中の場合はスキップする
    */
@@ -56,7 +71,7 @@ export class ServerProcessManager {
     console.log(`サーバーを起動中... (ポート: ${port})`)
 
     try {
-      const command = this.isDev ? 'npx' : 'node'
+      const command = this.isDev ? 'npx' : this.resolveBundledNode()
       const args = this.isDev ? ['tsx', 'watch', 'src/index.ts'] : ['index.js']
 
       // 本番時はクライアント静的ファイルのパスを渡す


### PR DESCRIPTION
## Summary
- CIビルドのElectronアプリがNode.jsバージョン不一致で白画面になる問題を修正
- ビルド時にNode.jsバイナリを`app-content/node-runtime/`にバンドル
- 本番サーバーはバンドル済みNodeで起動し、ユーザー環境に非依存に

## 変更内容
- `bundle-app.mjs`: `process.execPath`をnode-runtimeディレクトリにコピー
- `server-process.ts`: `resolveBundledNode()`で本番時にバンドル済みNodeを使用
- CI: Node 20→24に更新

closes #127

## Test plan
- [ ] `npm run build` が成功すること
- [ ] `app-content/node-runtime/node --version` が正しいバージョンを返すこと
- [ ] ビルドされたアプリが白画面にならずUIが表示されること
- [ ] ターミナルセッション・SSH再接続が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)