### PR TITLE
release: develop → main マージ（SSH configパーサー修正含む）

### DIFF
--- a/packages/server/src/services/ssh-config.ts
+++ b/packages/server/src/services/ssh-config.ts
@@ -64,14 +64,14 @@ function parseConfigContent(content: string): ParsedHost[] {
     const keyLower = key.toLowerCase()
 
     if (keyLower === 'host') {
+      // 前のホストを保存（ワイルドカード判定の前に行う）
+      if (current?.name) {
+        hosts.push(finalizeHost(current))
+      }
       // ワイルドカードホスト（* を含む）はスキップ
       if (value.includes('*')) {
         current = null
         continue
-      }
-      // 前のホストを保存
-      if (current?.name) {
-        hosts.push(finalizeHost(current))
       }
       current = { name: value.trim() }
     } else if (current) {


### PR DESCRIPTION
## Summary
- fix: SSH configパーサーが`Host *`直前のエントリを保存しないバグを修正 (#133)
- fix: package-lock.jsonをNode 24/npm 11形式に再生成 (#130)
- fix: Node.jsバイナリをバンドルしてCIビルドのABI不一致を解消 (#128)
- その他CI修正・リファクタリング多数

## Test plan
- [x] `npx vitest run packages/server` 全テスト合格
- [ ] CIでElectronビルドが成功すること
- [ ] DMGインストール後、wellfort-l40sのワークスペース作成が成功すること

closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)