### PR TITLE
feat: OSC 133シェル統合によるPTY内部状態の可視化

### DIFF
--- a/packages/client/src/components/terminal/Terminal.tsx
+++ b/packages/client/src/components/terminal/Terminal.tsx
@@ -6,6 +6,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalWs } from '../../hooks/useTerminalWs'
 import { hasValidSize, safeFit, getCellDimensions } from '../../utils/terminal-utils'
+import { useShellStateStore } from '../../stores/shell-state-store'
+import { useSshStore } from '../../stores/ssh-store'
 
 interface Props {
   sessionId: string
@@ -138,6 +140,57 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
 
     return () => disposable.dispose()
   }, [terminal])
+
+  // OSC 133 シェル統合ハンドラー
+  const commandStartTimeRef = useRef<number | null>(null)
+  /** コマンド完了通知の閾値（この秒数以上実行していたコマンドの完了を通知） */
+  const NOTIFY_THRESHOLD_MS = 5000
+
+  useEffect(() => {
+    if (!terminal) return
+
+    const { markCommandStart, markCommandFinish } = useShellStateStore.getState()
+    const { addNotification } = useSshStore.getState()
+
+    // OSC 133 ハンドラー登録
+    // データ形式: "A", "B", "C", "D;exitCode"
+    const disposable = terminal.parser.registerOscHandler(133, (data) => {
+      const marker = data.charAt(0)
+      switch (marker) {
+        case 'C': // コマンド実行開始
+          commandStartTimeRef.current = Date.now()
+          markCommandStart(sessionId)
+          break
+        case 'D': { // コマンド完了
+          const exitCodeStr = data.substring(2) // "D;0" → "0"
+          const exitCode = parseInt(exitCodeStr, 10)
+          const finalExitCode = isNaN(exitCode) ? 0 : exitCode
+          markCommandFinish(sessionId, finalExitCode)
+
+          // 長時間実行コマンドの完了を通知
+          const startTime = commandStartTimeRef.current
+          if (startTime && Date.now() - startTime >= NOTIFY_THRESHOLD_MS) {
+            const status = finalExitCode === 0 ? '成功' : `失敗 (code: ${finalExitCode})`
+            addNotification({
+              id: `cmd-${sessionId}-${Date.now()}`,
+              sessionId,
+              message: `コマンド完了: ${status}`,
+              timestamp: Date.now(),
+              read: false,
+            })
+          }
+          commandStartTimeRef.current = null
+          break
+        }
+        // A（プロンプト開始）, B（入力開始）は将来のPhase 3/4で使用
+      }
+      return false // XTerm.jsのデフォルト処理も継続
+    })
+
+    return () => {
+      disposable.dispose()
+    }
+  }, [terminal, sessionId])
 
   // WebSocket接続
   useTerminalWs(sessionId, terminal)

--- a/packages/client/src/components/terminal/TerminalHeader.tsx
+++ b/packages/client/src/components/terminal/TerminalHeader.tsx
@@ -1,4 +1,5 @@
 import type { Session } from '@kurimats/shared'
+import { useShellStateStore } from '../../stores/shell-state-store'
 
 interface Props {
   session: Session
@@ -8,9 +9,11 @@ interface Props {
 
 /**
  * ターミナルパネルのヘッダー
- * セッション名、ブランチ名、操作ボタンを表示
+ * セッション名、ブランチ名、シェル状態、操作ボタンを表示
  */
 export function TerminalHeader({ session, isActive, onClose }: Props) {
+  const shellState = useShellStateStore((s) => s.getState(session.id))
+
   return (
     <div
       className={`flex items-center justify-between px-3 py-1.5 text-xs border-b transition-colors ${
@@ -32,6 +35,26 @@ export function TerminalHeader({ session, isActive, onClose }: Props) {
         {session.branch && (
           <span className="text-text-muted truncate">
             [{session.branch}]
+          </span>
+        )}
+        {/* シェル実行状態インジケーター */}
+        {shellState.executionState === 'executing' && (
+          <span className="flex items-center gap-1 text-yellow-400 flex-shrink-0" title="コマンド実行中">
+            <span className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
+            <span className="text-[10px]">実行中</span>
+          </span>
+        )}
+        {/* 直前コマンドの終了コード */}
+        {shellState.lastExitCode !== null && shellState.executionState === 'idle' && (
+          <span
+            className={`text-[10px] px-1 py-0.5 rounded flex-shrink-0 ${
+              shellState.lastExitCode === 0
+                ? 'bg-green-900/30 text-green-400'
+                : 'bg-red-900/30 text-red-400'
+            }`}
+            title={`終了コード: ${shellState.lastExitCode}`}
+          >
+            {shellState.lastExitCode === 0 ? '✓' : `✗ ${shellState.lastExitCode}`}
           </span>
         )}
       </div>

--- a/packages/client/src/stores/shell-state-store.ts
+++ b/packages/client/src/stores/shell-state-store.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand'
+import type { ShellState } from '@kurimats/shared'
+
+/** 初期シェル状態 */
+const initialShellState: ShellState = {
+  executionState: 'idle',
+  lastExitCode: null,
+  lastCommandFinishedAt: null,
+}
+
+interface ShellStateStore {
+  /** セッションID → シェル状態 */
+  states: Map<string, ShellState>
+  /** シェル状態を取得（なければ初期状態） */
+  getState: (sessionId: string) => ShellState
+  /** コマンド実行開始（OSC 133;C） */
+  markCommandStart: (sessionId: string) => void
+  /** コマンド完了（OSC 133;D） */
+  markCommandFinish: (sessionId: string, exitCode: number) => void
+  /** セッション削除時のクリーンアップ */
+  removeSession: (sessionId: string) => void
+}
+
+export const useShellStateStore = create<ShellStateStore>((set, get) => ({
+  states: new Map(),
+
+  getState: (sessionId) => {
+    return get().states.get(sessionId) ?? initialShellState
+  },
+
+  markCommandStart: (sessionId) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      const current = next.get(sessionId) ?? { ...initialShellState }
+      next.set(sessionId, { ...current, executionState: 'executing' })
+      return { states: next }
+    })
+  },
+
+  markCommandFinish: (sessionId, exitCode) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      next.set(sessionId, {
+        executionState: 'idle',
+        lastExitCode: exitCode,
+        lastCommandFinishedAt: Date.now(),
+      })
+      return { states: next }
+    })
+  },
+
+  removeSession: (sessionId) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      next.delete(sessionId)
+      return { states: next }
+    })
+  },
+}))

--- a/packages/server/src/__tests__/shell-integration.test.ts
+++ b/packages/server/src/__tests__/shell-integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { PtyManager } from '../services/pty-manager.js'
+
+const __dir = path.dirname(fileURLToPath(import.meta.url))
+const servicesDir = path.join(__dir, '..', 'services')
+
+describe('シェル統合', () => {
+  // ========================================
+  // スクリプトファイルの存在・内容チェック
+  // ========================================
+  describe('スクリプトファイル', () => {
+    it('zsh用スクリプトが存在する', () => {
+      expect(existsSync(path.join(servicesDir, 'shell-integration-zsh.sh'))).toBe(true)
+    })
+
+    it('bash用スクリプトが存在する', () => {
+      expect(existsSync(path.join(servicesDir, 'shell-integration-bash.sh'))).toBe(true)
+    })
+
+    it('zsh用スクリプトがOSC 133マーカーを出力する', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-zsh.sh'), 'utf-8')
+      // A: プロンプト開始
+      expect(content).toContain('133;A')
+      // B: ユーザー入力開始
+      expect(content).toContain('133;B')
+      // C: コマンド実行開始
+      expect(content).toContain('133;C')
+      // D: コマンド完了
+      expect(content).toContain('133;D')
+    })
+
+    it('bash用スクリプトがOSC 133マーカーを出力する', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-bash.sh'), 'utf-8')
+      expect(content).toContain('133;A')
+      expect(content).toContain('133;B')
+      expect(content).toContain('133;C')
+      expect(content).toContain('133;D')
+    })
+
+    it('zsh用スクリプトに二重読み込み防止がある', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-zsh.sh'), 'utf-8')
+      expect(content).toContain('KURIMATS_SHELL_INTEGRATION_LOADED')
+    })
+
+    it('bash用スクリプトに二重読み込み防止がある', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-bash.sh'), 'utf-8')
+      expect(content).toContain('KURIMATS_SHELL_INTEGRATION_LOADED')
+    })
+  })
+
+  // ========================================
+  // PTY起動時のシェル統合注入テスト
+  // ========================================
+  describe('PTY起動時のシェル統合注入', () => {
+    let manager: PtyManager
+
+    beforeEach(() => {
+      manager = new PtyManager()
+      manager._forceBackend('child_process')
+    })
+
+    afterEach(() => {
+      manager.killAll()
+    })
+
+    it('シェル統合環境変数が設定される', async () => {
+      const received: string[] = []
+      manager.on('data', (sessionId: string, data: string) => {
+        if (sessionId === 'si-env') received.push(data)
+      })
+
+      await manager.spawn('si-env', '/tmp', 120, 30, '/bin/sh', ['-c', 'echo SI=$KURIMATS_SHELL_INTEGRATION'])
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      const output = received.join('')
+      expect(output).toContain('SI=1')
+    }, 10000)
+
+    it('zshコマンドでOSC 133マーカーが出力される', async () => {
+      // zshが利用可能かチェック
+      const zshPath = '/bin/zsh'
+      if (!existsSync(zshPath)) return
+
+      const received: string[] = []
+      manager.on('data', (sessionId: string, data: string) => {
+        if (sessionId === 'si-osc') received.push(data)
+      })
+
+      await manager.spawn('si-osc', '/tmp', 120, 30, zshPath)
+      // sourceコマンドの実行を待つ
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      // コマンドを実行してOSCマーカーが発生するか確認
+      manager.write('si-osc', 'echo test\n')
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      const output = received.join('')
+      // OSC 133マーカー（ESC ] 133 ; X BEL）が含まれるか確認
+      // \x1b]133;A\x07 or \x1b]133;C\x07 or \x1b]133;D;0\x07
+      const hasOscMarker = output.includes('\x1b]133;')
+      expect(hasOscMarker).toBe(true)
+    }, 15000)
+  })
+})

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -7,6 +7,10 @@ import { RingBuffer } from './ring-buffer.js'
 const __ptyDir = path.dirname(fileURLToPath(import.meta.url))
 const PTY_HELPER_PATH = path.join(__ptyDir, 'pty-helper.py')
 
+/** シェル統合スクリプトのパス */
+const SHELL_INTEGRATION_ZSH = path.join(__ptyDir, 'shell-integration-zsh.sh')
+const SHELL_INTEGRATION_BASH = path.join(__ptyDir, 'shell-integration-bash.sh')
+
 /** リサイズ用の特殊エスケープシーケンス（pty-helper.pyと同期） */
 const RESIZE_ESC = (cols: number, rows: number) => `\x1b[R;${cols};${rows}\x07`
 
@@ -184,6 +188,7 @@ export class PtyManager extends EventEmitter {
   ): void {
     const cmd = command || process.env.SHELL || '/bin/zsh'
     const cmdArgs = args || []
+    const shellIntegrationScript = this._getShellIntegrationPath(cmd)
     const ptyProcess = nodePty!.spawn(cmd, cmdArgs, {
       name: 'xterm-256color',
       cols,
@@ -195,8 +200,14 @@ export class PtyManager extends EventEmitter {
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
         ...(PANE_NUMBER != null ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
+        KURIMATS_SHELL_INTEGRATION: '1',
       } as Record<string, string>,
     })
+
+    // シェル統合スクリプトをPTY起動直後にsource
+    if (shellIntegrationScript) {
+      ptyProcess.write(`source "${shellIntegrationScript}"\n`)
+    }
 
     const session: PtySession = {
       backend: 'node-pty',
@@ -246,6 +257,7 @@ export class PtyManager extends EventEmitter {
   ): void {
     const cmd = command || process.env.SHELL || '/bin/zsh'
     const cmdArgs = args || []
+    const shellIntegrationScript = this._getShellIntegrationPath(cmd)
 
     // python3のpty-helper.pyで擬似tty割り当て（node-pty利用不可時の代替）
     // pty-helper.pyはリサイズ用の特殊エスケープシーケンスも処理する
@@ -263,8 +275,18 @@ export class PtyManager extends EventEmitter {
         PTY_CWD: cwd,
         PTY_COLS: String(cols),
         PTY_ROWS: String(rows),
+        KURIMATS_SHELL_INTEGRATION: '1',
       },
     })
+
+    // シェル統合スクリプトをPTY起動直後にsource
+    if (shellIntegrationScript) {
+      try {
+        child.stdin?.write(`source "${shellIntegrationScript}"\n`)
+      } catch {
+        // プロセス起動直後のwrite失敗は無視
+      }
+    }
 
     const session: PtySession = {
       backend: 'child_process',
@@ -436,5 +458,20 @@ export class PtyManager extends EventEmitter {
     return Array.from(this.sessions.entries())
       .filter(([, s]) => s.alive)
       .map(([id]) => id)
+  }
+
+  /**
+   * コマンド名からシェル統合スクリプトのパスを返す
+   * 対応シェル以外はnullを返す
+   */
+  private _getShellIntegrationPath(command: string): string | null {
+    const basename = path.basename(command)
+    if (basename === 'zsh' || basename === 'zsh-5.9') {
+      return SHELL_INTEGRATION_ZSH
+    }
+    if (basename === 'bash' || basename.startsWith('bash-')) {
+      return SHELL_INTEGRATION_BASH
+    }
+    return null
   }
 }

--- a/packages/server/src/services/shell-integration-bash.sh
+++ b/packages/server/src/services/shell-integration-bash.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# kurimats-emulator シェル統合スクリプト (bash用)
+# OSC 133 プロトコルでプロンプト/コマンド状態をターミナルに通知する
+
+# 二重読み込み防止
+[[ -n "$KURIMATS_SHELL_INTEGRATION_LOADED" ]] && return
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+
+__kurimats_command_started=""
+
+__kurimats_prompt_command() {
+  local exit_code=$?
+  # D: 前コマンド完了（終了コード付き）
+  if [[ -n "$__kurimats_command_started" ]]; then
+    printf '\e]133;D;%s\a' "$exit_code"
+    __kurimats_command_started=""
+  fi
+  # A: プロンプト開始
+  printf '\e]133;A\a'
+}
+
+__kurimats_preexec() {
+  # DEBUG trapはすべてのコマンドで発火するが、
+  # PROMPT_COMMAND実行中は無視する
+  [[ "$BASH_COMMAND" == "$PROMPT_COMMAND" ]] && return
+  [[ "$BASH_COMMAND" == __kurimats_* ]] && return
+  if [[ -z "$__kurimats_command_started" ]]; then
+    __kurimats_command_started=1
+    # C: コマンド実行開始
+    printf '\e]133;C\a'
+  fi
+}
+
+# PROMPT_COMMANDの先頭に追加（既存を壊さない）
+PROMPT_COMMAND="__kurimats_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+
+# B: ユーザー入力開始（PS1末尾に埋め込み）
+# \[ \] はbashのプロンプトエスケープでゼロ幅として扱われる
+PS1="${PS1}\[\e]133;B\a\]"
+
+# DEBUG trapでpreexecを実装
+trap '__kurimats_preexec' DEBUG

--- a/packages/server/src/services/shell-integration-zsh.sh
+++ b/packages/server/src/services/shell-integration-zsh.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+# kurimats-emulator シェル統合スクリプト (zsh用)
+# OSC 133 プロトコルでプロンプト/コマンド状態をターミナルに通知する
+
+# 二重読み込み防止
+[[ -n "$KURIMATS_SHELL_INTEGRATION_LOADED" ]] && return
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+
+__kurimats_precmd() {
+  local exit_code=$?
+  # D: 前コマンド完了（終了コード付き）
+  # 初回プロンプト表示時はコマンド未実行なのでスキップ
+  if [[ -n "$__kurimats_command_started" ]]; then
+    printf '\e]133;D;%s\a' "$exit_code"
+    unset __kurimats_command_started
+  fi
+  # A: プロンプト開始
+  printf '\e]133;A\a'
+}
+
+__kurimats_preexec() {
+  __kurimats_command_started=1
+  # C: コマンド実行開始
+  printf '\e]133;C\a'
+}
+
+# B: ユーザー入力開始（PROMPT末尾に埋め込み）
+# %{ %} はzshのプロンプトエスケープでゼロ幅として扱われる
+PROMPT="${PROMPT}%{\e]133;B\a%}"
+
+# 既存のhook関数を壊さないようappend
+precmd_functions+=(__kurimats_precmd)
+preexec_functions+=(__kurimats_preexec)

--- a/packages/server/src/services/ssh-manager.ts
+++ b/packages/server/src/services/ssh-manager.ts
@@ -7,6 +7,27 @@ import { RingBuffer } from './ring-buffer.js'
 const RECONNECT_DELAY_MS = 5000
 
 /**
+ * リモートシェルに注入するOSC 133シェル統合スクリプト（インライン版）
+ * リモートにファイルが存在しないため、コマンドとして直接書き込む
+ */
+const SHELL_INTEGRATION_INLINE = `
+if [ -n "$ZSH_VERSION" ]; then
+  __kurimats_precmd() { local e=$?; [ -n "$__kurimats_cs" ] && printf '\\e]133;D;%s\\a' "$e" && unset __kurimats_cs; printf '\\e]133;A\\a'; }
+  __kurimats_preexec() { __kurimats_cs=1; printf '\\e]133;C\\a'; }
+  PROMPT="\${PROMPT}%{\\e]133;B\\a%}"
+  precmd_functions+=(__kurimats_precmd)
+  preexec_functions+=(__kurimats_preexec)
+elif [ -n "$BASH_VERSION" ]; then
+  __kurimats_pc() { local e=$?; [ -n "$__kurimats_cs" ] && printf '\\e]133;D;%s\\a' "$e" && __kurimats_cs=""; printf '\\e]133;A\\a'; }
+  __kurimats_pe() { [[ "$BASH_COMMAND" == "\$PROMPT_COMMAND" || "$BASH_COMMAND" == __kurimats_* ]] && return; [ -z "$__kurimats_cs" ] && __kurimats_cs=1 && printf '\\e]133;C\\a'; }
+  PROMPT_COMMAND="__kurimats_pc\${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+  PS1="\${PS1}\\[\\e]133;B\\a\\]"
+  trap '__kurimats_pe' DEBUG
+fi
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+`.trim()
+
+/**
  * リモートSSHセッション情報
  */
 interface SshSession {
@@ -292,8 +313,8 @@ export class SshManager extends EventEmitter {
             finalized: false,
           }
 
-          // 作業ディレクトリの変更
-          channel.write(`cd ${cwd} && clear\n`)
+          // シェル統合スクリプトを注入 + 作業ディレクトリの変更
+          channel.write(`${SHELL_INTEGRATION_INLINE}\ncd ${cwd} && clear\n`)
 
           const onData = (data: Buffer) => {
             const str = data.toString()

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -335,6 +335,24 @@ export interface CreateStartupTemplateParams {
   envVars?: Record<string, string>
 }
 
+// ========== シェル統合 (OSC 133) ==========
+
+/** シェルの実行状態 */
+export type ShellExecutionState = 'idle' | 'executing'
+
+/**
+ * OSC 133マーカーから得られるシェル状態
+ * ターミナルセッションごとに1つ
+ */
+export interface ShellState {
+  /** シェルの実行状態 */
+  executionState: ShellExecutionState
+  /** 直前コマンドの終了コード（未実行時はnull） */
+  lastExitCode: number | null
+  /** 直前コマンドの終了時刻（通知判定用） */
+  lastCommandFinishedAt: number | null
+}
+
 // ========== 通知 ==========
 
 // Claude通知


### PR DESCRIPTION
## Summary
- PTY/SSHセッションにOSC 133シェル統合を自動注入し、コマンド実行状態をリアルタイム可視化
- zsh/bash対応のシェル統合スクリプト（OSC 133 A/B/C/Dマーカー出力）
- TerminalHeaderに実行中インジケーター・終了コード表示を追加
- 長時間コマンド（5秒以上）の完了通知

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `shared/types.ts` | ShellState型追加 |
| `server/services/shell-integration-zsh.sh` | zsh用OSC 133スクリプト |
| `server/services/shell-integration-bash.sh` | bash用OSC 133スクリプト |
| `server/services/pty-manager.ts` | PTY起動時にスクリプト注入 |
| `server/services/ssh-manager.ts` | SSH接続時にインライン注入 |
| `client/stores/shell-state-store.ts` | ShellState Zustandストア |
| `client/components/terminal/Terminal.tsx` | OSC 133パーサー登録 |
| `client/components/terminal/TerminalHeader.tsx` | 実行中/終了コードUI |

## Test plan
- [x] サーバー全テスト通過（158/158）
- [x] シェル統合専用テスト8件通過
- [ ] ローカルPTY（zsh）でOSCマーカーが発生し、ヘッダーに反映されることを確認
- [ ] SSHセッションでも同様に動作することを確認
- [ ] 長時間コマンド完了時に通知が表示されることを確認

closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)