### PR TITLE
fix: SSH configパーサーがHost *直前のエントリを保存しないバグを修正

### DIFF
--- a/packages/server/src/services/ssh-config.ts
+++ b/packages/server/src/services/ssh-config.ts
@@ -64,14 +64,14 @@ function parseConfigContent(content: string): ParsedHost[] {
     const keyLower = key.toLowerCase()
 
     if (keyLower === 'host') {
+      // 前のホストを保存（ワイルドカード判定の前に行う）
+      if (current?.name) {
+        hosts.push(finalizeHost(current))
+      }
       // ワイルドカードホスト（* を含む）はスキップ
       if (value.includes('*')) {
         current = null
         continue
-      }
-      // 前のホストを保存
-      if (current?.name) {
-        hosts.push(finalizeHost(current))
       }
       current = { name: value.trim() }
     } else if (current) {


### PR DESCRIPTION
## Summary
- `parseSshConfig()` で `Host *` に到達した際、直前のホストエントリを保存せずに `current = null` にしていたバグを修正
- `~/.ssh/config` 末尾付近のホスト（`wellfort-l40s`等）がSSHホスト一覧から欠落し、ワークスペース新規作成が500エラーになっていた

## Test plan
- [x] `npx vitest run packages/server` 全136テスト合格
- [ ] Electronアプリ再ビルド後、`/api/ssh/hosts` に `wellfort-l40s` が含まれることを確認
- [ ] `wellfort-l40s:proj-welfort-ai` のワークスペース新規作成が成功することを確認

closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)