### PR TITLE
release: develop → main マージ (CI/CD改善・ペインツールバー・worktree修正)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,61 @@ npm run build:electron   # Electron配布ビルド
 - develop起動例: `PANE_NUMBER=0 npm run dev` → Server:14000, Client:5180
 - pane起動例: `PANE_NUMBER=3 npm run dev` → Server:14003, Client:5183, Playwright:3553
 - kurimats-emulator経由の場合: PTY起動時に `PANE_NUMBER` が自動設定される
+
+### デプロイ手順（Electronデスクトップアプリ）
+
+**デプロイ時は必ずこの手順を上から順に実行すること。省略・順序変更禁止。**
+
+1. **develop → main のPRを作成・マージ**
+   ```bash
+   gh pr create --base main --head develop --title "release: ..." --body "..."
+   gh pr merge <PR番号> --merge
+   ```
+
+2. **CIビルド完了を待つ**（`.github/workflows/build-electron.yml` が自動実行）
+   ```bash
+   gh run list --branch main --limit 1        # run ID確認
+   gh run watch <run_id>                       # 完了まで待機（約3分）
+   ```
+
+3. **DMGダウンロード**
+   ```bash
+   gh release list --limit 1                   # タグ確認
+   gh release download <tag> --pattern "*.dmg" --dir /private/tmp
+   ```
+
+4. **稼働中アプリを終了**
+   ```bash
+   osascript -e 'quit app "kurimats"'
+   sleep 3
+   pgrep -f kurimats || echo "終了OK"
+   ```
+
+5. **新バージョンをインストール**
+   ```bash
+   hdiutil attach /private/tmp/kurimats-*.dmg -nobrowse
+   rm -rf /Applications/kurimats.app
+   cp -R "/Volumes/kurimats */kurimats.app" /Applications/
+   xattr -cr /Applications/kurimats.app
+   hdiutil detach "/Volumes/kurimats *"
+   rm /private/tmp/kurimats-*.dmg
+   ```
+
+6. **ローカルビルドを削除**（重要: macOSが古いローカルビルドを優先起動するため）
+   ```bash
+   rm -rf packages/electron/dist/mac-arm64/kurimats.app
+   ```
+
+7. **`/Applications` から起動・パス確認**
+   ```bash
+   open /Applications/kurimats.app
+   sleep 5
+   # 必ず /Applications/ から起動されていることを確認
+   ps aux | grep "[k]urimats" | grep "node index"
+   ```
+
+8. **動作確認**
+   ```bash
+   curl -s http://localhost:13001/api/ssh/hosts | python3 -m json.tool
+   ```
+   Playwrightでワークスペース作成等の基本操作を検証する

--- a/packages/client/src/__tests__/terminal-safe-fit.test.ts
+++ b/packages/client/src/__tests__/terminal-safe-fit.test.ts
@@ -1,45 +1,57 @@
 import { describe, it, expect, vi } from 'vitest'
-import { hasValidSize, safeFit } from '../utils/terminal-utils'
+import { hasValidSize, safeFit, getCellDimensions } from '../utils/terminal-utils'
+
+/** hasValidSizeテスト用のHTMLElementモック */
+function mockElement(clientWidth: number, clientHeight: number, rectWidth?: number, rectHeight?: number): HTMLElement {
+  return {
+    clientWidth,
+    clientHeight,
+    getBoundingClientRect: () => ({
+      width: rectWidth ?? clientWidth,
+      height: rectHeight ?? clientHeight,
+      x: 0, y: 0, top: 0, right: 0, bottom: 0, left: 0,
+      toJSON: () => {},
+    }),
+  } as unknown as HTMLElement
+}
 
 describe('ターミナル safeFit ユーティリティ', () => {
   describe('hasValidSize', () => {
     it('幅と高さが正の値なら true を返す', () => {
-      const el = { clientWidth: 100, clientHeight: 50 } as HTMLElement
-      expect(hasValidSize(el)).toBe(true)
+      expect(hasValidSize(mockElement(100, 50))).toBe(true)
     })
 
     it('幅が0なら false を返す', () => {
-      const el = { clientWidth: 0, clientHeight: 50 } as HTMLElement
-      expect(hasValidSize(el)).toBe(false)
+      expect(hasValidSize(mockElement(0, 50))).toBe(false)
     })
 
     it('高さが0なら false を返す', () => {
-      const el = { clientWidth: 100, clientHeight: 0 } as HTMLElement
-      expect(hasValidSize(el)).toBe(false)
+      expect(hasValidSize(mockElement(100, 0))).toBe(false)
     })
 
     it('幅と高さの両方が0なら false を返す', () => {
-      const el = { clientWidth: 0, clientHeight: 0 } as HTMLElement
-      expect(hasValidSize(el)).toBe(false)
+      expect(hasValidSize(mockElement(0, 0))).toBe(false)
+    })
+
+    it('clientWidthは正だがgetBoundingClientRectが0の場合はfalseを返す', () => {
+      expect(hasValidSize(mockElement(100, 50, 0, 0))).toBe(false)
+    })
+
+    it('getBoundingClientRectの幅だけ0の場合はfalseを返す', () => {
+      expect(hasValidSize(mockElement(100, 50, 0, 50))).toBe(false)
     })
   })
 
   describe('safeFit', () => {
     it('コンテナサイズが有効な場合、fit() を呼ぶ', () => {
       const mockFitAddon = { fit: vi.fn() }
-      const container = { clientWidth: 200, clientHeight: 100 } as HTMLElement
-
-      safeFit(mockFitAddon as any, container)
-
+      safeFit(mockFitAddon as any, mockElement(200, 100))
       expect(mockFitAddon.fit).toHaveBeenCalledOnce()
     })
 
     it('コンテナサイズが0の場合、fit() を呼ばない', () => {
       const mockFitAddon = { fit: vi.fn() }
-      const container = { clientWidth: 0, clientHeight: 0 } as HTMLElement
-
-      safeFit(mockFitAddon as any, container)
-
+      safeFit(mockFitAddon as any, mockElement(0, 0))
       expect(mockFitAddon.fit).not.toHaveBeenCalled()
     })
 
@@ -49,18 +61,42 @@ describe('ターミナル safeFit ユーティリティ', () => {
           throw new Error('dimensions エラー')
         }),
       }
-      const container = { clientWidth: 200, clientHeight: 100 } as HTMLElement
-
-      expect(() => safeFit(mockFitAddon as any, container)).not.toThrow()
+      expect(() => safeFit(mockFitAddon as any, mockElement(200, 100))).not.toThrow()
     })
 
     it('幅だけ0の場合、fit() を呼ばない', () => {
       const mockFitAddon = { fit: vi.fn() }
-      const container = { clientWidth: 0, clientHeight: 100 } as HTMLElement
-
-      safeFit(mockFitAddon as any, container)
-
+      safeFit(mockFitAddon as any, mockElement(0, 100))
       expect(mockFitAddon.fit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getCellDimensions', () => {
+    it('内部APIが存在する場合はセル寸法を返す', () => {
+      const mockTerm = {
+        _core: {
+          _renderService: {
+            dimensions: {
+              css: {
+                cell: { width: 8.5, height: 17 },
+              },
+            },
+          },
+        },
+      }
+      expect(getCellDimensions(mockTerm)).toEqual({ width: 8.5, height: 17 })
+    })
+
+    it('内部APIが存在しない場合はnullを返す', () => {
+      expect(getCellDimensions({})).toBeNull()
+    })
+
+    it('nullを渡してもnullを返す', () => {
+      expect(getCellDimensions(null)).toBeNull()
+    })
+
+    it('_coreが不完全な場合はnullを返す', () => {
+      expect(getCellDimensions({ _core: {} })).toBeNull()
     })
   })
 })

--- a/packages/client/src/components/overlays/CodeViewerOverlay.tsx
+++ b/packages/client/src/components/overlays/CodeViewerOverlay.tsx
@@ -7,6 +7,7 @@ import { OverlayContainer } from './OverlayContainer'
 interface Props {
   filePath: string
   onClose: () => void
+  sshHost?: string | null
 }
 
 // 拡張子から言語を推定
@@ -26,7 +27,7 @@ function getLanguage(path: string): string {
  * コードビューアオーバーレイ
  * ファイル内容をシンタックスハイライト付きで表示
  */
-export function CodeViewerOverlay({ filePath, onClose }: Props) {
+export function CodeViewerOverlay({ filePath, onClose, sshHost }: Props) {
   const [content, setContent] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -37,7 +38,7 @@ export function CodeViewerOverlay({ filePath, onClose }: Props) {
     if (!filePath) return
     setLoading(true)
     setError(null)
-    filesApi.content(filePath)
+    filesApi.content(filePath, sshHost)
       .then(data => {
         setContent(data.content)
         setLoading(false)
@@ -46,7 +47,7 @@ export function CodeViewerOverlay({ filePath, onClose }: Props) {
         setError(String(e))
         setLoading(false)
       })
-  }, [filePath])
+  }, [filePath, sshHost])
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(content).then(() => {

--- a/packages/client/src/components/overlays/FileTreeOverlay.tsx
+++ b/packages/client/src/components/overlays/FileTreeOverlay.tsx
@@ -22,9 +22,11 @@ export function FileTreeOverlay({ onClose }: Props) {
   const [filter, setFilter] = useState('')
   const [workingDir, setWorkingDir] = useState('')
 
-  // アクティブワークスペースのrepoPathを使用
+  // アクティブワークスペースのrepoPath + sshHostを使用
+  const activeWs = workspaces.find(w => w.id === activeWorkspaceId)
+  const sshHost = activeWs?.sshHost ?? null
+
   useEffect(() => {
-    const activeWs = workspaces.find(w => w.id === activeWorkspaceId)
     const root = activeWs?.repoPath || ''
     setWorkingDir(root)
 
@@ -36,7 +38,7 @@ export function FileTreeOverlay({ onClose }: Props) {
 
     setLoading(true)
     setError(null)
-    filesApi.tree(root)
+    filesApi.tree(root, sshHost)
       .then(nodes => {
         setTree(nodes)
         setLoading(false)
@@ -45,17 +47,17 @@ export function FileTreeOverlay({ onClose }: Props) {
         setError(String(e))
         setLoading(false)
       })
-  }, [workspaces, activeWorkspaceId])
+  }, [workspaces, activeWorkspaceId, sshHost])
 
   const handleFileClick = useCallback((path: string) => {
     if (path.endsWith('.md')) {
       // Markdownファイルなら全画面markdownオーバーレイ
-      openOverlay('markdown', { filePath: path, fullScreen: true })
+      openOverlay('markdown', { filePath: path, fullScreen: true, sshHost })
     } else {
       // コードビューアオーバーレイで開く
-      openOverlay('code-viewer', { filePath: path })
+      openOverlay('code-viewer', { filePath: path, sshHost })
     }
-  }, [openOverlay])
+  }, [openOverlay, sshHost])
 
   return (
     <OverlayContainer isOpen={true} onClose={onClose} title="ファイルツリー">

--- a/packages/client/src/components/overlays/MarkdownOverlay.tsx
+++ b/packages/client/src/components/overlays/MarkdownOverlay.tsx
@@ -9,13 +9,14 @@ interface Props {
   onClose: () => void
   filePath?: string
   fullScreen?: boolean
+  sshHost?: string | null
 }
 
 /**
  * Markdownオーバーレイ
- * マークダウンファイルの編集・プレビュー
+ * マークダウンファイルの編集・プレビュー（ローカル/リモート対応）
  */
-export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: Props) {
+export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen, sshHost }: Props) {
   const { workspaces, activeWorkspaceId } = useWorkspaceStore()
   const [filePath, setFilePath] = useState(initialPath || '')
   const [content, setContent] = useState('')
@@ -45,7 +46,7 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: 
     for (const path of candidates) {
       try {
         setLoading(true)
-        const data = await filesApi.content(path)
+        const data = await filesApi.content(path, sshHost)
         setFilePath(path)
         setContent(data.content)
         setLoading(false)
@@ -60,13 +61,13 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: 
     setContent('')
     setLoading(false)
     setError(null)
-  }, [])
+  }, [sshHost])
 
   const loadFile = useCallback((path: string) => {
     if (!path) return
     setLoading(true)
     setError(null)
-    filesApi.content(path)
+    filesApi.content(path, sshHost)
       .then(data => {
         setContent(data.content)
         setLoading(false)
@@ -75,7 +76,7 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: 
         setError(String(e))
         setLoading(false)
       })
-  }, [])
+  }, [sshHost])
 
   // デバウンス付き自動保存
   const handleContentChange = useCallback((newContent: string) => {
@@ -84,11 +85,11 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen }: 
 
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
     saveTimeoutRef.current = setTimeout(() => {
-      filesApi.save(filePath, newContent).catch(e => {
+      filesApi.save(filePath, newContent, sshHost).catch(e => {
         console.error('保存エラー:', e)
       })
     }, 1000)
-  }, [filePath])
+  }, [filePath, sshHost])
 
   // クリーンアップ
   useEffect(() => {

--- a/packages/client/src/components/overlays/OverlayRenderer.tsx
+++ b/packages/client/src/components/overlays/OverlayRenderer.tsx
@@ -25,6 +25,7 @@ export function OverlayRenderer() {
           onClose={closeOverlay}
           filePath={overlayProps.filePath as string | undefined}
           fullScreen={overlayProps.fullScreen as boolean | undefined}
+          sshHost={overlayProps.sshHost as string | null | undefined}
         />
       )
     case 'code-viewer':
@@ -32,6 +33,7 @@ export function OverlayRenderer() {
         <CodeViewerOverlay
           filePath={overlayProps.filePath as string}
           onClose={closeOverlay}
+          sshHost={overlayProps.sshHost as string | null | undefined}
         />
       )
     default:

--- a/packages/client/src/components/panes/PaneLeafView.tsx
+++ b/packages/client/src/components/panes/PaneLeafView.tsx
@@ -87,23 +87,23 @@ export function PaneLeafView({ leaf }: PaneLeafViewProps) {
 
       {/* サーフェスコンテンツ */}
       <div className="flex-1 overflow-hidden">
-        <SurfaceContent surface={activeSurface} paneId={leaf.id} />
+        <SurfaceContent surface={activeSurface} paneId={leaf.id} sshHost={activeWorkspace?.sshHost ?? null} />
       </div>
     </div>
   )
 }
 
 /** サーフェスタイプに応じたコンテンツレンダリング */
-function SurfaceContent({ surface, paneId }: { surface: PaneLeaf['surfaces'][0]; paneId: string }) {
+function SurfaceContent({ surface, paneId, sshHost }: { surface: PaneLeaf['surfaces'][0]; paneId: string; sshHost: string | null }) {
   switch (surface.type) {
     case 'terminal':
       return <TerminalSurface sessionId={surface.target} paneId={paneId} />
     case 'browser':
       return <BrowserSurface url={surface.target} />
     case 'editor':
-      return <EditorSurface filePath={surface.target} />
+      return <EditorSurface filePath={surface.target} sshHost={sshHost} />
     case 'markdown':
-      return <MarkdownSurface filePath={surface.target} />
+      return <MarkdownSurface filePath={surface.target} sshHost={sshHost} />
     default:
       return <div className="p-4 text-text-muted">不明なサーフェスタイプ</div>
   }

--- a/packages/client/src/components/surfaces/EditorSurface.tsx
+++ b/packages/client/src/components/surfaces/EditorSurface.tsx
@@ -3,14 +3,15 @@ import { filesApi } from '../../lib/api'
 
 interface EditorSurfaceProps {
   filePath: string
+  sshHost?: string | null
 }
 
 /**
  * エディタサーフェス
- * ファイルの内容を表示・編集する（Phase 3 ではシンプルなテキストエリア実装）
+ * ファイルの内容を表示・編集する（ローカル/リモート対応）
  * TODO: Monaco Editorに置き換え（#60 統合時）
  */
-export function EditorSurface({ filePath }: EditorSurfaceProps) {
+export function EditorSurface({ filePath, sshHost }: EditorSurfaceProps) {
   const [content, setContent] = useState('')
   const [modified, setModified] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -21,7 +22,7 @@ export function EditorSurface({ filePath }: EditorSurfaceProps) {
   useEffect(() => {
     setLoading(true)
     setError(null)
-    filesApi.content(filePath)
+    filesApi.content(filePath, sshHost)
       .then(({ content }) => {
         setContent(content)
         originalContentRef.current = content
@@ -29,7 +30,7 @@ export function EditorSurface({ filePath }: EditorSurfaceProps) {
       })
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false))
-  }, [filePath])
+  }, [filePath, sshHost])
 
   // ファイル名を取得
   const fileName = filePath.split('/').pop() ?? filePath
@@ -37,13 +38,13 @@ export function EditorSurface({ filePath }: EditorSurfaceProps) {
   // 保存処理
   const handleSave = useCallback(async () => {
     try {
-      await filesApi.save(filePath, content)
+      await filesApi.save(filePath, content, sshHost)
       originalContentRef.current = content
       setModified(false)
     } catch (e) {
       setError(`保存エラー: ${e}`)
     }
-  }, [filePath, content])
+  }, [filePath, content, sshHost])
 
   // Cmd+S でファイル保存
   useEffect(() => {

--- a/packages/client/src/components/surfaces/MarkdownSurface.tsx
+++ b/packages/client/src/components/surfaces/MarkdownSurface.tsx
@@ -5,13 +5,14 @@ import { filesApi } from '../../lib/api'
 
 interface MarkdownSurfaceProps {
   filePath: string
+  sshHost?: string | null
 }
 
 /**
  * Markdownサーフェス
- * ファイルのMarkdownをプレビュー表示する
+ * ファイルのMarkdownをプレビュー表示する（ローカル/リモート対応）
  */
-export function MarkdownSurface({ filePath }: MarkdownSurfaceProps) {
+export function MarkdownSurface({ filePath, sshHost }: MarkdownSurfaceProps) {
   const [content, setContent] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -21,21 +22,21 @@ export function MarkdownSurface({ filePath }: MarkdownSurfaceProps) {
   useEffect(() => {
     setLoading(true)
     setError(null)
-    filesApi.content(filePath)
+    filesApi.content(filePath, sshHost)
       .then(({ content }) => setContent(content))
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false))
-  }, [filePath])
+  }, [filePath, sshHost])
 
   const fileName = filePath.split('/').pop() ?? filePath
 
   const handleSave = useCallback(async () => {
     try {
-      await filesApi.save(filePath, content)
+      await filesApi.save(filePath, content, sshHost)
     } catch (e) {
       setError(`保存エラー: ${e}`)
     }
-  }, [filePath, content])
+  }, [filePath, content, sshHost])
 
   if (loading) {
     return (

--- a/packages/client/src/components/terminal/Terminal.tsx
+++ b/packages/client/src/components/terminal/Terminal.tsx
@@ -6,6 +6,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalWs } from '../../hooks/useTerminalWs'
 import { hasValidSize, safeFit, getCellDimensions } from '../../utils/terminal-utils'
+import { useShellStateStore } from '../../stores/shell-state-store'
+import { useSshStore } from '../../stores/ssh-store'
 
 interface Props {
   sessionId: string
@@ -138,6 +140,57 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
 
     return () => disposable.dispose()
   }, [terminal])
+
+  // OSC 133 シェル統合ハンドラー
+  const commandStartTimeRef = useRef<number | null>(null)
+  /** コマンド完了通知の閾値（この秒数以上実行していたコマンドの完了を通知） */
+  const NOTIFY_THRESHOLD_MS = 5000
+
+  useEffect(() => {
+    if (!terminal) return
+
+    const { markCommandStart, markCommandFinish } = useShellStateStore.getState()
+    const { addNotification } = useSshStore.getState()
+
+    // OSC 133 ハンドラー登録
+    // データ形式: "A", "B", "C", "D;exitCode"
+    const disposable = terminal.parser.registerOscHandler(133, (data) => {
+      const marker = data.charAt(0)
+      switch (marker) {
+        case 'C': // コマンド実行開始
+          commandStartTimeRef.current = Date.now()
+          markCommandStart(sessionId)
+          break
+        case 'D': { // コマンド完了
+          const exitCodeStr = data.substring(2) // "D;0" → "0"
+          const exitCode = parseInt(exitCodeStr, 10)
+          const finalExitCode = isNaN(exitCode) ? 0 : exitCode
+          markCommandFinish(sessionId, finalExitCode)
+
+          // 長時間実行コマンドの完了を通知
+          const startTime = commandStartTimeRef.current
+          if (startTime && Date.now() - startTime >= NOTIFY_THRESHOLD_MS) {
+            const status = finalExitCode === 0 ? '成功' : `失敗 (code: ${finalExitCode})`
+            addNotification({
+              id: `cmd-${sessionId}-${Date.now()}`,
+              sessionId,
+              message: `コマンド完了: ${status}`,
+              timestamp: Date.now(),
+              read: false,
+            })
+          }
+          commandStartTimeRef.current = null
+          break
+        }
+        // A（プロンプト開始）, B（入力開始）は将来のPhase 3/4で使用
+      }
+      return false // XTerm.jsのデフォルト処理も継続
+    })
+
+    return () => {
+      disposable.dispose()
+    }
+  }, [terminal, sessionId])
 
   // WebSocket接続
   useTerminalWs(sessionId, terminal)

--- a/packages/client/src/components/terminal/Terminal.tsx
+++ b/packages/client/src/components/terminal/Terminal.tsx
@@ -5,7 +5,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalWs } from '../../hooks/useTerminalWs'
-import { hasValidSize, safeFit } from '../../utils/terminal-utils'
+import { hasValidSize, safeFit, getCellDimensions } from '../../utils/terminal-utils'
 
 interface Props {
   sessionId: string
@@ -54,7 +54,7 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
         brightWhite: '#ffffff',
       },
       fontSize: 14,
-      fontFamily: "'Cascadia Code', 'Fira Code', 'Menlo', monospace",
+      fontFamily: "'Cascadia Code', 'Fira Code', 'Source Han Code JP', 'Noto Sans Mono CJK JP', 'Menlo', monospace",
       cursorBlink: true,
       allowProposedApi: true,
     })
@@ -70,44 +70,32 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
     term.loadAddon(webLinksAddon)
     fitAddonRef.current = fitAddon
 
-    let initObserver: ResizeObserver | null = null
-
     /**
-     * ターミナルの初期化を実行する
-     * open()はコンテナサイズが0だと内部のrenderServiceが未初期化となり
-     * syncScrollAreaでdimensionsエラーが発生する。
-     * さらにopen()内部でも同期的にsyncScrollAreaが呼ばれるため、
-     * requestAnimationFrameで次フレームに遅延させ、DOMレイアウト確定後に実行する。
+     * IntersectionObserverでコンテナが画面に表示されたことを検出してから初期化
+     * - requestAnimationFrameでは1フレーム遅延が不十分な場合がある
+     * - IntersectionObserverは要素が実際にビューポートに表示された時点で発火するため確実
+     * - 非アクティブタブのターミナルは表示時まで初期化を遅延（リソース削減）
      */
-    const initTerminal = () => {
-      requestAnimationFrame(() => {
-        if (disposed) return
+    const initObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (!entry?.isIntersecting || disposed) return
         if (!hasValidSize(container)) return
+
+        initObserver.disconnect()
         try {
           term.open(container)
-        } catch {
-          // xterm.js内部のdimensionsエラーをキャッチ（初回open時の既知の問題）
+        } catch (e) {
+          console.warn('xterm.js open()エラー:', e)
           return
         }
         safeFit(fitAddon, container)
         setTerminal(term)
-      })
-    }
+      },
+      { threshold: 0.01 },
+    )
 
-    // コンテナサイズが有効ならすぐ初期化、そうでなければサイズ確定を待つ
-    if (hasValidSize(container)) {
-      initTerminal()
-    } else {
-      // サイズが0の場合、ResizeObserverでサイズ確定を検知してから初期化
-      initObserver = new ResizeObserver(() => {
-        if (hasValidSize(container)) {
-          initObserver?.disconnect()
-          initObserver = null
-          initTerminal()
-        }
-      })
-      initObserver.observe(container)
-    }
+    initObserver.observe(container)
 
     // リサイズ監視（サイズが有効な場合のみfit）
     const resizeObserver = new ResizeObserver(() => {
@@ -119,12 +107,37 @@ export function TerminalComponent({ sessionId, isActive, onFocus }: Props) {
 
     return () => {
       disposed = true
-      initObserver?.disconnect()
+      initObserver.disconnect()
       resizeObserver.disconnect()
       term.dispose()
       setTerminal(null)
     }
   }, [])
+
+  // IME変換候補ウィンドウの位置をカーソルに同期
+  useEffect(() => {
+    if (!terminal || !containerRef.current) return
+
+    const container = containerRef.current
+    const disposable = terminal.onCursorMove(() => {
+      const textarea = container.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+      if (!textarea) return
+
+      const cell = getCellDimensions(terminal)
+      if (!cell) return
+
+      const cursorCol = terminal.buffer.active.cursorX
+      const cursorRow = terminal.buffer.active.cursorY - terminal.buffer.active.viewportY
+      textarea.style.left = `${cursorCol * cell.width}px`
+      textarea.style.top = `${cursorRow * cell.height}px`
+      textarea.style.width = `${cell.width}px`
+      textarea.style.height = `${cell.height}px`
+      textarea.style.fontSize = `${terminal.options.fontSize}px`
+      textarea.style.lineHeight = 'normal'
+    })
+
+    return () => disposable.dispose()
+  }, [terminal])
 
   // WebSocket接続
   useTerminalWs(sessionId, terminal)

--- a/packages/client/src/components/terminal/TerminalHeader.tsx
+++ b/packages/client/src/components/terminal/TerminalHeader.tsx
@@ -1,4 +1,5 @@
 import type { Session } from '@kurimats/shared'
+import { useShellStateStore } from '../../stores/shell-state-store'
 
 interface Props {
   session: Session
@@ -8,9 +9,11 @@ interface Props {
 
 /**
  * ターミナルパネルのヘッダー
- * セッション名、ブランチ名、操作ボタンを表示
+ * セッション名、ブランチ名、シェル状態、操作ボタンを表示
  */
 export function TerminalHeader({ session, isActive, onClose }: Props) {
+  const shellState = useShellStateStore((s) => s.getState(session.id))
+
   return (
     <div
       className={`flex items-center justify-between px-3 py-1.5 text-xs border-b transition-colors ${
@@ -32,6 +35,26 @@ export function TerminalHeader({ session, isActive, onClose }: Props) {
         {session.branch && (
           <span className="text-text-muted truncate">
             [{session.branch}]
+          </span>
+        )}
+        {/* シェル実行状態インジケーター */}
+        {shellState.executionState === 'executing' && (
+          <span className="flex items-center gap-1 text-yellow-400 flex-shrink-0" title="コマンド実行中">
+            <span className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
+            <span className="text-[10px]">実行中</span>
+          </span>
+        )}
+        {/* 直前コマンドの終了コード */}
+        {shellState.lastExitCode !== null && shellState.executionState === 'idle' && (
+          <span
+            className={`text-[10px] px-1 py-0.5 rounded flex-shrink-0 ${
+              shellState.lastExitCode === 0
+                ? 'bg-green-900/30 text-green-400'
+                : 'bg-red-900/30 text-red-400'
+            }`}
+            title={`終了コード: ${shellState.lastExitCode}`}
+          >
+            {shellState.lastExitCode === 0 ? '✓' : `✗ ${shellState.lastExitCode}`}
           </span>
         )}
       </div>

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -43,14 +43,22 @@ export const sessionsApi = {
     }),
 }
 
-// ファイルAPI
+// ファイルAPI（sshHostがある場合はリモートSFTP経由）
 export const filesApi = {
-  tree: (root: string) => request<FileNode[]>(`/files/tree?root=${encodeURIComponent(root)}`),
-  content: (path: string) => request<{ content: string; path: string }>(`/files/content?path=${encodeURIComponent(path)}`),
-  save: (path: string, content: string) =>
+  tree: (root: string, sshHost?: string | null) => {
+    const params = new URLSearchParams({ root })
+    if (sshHost) params.set('sshHost', sshHost)
+    return request<FileNode[]>(`/files/tree?${params}`)
+  },
+  content: (path: string, sshHost?: string | null) => {
+    const params = new URLSearchParams({ path })
+    if (sshHost) params.set('sshHost', sshHost)
+    return request<{ content: string; path: string }>(`/files/content?${params}`)
+  },
+  save: (path: string, content: string, sshHost?: string | null) =>
     request<{ ok: boolean }>('/files/content', {
       method: 'PUT',
-      body: JSON.stringify({ path, content }),
+      body: JSON.stringify({ path, content, ...(sshHost ? { sshHost } : {}) }),
     }),
 }
 

--- a/packages/client/src/stores/shell-state-store.ts
+++ b/packages/client/src/stores/shell-state-store.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand'
+import type { ShellState } from '@kurimats/shared'
+
+/** 初期シェル状態 */
+const initialShellState: ShellState = {
+  executionState: 'idle',
+  lastExitCode: null,
+  lastCommandFinishedAt: null,
+}
+
+interface ShellStateStore {
+  /** セッションID → シェル状態 */
+  states: Map<string, ShellState>
+  /** シェル状態を取得（なければ初期状態） */
+  getState: (sessionId: string) => ShellState
+  /** コマンド実行開始（OSC 133;C） */
+  markCommandStart: (sessionId: string) => void
+  /** コマンド完了（OSC 133;D） */
+  markCommandFinish: (sessionId: string, exitCode: number) => void
+  /** セッション削除時のクリーンアップ */
+  removeSession: (sessionId: string) => void
+}
+
+export const useShellStateStore = create<ShellStateStore>((set, get) => ({
+  states: new Map(),
+
+  getState: (sessionId) => {
+    return get().states.get(sessionId) ?? initialShellState
+  },
+
+  markCommandStart: (sessionId) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      const current = next.get(sessionId) ?? { ...initialShellState }
+      next.set(sessionId, { ...current, executionState: 'executing' })
+      return { states: next }
+    })
+  },
+
+  markCommandFinish: (sessionId, exitCode) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      next.set(sessionId, {
+        executionState: 'idle',
+        lastExitCode: exitCode,
+        lastCommandFinishedAt: Date.now(),
+      })
+      return { states: next }
+    })
+  },
+
+  removeSession: (sessionId) => {
+    set((prev) => {
+      const next = new Map(prev.states)
+      next.delete(sessionId)
+      return { states: next }
+    })
+  },
+}))

--- a/packages/client/src/utils/terminal-utils.ts
+++ b/packages/client/src/utils/terminal-utils.ts
@@ -8,7 +8,9 @@
  * xterm.js の fit() はコンテナサイズが0だと dimensions エラーを起こすため
  */
 export function hasValidSize(element: HTMLElement): boolean {
-  return element.clientWidth > 0 && element.clientHeight > 0
+  if (element.clientWidth <= 0 || element.clientHeight <= 0) return false
+  const rect = element.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
 }
 
 /**
@@ -22,4 +24,24 @@ export function safeFit(fitAddon: { fit: () => void }, container: HTMLElement): 
   } catch {
     // ターミナルが未初期化またはdispose済みの場合は無視
   }
+}
+
+/**
+ * xterm.jsの内部APIからセル寸法（CSS px）を取得する
+ * 内部APIのため、取得失敗時はnullを返す
+ */
+export function getCellDimensions(term: unknown): { width: number; height: number } | null {
+  try {
+    const core = (term as Record<string, unknown>)?._core as Record<string, unknown> | undefined
+    const renderService = core?._renderService as Record<string, unknown> | undefined
+    const dimensions = renderService?.dimensions as Record<string, unknown> | undefined
+    const css = dimensions?.css as Record<string, unknown> | undefined
+    const cell = css?.cell as { width: number; height: number } | undefined
+    if (cell && typeof cell.width === 'number' && typeof cell.height === 'number') {
+      return cell
+    }
+  } catch {
+    // 内部API変更時は静かに失敗
+  }
+  return null
 }

--- a/packages/server/src/__tests__/pty-manager.test.ts
+++ b/packages/server/src/__tests__/pty-manager.test.ts
@@ -124,6 +124,18 @@ describe('PtyManager', () => {
       manager.resize('resize-multi', 160, 48)
       expect(manager.getSessionSize('resize-multi')).toEqual({ cols: 160, rows: 48 })
     })
+
+    it('child_processモードの連続リサイズがデバウンスされる', async () => {
+      await manager.spawn('resize-debounce', '/tmp')
+      // 短時間に3回連続リサイズ → cols/rowsは即時更新される
+      manager.resize('resize-debounce', 80, 24)
+      manager.resize('resize-debounce', 100, 30)
+      manager.resize('resize-debounce', 120, 40)
+      // 内部状態は最後のサイズが反映される
+      expect(manager.getSessionSize('resize-debounce')).toEqual({ cols: 120, rows: 40 })
+      // デバウンスの100ms待機後、実際のリサイズ送信が行われる
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    })
   })
 
   // ========================================

--- a/packages/server/src/__tests__/remote-files.test.ts
+++ b/packages/server/src/__tests__/remote-files.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createFilesRouter } from '../routes/files.js'
+import type { SshManager } from '../services/ssh-manager.js'
+import type { FileNode } from '@kurimats/shared'
+
+// SshManagerのモック
+function createMockSshManager(overrides: Partial<Record<string, unknown>> = {}): SshManager {
+  return {
+    listDirectory: vi.fn().mockResolvedValue([
+      { name: 'src', path: '/remote/project/src', isDirectory: true, children: [] },
+      { name: 'README.md', path: '/remote/project/README.md', isDirectory: false },
+    ] as FileNode[]),
+    readFile: vi.fn().mockResolvedValue('# リモートファイルの内容'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as SshManager
+}
+
+// Expressのreq/resモック
+function mockReq(query: Record<string, string> = {}, body: Record<string, unknown> = {}) {
+  return { query, body }
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status: vi.fn().mockImplementation((code: number) => {
+      res.statusCode = code
+      return res
+    }),
+    json: vi.fn().mockImplementation((data: unknown) => {
+      res.body = data
+      return res
+    }),
+  }
+  return res
+}
+
+describe('ファイルAPI（リモートファイル対応）', () => {
+  // ========================================
+  // ルーター作成テスト
+  // ========================================
+  describe('createFilesRouter', () => {
+    it('sshManagerなしでルーターを作成できる', () => {
+      const router = createFilesRouter()
+      expect(router).toBeDefined()
+    })
+
+    it('sshManagerありでルーターを作成できる', () => {
+      const mock = createMockSshManager()
+      const router = createFilesRouter(mock)
+      expect(router).toBeDefined()
+    })
+  })
+
+  // ========================================
+  // SshManager SFTPメソッドのモックテスト
+  // ========================================
+  describe('SshManagerのSFTPメソッド呼び出し', () => {
+    it('listDirectoryが正しい引数で呼ばれる', async () => {
+      const mock = createMockSshManager()
+      const result = await mock.listDirectory('my-server', '/remote/project')
+      expect(mock.listDirectory).toHaveBeenCalledWith('my-server', '/remote/project')
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('src')
+      expect(result[0].isDirectory).toBe(true)
+      expect(result[1].name).toBe('README.md')
+      expect(result[1].isDirectory).toBe(false)
+    })
+
+    it('readFileが正しい引数で呼ばれ、内容を返す', async () => {
+      const mock = createMockSshManager()
+      const content = await mock.readFile('my-server', '/remote/project/README.md')
+      expect(mock.readFile).toHaveBeenCalledWith('my-server', '/remote/project/README.md')
+      expect(content).toBe('# リモートファイルの内容')
+    })
+
+    it('writeFileが正しい引数で呼ばれる', async () => {
+      const mock = createMockSshManager()
+      await mock.writeFile('my-server', '/remote/project/test.txt', '新しい内容')
+      expect(mock.writeFile).toHaveBeenCalledWith('my-server', '/remote/project/test.txt', '新しい内容')
+    })
+
+    it('listDirectoryのエラーが正しく伝播する', async () => {
+      const mock = createMockSshManager({
+        listDirectory: vi.fn().mockRejectedValue(new Error('SSHホスト "dead" に接続されていません')),
+      })
+      await expect(mock.listDirectory('dead', '/remote')).rejects.toThrow('接続されていません')
+    })
+
+    it('readFileのサイズ超過エラーが伝播する', async () => {
+      const mock = createMockSshManager({
+        readFile: vi.fn().mockRejectedValue(new Error('ファイルサイズが上限を超えています (2MB > 1MB)')),
+      })
+      await expect(mock.readFile('my-server', '/remote/big.bin')).rejects.toThrow('サイズが上限')
+    })
+
+    it('writeFileのエラーが伝播する', async () => {
+      const mock = createMockSshManager({
+        writeFile: vi.fn().mockRejectedValue(new Error('リモートファイル書き込みエラー: Permission denied')),
+      })
+      await expect(mock.writeFile('my-server', '/remote/readonly.txt', 'test')).rejects.toThrow('Permission denied')
+    })
+  })
+
+  // ========================================
+  // filesApi URLパラメータ構築テスト
+  // ========================================
+  describe('APIパラメータ構築', () => {
+    it('sshHostなしの場合URLにsshHostパラメータが含まれない', () => {
+      const params = new URLSearchParams({ root: '/local/path' })
+      expect(params.toString()).toBe('root=%2Flocal%2Fpath')
+      expect(params.has('sshHost')).toBe(false)
+    })
+
+    it('sshHostありの場合URLにsshHostパラメータが含まれる', () => {
+      const params = new URLSearchParams({ root: '/remote/path' })
+      params.set('sshHost', 'my-server')
+      expect(params.has('sshHost')).toBe(true)
+      expect(params.get('sshHost')).toBe('my-server')
+    })
+
+    it('PUTリクエストのbodyにsshHostが含まれる', () => {
+      const body = { path: '/remote/test.txt', content: 'hello', sshHost: 'my-server' }
+      expect(body.sshHost).toBe('my-server')
+    })
+
+    it('PUTリクエストのbodyにsshHostがnullの場合省略される', () => {
+      const sshHost: string | null = null
+      const body = { path: '/local/test.txt', content: 'hello', ...(sshHost ? { sshHost } : {}) }
+      expect('sshHost' in body).toBe(false)
+    })
+  })
+})

--- a/packages/server/src/__tests__/ring-buffer.test.ts
+++ b/packages/server/src/__tests__/ring-buffer.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { RingBuffer } from '../services/ring-buffer.js'
+
+describe('RingBuffer', () => {
+  describe('基本動作', () => {
+    it('空バッファはgetContentで空文字を返す', () => {
+      const buf = new RingBuffer()
+      expect(buf.getContent()).toBe('')
+    })
+
+    it('空バッファはgetSafeContentで空文字を返す', () => {
+      const buf = new RingBuffer()
+      expect(buf.getSafeContent()).toBe('')
+    })
+
+    it('appendしたデータがgetContentで取得できる', () => {
+      const buf = new RingBuffer()
+      buf.append('hello')
+      buf.append(' world')
+      expect(buf.getContent()).toBe('hello world')
+    })
+
+    it('clearでバッファがクリアされる', () => {
+      const buf = new RingBuffer()
+      buf.append('data')
+      buf.clear()
+      expect(buf.getContent()).toBe('')
+    })
+  })
+
+  describe('バッファサイズ制限', () => {
+    it('maxSizeを超えるとデータが切り詰められる', () => {
+      const buf = new RingBuffer(10)
+      buf.append('abcdefghijklmnop') // 16文字 > 10
+      const content = buf.getContent()
+      // safeSliceにより先頭にSGRリセットが入る場合がある
+      // 末尾のデータが保持されていることを確認
+      expect(content).toContain('mnop')
+      expect(content.length).toBeLessThanOrEqual(20) // リセット分の余裕
+    })
+
+    it('maxSize以下のデータはそのまま保持される', () => {
+      const buf = new RingBuffer(100)
+      buf.append('short')
+      expect(buf.getContent()).toBe('short')
+    })
+
+    it('コンストラクタにサイズ指定で上限が設定される', () => {
+      const buf = new RingBuffer(5)
+      buf.append('12345678')
+      // 末尾5文字付近が保持される
+      expect(buf.getContent()).toContain('45678')
+    })
+  })
+
+  describe('環境変数からのサイズ設定', () => {
+    const originalEnv = process.env.PTY_BUFFER_SIZE
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.PTY_BUFFER_SIZE
+      } else {
+        process.env.PTY_BUFFER_SIZE = originalEnv
+      }
+    })
+
+    it('PTY_BUFFER_SIZE環境変数が反映される', async () => {
+      process.env.PTY_BUFFER_SIZE = '20'
+      // 動的インポートで環境変数を反映（キャッシュ回避のため新インスタンスで確認）
+      const buf = new RingBuffer()
+      buf.append('a'.repeat(30))
+      const content = buf.getContent()
+      // 環境変数の20バイト + SGRリセット分
+      expect(content.length).toBeLessThanOrEqual(30)
+    })
+  })
+
+  describe('getSafeContent', () => {
+    it('データがある場合は先頭にSGRリセットが挿入される', () => {
+      const buf = new RingBuffer()
+      buf.append('test data')
+      const safe = buf.getSafeContent()
+      expect(safe).toBe('\x1b[0mtest data')
+    })
+
+    it('SGRリセットでANSIエスケープの色化けを防止する', () => {
+      const buf = new RingBuffer()
+      // 赤色の途中で終わるデータ
+      buf.append('\x1b[31m赤色テキスト')
+      const safe = buf.getSafeContent()
+      // 先頭にリセットが入り、色がリセットされる
+      expect(safe.startsWith('\x1b[0m')).toBe(true)
+    })
+  })
+
+  describe('マルチバイト文字の安全性', () => {
+    it('日本語テキストが正しく切り詰められる', () => {
+      const buf = new RingBuffer(20)
+      buf.append('あいうえおかきくけこ') // 各3バイトだが文字列長は10
+      const content = buf.getContent()
+      // 壊れた文字がないことを確認（デコード可能）
+      expect(() => JSON.stringify(content)).not.toThrow()
+    })
+
+    it('絵文字（サロゲートペア）が壊れない', () => {
+      const buf = new RingBuffer(10)
+      const emoji = '😀😁😂🤣😃' // 各2文字分（サロゲートペア）
+      buf.append(emoji)
+      const content = buf.getContent()
+      // サロゲートペアの途中で切れていないことを確認
+      for (let i = 0; i < content.length; i++) {
+        const code = content.charCodeAt(i)
+        // 後半サロゲートが先頭に来ていないこと
+        if (i === 0 || (content.charAt(i - 1) !== '\x1b' && content.charCodeAt(i - 1) < 0xD800)) {
+          expect(code < 0xDC00 || code > 0xDFFF || i > 0).toBe(true)
+        }
+      }
+    })
+  })
+
+  describe('デフォルトサイズ', () => {
+    it('デフォルトで256KBのバッファが確保される', () => {
+      const buf = new RingBuffer()
+      const data = 'x'.repeat(200 * 1024) // 200KB
+      buf.append(data)
+      // 200KB < 256KBなのでそのまま保持
+      expect(buf.getContent()).toBe(data)
+    })
+  })
+})

--- a/packages/server/src/__tests__/shell-integration.test.ts
+++ b/packages/server/src/__tests__/shell-integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { PtyManager } from '../services/pty-manager.js'
+
+const __dir = path.dirname(fileURLToPath(import.meta.url))
+const servicesDir = path.join(__dir, '..', 'services')
+
+describe('シェル統合', () => {
+  // ========================================
+  // スクリプトファイルの存在・内容チェック
+  // ========================================
+  describe('スクリプトファイル', () => {
+    it('zsh用スクリプトが存在する', () => {
+      expect(existsSync(path.join(servicesDir, 'shell-integration-zsh.sh'))).toBe(true)
+    })
+
+    it('bash用スクリプトが存在する', () => {
+      expect(existsSync(path.join(servicesDir, 'shell-integration-bash.sh'))).toBe(true)
+    })
+
+    it('zsh用スクリプトがOSC 133マーカーを出力する', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-zsh.sh'), 'utf-8')
+      // A: プロンプト開始
+      expect(content).toContain('133;A')
+      // B: ユーザー入力開始
+      expect(content).toContain('133;B')
+      // C: コマンド実行開始
+      expect(content).toContain('133;C')
+      // D: コマンド完了
+      expect(content).toContain('133;D')
+    })
+
+    it('bash用スクリプトがOSC 133マーカーを出力する', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-bash.sh'), 'utf-8')
+      expect(content).toContain('133;A')
+      expect(content).toContain('133;B')
+      expect(content).toContain('133;C')
+      expect(content).toContain('133;D')
+    })
+
+    it('zsh用スクリプトに二重読み込み防止がある', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-zsh.sh'), 'utf-8')
+      expect(content).toContain('KURIMATS_SHELL_INTEGRATION_LOADED')
+    })
+
+    it('bash用スクリプトに二重読み込み防止がある', () => {
+      const content = readFileSync(path.join(servicesDir, 'shell-integration-bash.sh'), 'utf-8')
+      expect(content).toContain('KURIMATS_SHELL_INTEGRATION_LOADED')
+    })
+  })
+
+  // ========================================
+  // PTY起動時のシェル統合注入テスト
+  // ========================================
+  describe('PTY起動時のシェル統合注入', () => {
+    let manager: PtyManager
+
+    beforeEach(() => {
+      manager = new PtyManager()
+      manager._forceBackend('child_process')
+    })
+
+    afterEach(() => {
+      manager.killAll()
+    })
+
+    it('シェル統合環境変数が設定される', async () => {
+      const received: string[] = []
+      manager.on('data', (sessionId: string, data: string) => {
+        if (sessionId === 'si-env') received.push(data)
+      })
+
+      await manager.spawn('si-env', '/tmp', 120, 30, '/bin/sh', ['-c', 'echo SI=$KURIMATS_SHELL_INTEGRATION'])
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      const output = received.join('')
+      expect(output).toContain('SI=1')
+    }, 10000)
+
+    it('zshコマンドでOSC 133マーカーが出力される', async () => {
+      // zshが利用可能かチェック
+      const zshPath = '/bin/zsh'
+      if (!existsSync(zshPath)) return
+
+      const received: string[] = []
+      manager.on('data', (sessionId: string, data: string) => {
+        if (sessionId === 'si-osc') received.push(data)
+      })
+
+      await manager.spawn('si-osc', '/tmp', 120, 30, zshPath)
+      // sourceコマンドの実行を待つ
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      // コマンドを実行してOSCマーカーが発生するか確認
+      manager.write('si-osc', 'echo test\n')
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      const output = received.join('')
+      // OSC 133マーカー（ESC ] 133 ; X BEL）が含まれるか確認
+      // \x1b]133;A\x07 or \x1b]133;C\x07 or \x1b]133;D;0\x07
+      const hasOscMarker = output.includes('\x1b]133;')
+      expect(hasOscMarker).toBe(true)
+    }, 15000)
+  })
+})

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { runStartupTasks } from '../startup'
+import type { WorktreeService } from '../services/worktree-service'
+
+/** WorktreeServiceのモック */
+function createMockWorktreeService(): WorktreeService {
+  return {
+    create: vi.fn().mockReturnValue('/tmp/worktree'),
+    remove: vi.fn(),
+    list: vi.fn().mockReturnValue([]),
+    prune: vi.fn(),
+    getBranch: vi.fn().mockReturnValue(null),
+    isGitRepo: vi.fn().mockReturnValue(true),
+    cleanupOrphanedBranches: vi.fn().mockReturnValue([]),
+  } as unknown as WorktreeService
+}
+
+describe('runStartupTasks', () => {
+  let store: SessionStore
+  let worktreeService: ReturnType<typeof createMockWorktreeService>
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    worktreeService = createMockWorktreeService()
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('activeセッションをdisconnectedに変更する', () => {
+    const session = store.create({
+      name: 'test-session',
+      repoPath: '/tmp/repo',
+      isRemote: false,
+      workspaceId: null,
+      projectId: null,
+    })
+    // activeのまま
+
+    runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+    const updated = store.getById(session.id)
+    expect(updated?.status).toBe('disconnected')
+  })
+
+  it('disconnectedセッションのworktreePathをnullに更新する', () => {
+    const session = store.create({
+      name: 'test-session',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/test-session',
+      baseBranch: 'kurimats/test-session',
+      isRemote: false,
+      workspaceId: null,
+      projectId: null,
+    })
+    // disconnectedに設定
+    store.updateStatus(session.id, 'disconnected')
+
+    runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+    const updated = store.getById(session.id)
+    expect(updated?.worktreePath).toBeNull()
+    expect(worktreeService.remove).toHaveBeenCalledWith(
+      '/tmp/repo',
+      '/tmp/repo/.kurimats-worktrees/test-session',
+    )
+  })
+
+  it('ペインツリーに含まれない孤立セッションを削除する', () => {
+    // ワークスペースに紐付いているがペインツリーに含まれないセッション
+    const ws = store.createCmuxWorkspace(
+      { name: 'test-ws', repoPath: '/tmp/repo' },
+      { kind: 'leaf', id: 'pane-a', surfaces: [], activeSurfaceIndex: 0, ratio: 1 },
+    )
+    const orphan = store.create({
+      name: 'orphan-session',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/orphan',
+      isRemote: false,
+      workspaceId: ws.id,
+      projectId: null,
+    })
+
+    runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+    const found = store.getById(orphan.id)
+    expect(found).toBeNull()
+    expect(worktreeService.remove).toHaveBeenCalledWith(
+      '/tmp/repo',
+      '/tmp/repo/.kurimats-worktrees/orphan',
+    )
+  })
+
+  it('worktreeService.remove失敗時もセッション削除は続行する', () => {
+    const ws = store.createCmuxWorkspace(
+      { name: 'test-ws', repoPath: '/tmp/repo' },
+      { kind: 'leaf', id: 'pane-a', surfaces: [], activeSurfaceIndex: 0, ratio: 1 },
+    )
+    const orphan = store.create({
+      name: 'orphan-session',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/orphan',
+      isRemote: false,
+      workspaceId: ws.id,
+      projectId: null,
+    })
+
+    vi.mocked(worktreeService.remove).mockImplementation(() => {
+      throw new Error('worktree not found')
+    })
+
+    // エラーが投げられないことを確認
+    expect(() => runStartupTasks(store, worktreeService as unknown as WorktreeService)).not.toThrow()
+
+    // セッションは削除されている
+    expect(store.getById(orphan.id)).toBeNull()
+  })
+})

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -29,20 +29,21 @@ describe('runStartupTasks', () => {
     store.close()
   })
 
-  it('activeセッションをdisconnectedに変更する', () => {
-    const session = store.create({
-      name: 'test-session',
-      repoPath: '/tmp/repo',
-      isRemote: false,
-      workspaceId: null,
-      projectId: null,
+  describe('ローカルセッション', () => {
+    it('activeセッションをdisconnectedに変更する', () => {
+      const session = store.create({
+        name: 'test-session',
+        repoPath: '/tmp/repo',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('disconnected')
     })
-    // activeのまま
-
-    runStartupTasks(store, worktreeService as unknown as WorktreeService)
-
-    const updated = store.getById(session.id)
-    expect(updated?.status).toBe('disconnected')
   })
 
   it('disconnectedセッションのworktreePathをnullに更新する', () => {
@@ -91,6 +92,154 @@ describe('runStartupTasks', () => {
       '/tmp/repo',
       '/tmp/repo/.kurimats-worktrees/orphan',
     )
+  })
+
+  describe('SSHセッション', () => {
+    it('activeなSSHセッションをdisconnectedに変更する', () => {
+      const session = store.create({
+        name: 'remote-session',
+        repoPath: '/data1/remote-repo',
+        sshHost: 'elith-remote',
+        isRemote: true,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('disconnected')
+      // SSHセッションはworktreeを持たないのでremoveは呼ばれない
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+    })
+
+    it('disconnectedなSSHセッションはworktree操作なしで保持される', () => {
+      const session = store.create({
+        name: 'remote-session',
+        repoPath: '/data1/remote-repo',
+        sshHost: 'elith-remote',
+        isRemote: true,
+        workspaceId: null,
+        projectId: null,
+      })
+      store.updateStatus(session.id, 'disconnected')
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      const updated = store.getById(session.id)
+      // セッション自体は残る
+      expect(updated).not.toBeNull()
+      expect(updated?.status).toBe('disconnected')
+      expect(updated?.worktreePath).toBeNull()
+      // worktreePathがnullなのでremoveは呼ばれない
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+    })
+
+    it('ペインツリーに含まれない孤立SSHセッションを削除する', () => {
+      const ws = store.createCmuxWorkspace(
+        { name: 'ssh-ws', repoPath: '/data1/remote-repo', sshHost: 'elith-remote' },
+        { kind: 'leaf', id: 'pane-a', surfaces: [], activeSurfaceIndex: 0, ratio: 1 },
+      )
+      const orphan = store.create({
+        name: 'orphan-ssh',
+        repoPath: '/data1/remote-repo',
+        sshHost: 'elith-remote',
+        isRemote: true,
+        workspaceId: ws.id,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      expect(store.getById(orphan.id)).toBeNull()
+      // SSHはworktreeを持たないのでremoveは呼ばれない
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ローカル+SSH混在', () => {
+    it('ローカルとSSHが混在するワークスペースで正しくcleanupされる', () => {
+      const ws = store.createCmuxWorkspace(
+        { name: 'mixed-ws', repoPath: '/tmp/repo' },
+        { kind: 'leaf', id: 'pane-a', surfaces: [], activeSurfaceIndex: 0, ratio: 1 },
+      )
+
+      // ローカルセッション（worktreeあり）— 孤立
+      const localOrphan = store.create({
+        name: 'local-orphan',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/local-orphan',
+        isRemote: false,
+        workspaceId: ws.id,
+        projectId: null,
+      })
+
+      // SSHセッション（worktreeなし）— 孤立
+      const sshOrphan = store.create({
+        name: 'ssh-orphan',
+        repoPath: '/data1/remote-repo',
+        sshHost: 'elith-remote',
+        isRemote: true,
+        workspaceId: ws.id,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      // 両方とも削除される
+      expect(store.getById(localOrphan.id)).toBeNull()
+      expect(store.getById(sshOrphan.id)).toBeNull()
+
+      // ローカルのworktreeのみremoveが呼ばれる
+      expect(worktreeService.remove).toHaveBeenCalledTimes(1)
+      expect(worktreeService.remove).toHaveBeenCalledWith(
+        '/tmp/repo',
+        '/tmp/repo/.kurimats-worktrees/local-orphan',
+      )
+    })
+
+    it('disconnected時にローカルのworktreeのみ解放しSSHは影響しない', () => {
+      // ローカルセッション（worktreeあり）
+      const localSession = store.create({
+        name: 'local-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/local-session',
+        baseBranch: 'kurimats/local-session',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+      store.updateStatus(localSession.id, 'disconnected')
+
+      // SSHセッション
+      const sshSession = store.create({
+        name: 'ssh-session',
+        repoPath: '/data1/remote-repo',
+        sshHost: 'elith-remote',
+        isRemote: true,
+        workspaceId: null,
+        projectId: null,
+      })
+      store.updateStatus(sshSession.id, 'disconnected')
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+
+      // ローカル: worktreePathがnullに更新
+      const localUpdated = store.getById(localSession.id)
+      expect(localUpdated?.worktreePath).toBeNull()
+      expect(worktreeService.remove).toHaveBeenCalledWith(
+        '/tmp/repo',
+        '/tmp/repo/.kurimats-worktrees/local-session',
+      )
+
+      // SSH: 変化なし（元からworktreePathがnull）
+      const sshUpdated = store.getById(sshSession.id)
+      expect(sshUpdated).not.toBeNull()
+      expect(sshUpdated?.status).toBe('disconnected')
+
+      // removeは1回のみ（ローカル分）
+      expect(worktreeService.remove).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('worktreeService.remove失敗時もセッション削除は続行する', () => {

--- a/packages/server/src/__tests__/worktree-service.test.ts
+++ b/packages/server/src/__tests__/worktree-service.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { WorktreeService } from '../services/worktree-service'
+
+// execFileSyncをモック
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn().mockReturnValue('.kurimats-worktrees/\n'),
+    appendFileSync: vi.fn(),
+  }
+})
+
+import { execFileSync } from 'child_process'
+import { existsSync } from 'fs'
+
+const mockExecFileSync = vi.mocked(execFileSync)
+const mockExistsSync = vi.mocked(existsSync)
+
+describe('WorktreeService', () => {
+  let service: WorktreeService
+
+  beforeEach(() => {
+    service = new WorktreeService()
+    vi.clearAllMocks()
+  })
+
+  describe('remove()', () => {
+    it('worktree削除後にkurimats/ブランチも削除する', () => {
+      // getBranch のモック（git branch --show-current）
+      mockExecFileSync
+        .mockReturnValueOnce('kurimats/test-pane\n') // getBranch
+        .mockReturnValueOnce('') // git worktree remove
+        .mockReturnValueOnce('') // git branch -D
+
+      service.remove('/repo', '/repo/.kurimats-worktrees/test-pane')
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'git', ['worktree', 'remove', '/repo/.kurimats-worktrees/test-pane', '--force'],
+        expect.objectContaining({ cwd: '/repo' }),
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'git', ['branch', '-D', 'kurimats/test-pane'],
+        expect.objectContaining({ cwd: '/repo' }),
+      )
+    })
+
+    it('kurimats/プレフィックスでないブランチは削除しない', () => {
+      mockExecFileSync
+        .mockReturnValueOnce('main\n') // getBranch → mainブランチ
+        .mockReturnValueOnce('') // git worktree remove
+
+      service.remove('/repo', '/repo/.kurimats-worktrees/test-pane')
+
+      // git branch -D は呼ばれない（worktree removeの1回+getBranchの1回のみ）
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('ブランチ削除失敗は無視する', () => {
+      mockExecFileSync
+        .mockReturnValueOnce('kurimats/test-pane\n') // getBranch
+        .mockReturnValueOnce('') // git worktree remove
+        .mockImplementationOnce(() => { throw new Error('branch not found') }) // git branch -D 失敗
+
+      // エラーが投げられないことを確認
+      expect(() => service.remove('/repo', '/repo/.kurimats-worktrees/test-pane')).not.toThrow()
+    })
+  })
+
+  describe('cleanupOrphanedBranches()', () => {
+    it('worktreeに紐づかないkurimats/ブランチを削除する', () => {
+      // list() のモック（git worktree list --porcelain）
+      mockExecFileSync
+        .mockReturnValueOnce(
+          'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' +
+          'worktree /repo/.kurimats-worktrees/active-pane\nHEAD def456\nbranch refs/heads/kurimats/active-pane\n\n',
+        ) // list
+        .mockReturnValueOnce('  kurimats/active-pane\n  kurimats/orphan1\n  kurimats/orphan2\n') // git branch --list
+        .mockReturnValueOnce('') // git branch -D orphan1
+        .mockReturnValueOnce('') // git branch -D orphan2
+
+      const deleted = service.cleanupOrphanedBranches('/repo')
+
+      expect(deleted).toEqual(['kurimats/orphan1', 'kurimats/orphan2'])
+      expect(mockExecFileSync).not.toHaveBeenCalledWith(
+        'git', ['branch', '-D', 'kurimats/active-pane'],
+        expect.anything(),
+      )
+    })
+
+    it('孤立ブランチがなければ空配列を返す', () => {
+      mockExecFileSync
+        .mockReturnValueOnce('worktree /repo\nHEAD abc\nbranch refs/heads/main\n\n')
+        .mockReturnValueOnce('') // git branch --list → 空
+
+      const deleted = service.cleanupOrphanedBranches('/repo')
+      expect(deleted).toEqual([])
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,7 +78,7 @@ if (AUTH_TOKEN) {
 
 // REST APIルーティング
 app.use('/api/sessions', createSessionsRouter(sessionStore, ptyManager, sshManager, worktreeService))
-app.use('/api/files', createFilesRouter())
+app.use('/api/files', createFilesRouter(sshManager))
 app.use('/api/worktrees', createWorktreesRouter(worktreeService))
 app.use('/api/projects', createProjectsRouter(sessionStore))
 app.use('/api/layout', createLayoutRouter(sessionStore, canvasStore))

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -2,8 +2,13 @@ import { Router } from 'express'
 import { readdir, readFile, writeFile, stat } from 'fs/promises'
 import path from 'path'
 import type { FileNode } from '@kurimats/shared'
+import type { SshManager } from '../services/ssh-manager.js'
 
-export function createFilesRouter(): Router {
+/**
+ * ファイルAPIルーター
+ * sshHostパラメータがある場合はSFTP経由でリモート操作、なければローカルfs
+ */
+export function createFilesRouter(sshManager?: SshManager): Router {
   const router = Router()
 
   // 無視するディレクトリ/ファイル
@@ -13,7 +18,7 @@ export function createFilesRouter(): Router {
   ])
 
   /**
-   * ディレクトリツリーを再帰的に取得（深さ制限あり）
+   * ローカルディレクトリツリーを再帰的に取得（深さ制限あり）
    */
   async function buildTree(dirPath: string, depth = 0, maxDepth = 3): Promise<FileNode[]> {
     if (depth >= maxDepth) return []
@@ -45,56 +50,101 @@ export function createFilesRouter(): Router {
     })
   }
 
+  /**
+   * パスサニタイズ（ディレクトリトラバーサル防止）
+   * basePath外へのアクセスをブロックする
+   */
+  function sanitizeRemotePath(basePath: string, requestedPath: string): string {
+    const resolved = path.posix.resolve(basePath, requestedPath)
+    if (!resolved.startsWith(basePath)) {
+      throw new Error('パストラバーサル検出: ベースディレクトリ外へのアクセスは禁止されています')
+    }
+    return resolved
+  }
+
   // ファイルツリー取得
   router.get('/tree', async (req, res) => {
     const root = req.query.root as string
+    const sshHost = req.query.sshHost as string | undefined
+
     if (!root) {
       res.status(400).json({ error: 'root パラメータが必要です' })
       return
     }
 
     try {
-      const tree = await buildTree(root)
-      res.json(tree)
+      if (sshHost && sshManager) {
+        // リモート: SFTP経由
+        const tree = await sshManager.listDirectory(sshHost, root)
+        res.json(tree)
+      } else {
+        // ローカル: fs
+        const tree = await buildTree(root)
+        res.json(tree)
+      }
     } catch (e) {
-      res.status(500).json({ error: `ツリー取得エラー: ${e}` })
+      const status = sshHost ? 502 : 500
+      res.status(status).json({ error: `ツリー取得エラー: ${e}` })
     }
   })
 
   // ファイル内容取得
   router.get('/content', async (req, res) => {
     const filePath = req.query.path as string
+    const sshHost = req.query.sshHost as string | undefined
+
     if (!filePath) {
       res.status(400).json({ error: 'path パラメータが必要です' })
       return
     }
 
     try {
-      const info = await stat(filePath)
-      if (info.size > 1024 * 1024) {
-        res.status(413).json({ error: 'ファイルサイズが1MBを超えています' })
-        return
+      if (sshHost && sshManager) {
+        // リモート: SFTP経由
+        const content = await sshManager.readFile(sshHost, filePath)
+        res.json({ content, path: filePath })
+      } else {
+        // ローカル: fs
+        const info = await stat(filePath)
+        if (info.size > 1024 * 1024) {
+          res.status(413).json({ error: 'ファイルサイズが1MBを超えています' })
+          return
+        }
+        const content = await readFile(filePath, 'utf-8')
+        res.json({ content, path: filePath })
       }
-      const content = await readFile(filePath, 'utf-8')
-      res.json({ content, path: filePath })
     } catch (e) {
-      res.status(500).json({ error: `ファイル読み込みエラー: ${e}` })
+      const msg = e instanceof Error ? e.message : String(e)
+      const status = msg.includes('サイズが上限') ? 413 : sshHost ? 502 : 500
+      res.status(status).json({ error: `ファイル読み込みエラー: ${msg}` })
     }
   })
 
   // ファイル保存
   router.put('/content', async (req, res) => {
-    const { path: filePath, content } = req.body as { path: string; content: string }
+    const { path: filePath, content, sshHost } = req.body as {
+      path: string
+      content: string
+      sshHost?: string
+    }
     if (!filePath || content === undefined) {
       res.status(400).json({ error: 'path と content が必要です' })
       return
     }
 
     try {
-      await writeFile(filePath, content, 'utf-8')
-      res.json({ ok: true })
+      if (sshHost && sshManager) {
+        // リモート: SFTP経由
+        await sshManager.writeFile(sshHost, filePath, content)
+        res.json({ ok: true })
+      } else {
+        // ローカル: fs
+        await writeFile(filePath, content, 'utf-8')
+        res.json({ ok: true })
+      }
     } catch (e) {
-      res.status(500).json({ error: `ファイル保存エラー: ${e}` })
+      const status = sshHost ? 502 : 500
+      res.status(status).json({ error: `ファイル保存エラー: ${e}` })
     }
   })
 

--- a/packages/server/src/services/pty-helper.py
+++ b/packages/server/src/services/pty-helper.py
@@ -94,8 +94,8 @@ def main():
                             set_pty_size(master_fd, int(c), int(r))
                             # SIGWINCHを子プロセスに送信
                             os.kill(pid, signal.SIGWINCH)
-                        except (ValueError, OSError):
-                            pass
+                        except (ValueError, OSError) as e:
+                            print(f"リサイズ処理エラー: {e}", file=sys.stderr)
                     # 残りのデータをptyに送信
                     if buf and RESIZE_PREFIX not in buf:
                         os.write(master_fd, buf)

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -7,6 +7,10 @@ import { RingBuffer } from './ring-buffer.js'
 const __ptyDir = path.dirname(fileURLToPath(import.meta.url))
 const PTY_HELPER_PATH = path.join(__ptyDir, 'pty-helper.py')
 
+/** シェル統合スクリプトのパス */
+const SHELL_INTEGRATION_ZSH = path.join(__ptyDir, 'shell-integration-zsh.sh')
+const SHELL_INTEGRATION_BASH = path.join(__ptyDir, 'shell-integration-bash.sh')
+
 /** リサイズ用の特殊エスケープシーケンス（pty-helper.pyと同期） */
 const RESIZE_ESC = (cols: number, rows: number) => `\x1b[R;${cols};${rows}\x07`
 
@@ -184,6 +188,7 @@ export class PtyManager extends EventEmitter {
   ): void {
     const cmd = command || process.env.SHELL || '/bin/zsh'
     const cmdArgs = args || []
+    const shellIntegrationScript = this._getShellIntegrationPath(cmd)
     const ptyProcess = nodePty!.spawn(cmd, cmdArgs, {
       name: 'xterm-256color',
       cols,
@@ -195,8 +200,14 @@ export class PtyManager extends EventEmitter {
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
         ...(PANE_NUMBER != null ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
+        KURIMATS_SHELL_INTEGRATION: '1',
       } as Record<string, string>,
     })
+
+    // シェル統合スクリプトをPTY起動直後にsource
+    if (shellIntegrationScript) {
+      ptyProcess.write(`source "${shellIntegrationScript}"\n`)
+    }
 
     const session: PtySession = {
       backend: 'node-pty',
@@ -246,6 +257,7 @@ export class PtyManager extends EventEmitter {
   ): void {
     const cmd = command || process.env.SHELL || '/bin/zsh'
     const cmdArgs = args || []
+    const shellIntegrationScript = this._getShellIntegrationPath(cmd)
 
     // python3のpty-helper.pyで擬似tty割り当て（node-pty利用不可時の代替）
     // pty-helper.pyはリサイズ用の特殊エスケープシーケンスも処理する
@@ -263,8 +275,18 @@ export class PtyManager extends EventEmitter {
         PTY_CWD: cwd,
         PTY_COLS: String(cols),
         PTY_ROWS: String(rows),
+        KURIMATS_SHELL_INTEGRATION: '1',
       },
     })
+
+    // シェル統合スクリプトをPTY起動直後にsource
+    if (shellIntegrationScript) {
+      try {
+        child.stdin?.write(`source "${shellIntegrationScript}"\n`)
+      } catch {
+        // プロセス起動直後のwrite失敗は無視
+      }
+    }
 
     const session: PtySession = {
       backend: 'child_process',
@@ -436,5 +458,20 @@ export class PtyManager extends EventEmitter {
     return Array.from(this.sessions.entries())
       .filter(([, s]) => s.alive)
       .map(([id]) => id)
+  }
+
+  /**
+   * コマンド名からシェル統合スクリプトのパスを返す
+   * 対応シェル以外はnullを返す
+   */
+  private _getShellIntegrationPath(command: string): string | null {
+    const basename = path.basename(command)
+    if (basename === 'zsh' || basename === 'zsh-5.9') {
+      return SHELL_INTEGRATION_ZSH
+    }
+    if (basename === 'bash' || basename.startsWith('bash-')) {
+      return SHELL_INTEGRATION_BASH
+    }
+    return null
   }
 }

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -2,6 +2,7 @@ import { spawn as cpSpawn, type ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { RingBuffer } from './ring-buffer.js'
 
 const __ptyDir = path.dirname(fileURLToPath(import.meta.url))
 const PTY_HELPER_PATH = path.join(__ptyDir, 'pty-helper.py')
@@ -43,17 +44,16 @@ interface PtySession {
   ptyProcess?: IPtyProcess
   childProcess?: ChildProcess
   sessionId: string
-  ringBuffer: string
+  ringBuffer: RingBuffer
   alive: boolean
   cols: number
   rows: number
   cleanup: () => void
   finalized: boolean
+  resizeTimer: ReturnType<typeof setTimeout> | null
 }
 
 import { PLAYWRIGHT_PORT_BASE, calculatePort } from '../utils/ports.js'
-
-const RING_BUFFER_SIZE = 50 * 1024 // 50KB
 /** ペイン番号（環境変数から取得、0=develop, N=paneN, null=未設定） */
 const PANE_NUMBER = process.env.PANE_NUMBER != null
   ? parseInt(process.env.PANE_NUMBER, 10)
@@ -202,19 +202,17 @@ export class PtyManager extends EventEmitter {
       backend: 'node-pty',
       ptyProcess,
       sessionId,
-      ringBuffer: '',
+      ringBuffer: new RingBuffer(),
       alive: true,
       cols,
       rows,
       cleanup: () => {},
       finalized: false,
+      resizeTimer: null,
     }
 
     const dataDisposable = ptyProcess.onData((data: string) => {
-      session.ringBuffer += data
-      if (session.ringBuffer.length > RING_BUFFER_SIZE) {
-        session.ringBuffer = session.ringBuffer.slice(-RING_BUFFER_SIZE)
-      }
+      session.ringBuffer.append(data)
       this.emit('data', sessionId, data)
     })
 
@@ -272,20 +270,18 @@ export class PtyManager extends EventEmitter {
       backend: 'child_process',
       childProcess: child,
       sessionId,
-      ringBuffer: '',
+      ringBuffer: new RingBuffer(),
       alive: true,
       cols,
       rows,
       cleanup: () => {},
       finalized: false,
+      resizeTimer: null,
     }
 
     const handleData = (data: Buffer) => {
       const str = data.toString()
-      session.ringBuffer += str
-      if (session.ringBuffer.length > RING_BUFFER_SIZE) {
-        session.ringBuffer = session.ringBuffer.slice(-RING_BUFFER_SIZE)
-      }
+      session.ringBuffer.append(str)
       this.emit('data', sessionId, str)
     }
 
@@ -350,12 +346,17 @@ export class PtyManager extends EventEmitter {
     if (session.backend === 'node-pty' && session.ptyProcess) {
       session.ptyProcess.resize(cols, rows)
     } else if (session.childProcess) {
-      // child_processモード: pty-helper.pyに特殊エスケープシーケンスでリサイズ通知
-      try {
-        session.childProcess.stdin?.write(RESIZE_ESC(cols, rows))
-      } catch {
-        // プロセス終了済みの場合は無視
-      }
+      // child_processモード: デバウンス付きでpty-helper.pyにリサイズ通知
+      // 連続リサイズ（ウィンドウドラッグ等）時は最後の1回だけ送信
+      if (session.resizeTimer) clearTimeout(session.resizeTimer)
+      session.resizeTimer = setTimeout(() => {
+        session.resizeTimer = null
+        try {
+          session.childProcess?.stdin?.write(RESIZE_ESC(cols, rows))
+        } catch (e) {
+          console.warn(`セッション ${sessionId} のリサイズ送信に失敗:`, e)
+        }
+      }, 100)
     }
   }
 
@@ -363,7 +364,7 @@ export class PtyManager extends EventEmitter {
    * リングバッファの内容を取得（再接続時に使用）
    */
   getBuffer(sessionId: string): string {
-    return this.sessions.get(sessionId)?.ringBuffer ?? ''
+    return this.sessions.get(sessionId)?.ringBuffer.getSafeContent() ?? ''
   }
 
   /**
@@ -395,6 +396,11 @@ export class PtyManager extends EventEmitter {
   kill(sessionId: string): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
+
+    if (session.resizeTimer) {
+      clearTimeout(session.resizeTimer)
+      session.resizeTimer = null
+    }
 
     if (session.alive) {
       session.alive = false

--- a/packages/server/src/services/ring-buffer.ts
+++ b/packages/server/src/services/ring-buffer.ts
@@ -1,0 +1,85 @@
+/**
+ * リングバッファ — PTY/SSH出力のバッファリングと安全な切り出しを提供する
+ * pty-manager / ssh-manager で共通利用
+ */
+
+/** デフォルトバッファサイズ: 256KB */
+const DEFAULT_BUFFER_SIZE = 256 * 1024
+
+/**
+ * 環境変数からバッファサイズを取得（未設定時はデフォルト値）
+ */
+function resolveMaxSize(maxSize?: number): number {
+  if (maxSize != null && maxSize > 0) return maxSize
+  const envVal = parseInt(process.env.PTY_BUFFER_SIZE ?? '', 10)
+  return envVal > 0 ? envVal : DEFAULT_BUFFER_SIZE
+}
+
+/**
+ * マルチバイト文字とANSIエスケープの安全な切り出し
+ * - サロゲートペアの途中切断を防止
+ * - 先頭にSGRリセットを挿入して色化けを防止
+ */
+function safeSlice(buffer: string, maxSize: number): string {
+  if (buffer.length <= maxSize) return buffer
+
+  let sliced = buffer.slice(-maxSize)
+
+  // サロゲートペアの後半（0xDC00〜0xDFFF）で始まる場合は1文字スキップ
+  const firstCode = sliced.charCodeAt(0)
+  if (firstCode >= 0xDC00 && firstCode <= 0xDFFF) {
+    sliced = sliced.slice(1)
+  }
+
+  // 不完全なANSIエスケープシーケンスを先頭から除去
+  // ESC[ で始まるCSIシーケンスの途中で切れている場合をチェック
+  const escIdx = sliced.indexOf('\x1b[')
+  if (escIdx === -1 || escIdx > 0) {
+    // 先頭が ESC の途中（\x1b があるが [ がない）の場合もスキップ
+    if (sliced.charCodeAt(0) === 0x1b) {
+      const nextNewline = sliced.indexOf('\n')
+      if (nextNewline > 0 && nextNewline < 20) {
+        sliced = sliced.slice(nextNewline)
+      }
+    }
+  }
+
+  // SGRリセットを先頭に挿入（途中切断されたスタイルをリセット）
+  return '\x1b[0m' + sliced
+}
+
+/**
+ * セッション出力用リングバッファ
+ */
+export class RingBuffer {
+  private buffer = ''
+  private readonly maxSize: number
+
+  constructor(maxSize?: number) {
+    this.maxSize = resolveMaxSize(maxSize)
+  }
+
+  /** データを追記（上限超過時は自動切り詰め） */
+  append(data: string): void {
+    this.buffer += data
+    if (this.buffer.length > this.maxSize) {
+      this.buffer = safeSlice(this.buffer, this.maxSize)
+    }
+  }
+
+  /** バッファ内容をそのまま取得 */
+  getContent(): string {
+    return this.buffer
+  }
+
+  /** 再接続用: SGRリセット付きで取得 */
+  getSafeContent(): string {
+    if (this.buffer.length === 0) return ''
+    return '\x1b[0m' + this.buffer
+  }
+
+  /** バッファをクリア */
+  clear(): void {
+    this.buffer = ''
+  }
+}

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -128,6 +128,14 @@ export class SessionStore {
   }
 
   /**
+   * セッションのworktreeパス更新
+   */
+  updateWorktreePath(id: string, worktreePath: string | null): void {
+    this.db.prepare('UPDATE sessions SET worktree_path = ?, last_active_at = ? WHERE id = ?')
+      .run(worktreePath, Date.now(), id)
+  }
+
+  /**
    * セッション名変更
    */
   rename(id: string, name: string): void {

--- a/packages/server/src/services/shell-integration-bash.sh
+++ b/packages/server/src/services/shell-integration-bash.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# kurimats-emulator シェル統合スクリプト (bash用)
+# OSC 133 プロトコルでプロンプト/コマンド状態をターミナルに通知する
+
+# 二重読み込み防止
+[[ -n "$KURIMATS_SHELL_INTEGRATION_LOADED" ]] && return
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+
+__kurimats_command_started=""
+
+__kurimats_prompt_command() {
+  local exit_code=$?
+  # D: 前コマンド完了（終了コード付き）
+  if [[ -n "$__kurimats_command_started" ]]; then
+    printf '\e]133;D;%s\a' "$exit_code"
+    __kurimats_command_started=""
+  fi
+  # A: プロンプト開始
+  printf '\e]133;A\a'
+}
+
+__kurimats_preexec() {
+  # DEBUG trapはすべてのコマンドで発火するが、
+  # PROMPT_COMMAND実行中は無視する
+  [[ "$BASH_COMMAND" == "$PROMPT_COMMAND" ]] && return
+  [[ "$BASH_COMMAND" == __kurimats_* ]] && return
+  if [[ -z "$__kurimats_command_started" ]]; then
+    __kurimats_command_started=1
+    # C: コマンド実行開始
+    printf '\e]133;C\a'
+  fi
+}
+
+# PROMPT_COMMANDの先頭に追加（既存を壊さない）
+PROMPT_COMMAND="__kurimats_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+
+# B: ユーザー入力開始（PS1末尾に埋め込み）
+# \[ \] はbashのプロンプトエスケープでゼロ幅として扱われる
+PS1="${PS1}\[\e]133;B\a\]"
+
+# DEBUG trapでpreexecを実装
+trap '__kurimats_preexec' DEBUG

--- a/packages/server/src/services/shell-integration-zsh.sh
+++ b/packages/server/src/services/shell-integration-zsh.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+# kurimats-emulator シェル統合スクリプト (zsh用)
+# OSC 133 プロトコルでプロンプト/コマンド状態をターミナルに通知する
+
+# 二重読み込み防止
+[[ -n "$KURIMATS_SHELL_INTEGRATION_LOADED" ]] && return
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+
+__kurimats_precmd() {
+  local exit_code=$?
+  # D: 前コマンド完了（終了コード付き）
+  # 初回プロンプト表示時はコマンド未実行なのでスキップ
+  if [[ -n "$__kurimats_command_started" ]]; then
+    printf '\e]133;D;%s\a' "$exit_code"
+    unset __kurimats_command_started
+  fi
+  # A: プロンプト開始
+  printf '\e]133;A\a'
+}
+
+__kurimats_preexec() {
+  __kurimats_command_started=1
+  # C: コマンド実行開始
+  printf '\e]133;C\a'
+}
+
+# B: ユーザー入力開始（PROMPT末尾に埋め込み）
+# %{ %} はzshのプロンプトエスケープでゼロ幅として扱われる
+PROMPT="${PROMPT}%{\e]133;B\a%}"
+
+# 既存のhook関数を壊さないようappend
+precmd_functions+=(__kurimats_precmd)
+preexec_functions+=(__kurimats_preexec)

--- a/packages/server/src/services/ssh-manager.ts
+++ b/packages/server/src/services/ssh-manager.ts
@@ -1,9 +1,25 @@
-import { Client, type ClientChannel } from 'ssh2'
+import { Client, type ClientChannel, type SFTPWrapper } from 'ssh2'
 import { readFileSync } from 'fs'
 import { EventEmitter } from 'events'
-import type { SshHost, SshConnectionStatus } from '@kurimats/shared'
+import path from 'path'
+import type { SshHost, SshConnectionStatus, FileNode } from '@kurimats/shared'
 import { parseSshConfig } from './ssh-config.js'
 import { RingBuffer } from './ring-buffer.js'
+
+/** リモートファイル読み込みの上限サイズ（1MB） */
+const MAX_REMOTE_FILE_SIZE = 1 * 1024 * 1024
+
+/** SFTPセッションキャッシュのTTL（30秒） */
+const SFTP_CACHE_TTL_MS = 30_000
+
+/** ファイルツリー探索の最大深度 */
+const MAX_TREE_DEPTH = 3
+
+/** ファイルツリーで無視するディレクトリ名 */
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', '.kurimats-worktrees', '.turbo',
+  'dist', '.next', '__pycache__', '.DS_Store',
+])
 const RECONNECT_DELAY_MS = 5000
 
 /**
@@ -28,6 +44,10 @@ interface SshConnection {
   status: SshConnectionStatus
   reconnectTimer: ReturnType<typeof setTimeout> | null
   connectPromise: Promise<void> | null
+  /** SFTPセッション（キャッシュ） */
+  sftp: SFTPWrapper | null
+  sftpPromise: Promise<SFTPWrapper> | null
+  sftpCreatedAt: number
 }
 
 /**
@@ -118,6 +138,9 @@ export class SshManager extends EventEmitter {
         status: 'reconnecting',
         reconnectTimer: null,
         connectPromise: null,
+        sftp: null,
+        sftpPromise: null,
+        sftpCreatedAt: 0,
       }
 
       this.connections.set(host.name, connInfo)
@@ -409,5 +432,156 @@ export class SshManager extends EventEmitter {
    */
   hasSession(sessionId: string): boolean {
     return this.sessions.has(sessionId)
+  }
+
+  // ========================================
+  // SFTP ファイル操作
+  // ========================================
+
+  /**
+   * SFTPセッションを取得（キャッシュ付き）
+   */
+  private async getSftp(hostName: string): Promise<SFTPWrapper> {
+    const conn = this.connections.get(hostName)
+    if (!conn || conn.status !== 'online') {
+      throw new Error(`SSHホスト "${hostName}" に接続されていません`)
+    }
+
+    // キャッシュが有効ならそのまま返す
+    if (conn.sftp && Date.now() - conn.sftpCreatedAt < SFTP_CACHE_TTL_MS) {
+      return conn.sftp
+    }
+
+    // 既に取得中ならそのPromiseを返す
+    if (conn.sftpPromise) {
+      return conn.sftpPromise
+    }
+
+    // 新規SFTPセッション取得
+    conn.sftpPromise = new Promise<SFTPWrapper>((resolve, reject) => {
+      conn.client.sftp((err, sftp) => {
+        conn.sftpPromise = null
+        if (err) {
+          reject(new Error(`SFTPセッション取得エラー: ${err.message}`))
+          return
+        }
+        conn.sftp = sftp
+        conn.sftpCreatedAt = Date.now()
+
+        // SFTPセッション切断時にキャッシュをクリア
+        sftp.on('close', () => {
+          if (conn.sftp === sftp) {
+            conn.sftp = null
+          }
+        })
+
+        resolve(sftp)
+      })
+    })
+
+    return conn.sftpPromise
+  }
+
+  /**
+   * リモートディレクトリのファイルツリーを取得（再帰・遅延読み込み）
+   */
+  async listDirectory(hostName: string, dirPath: string, depth = 0): Promise<FileNode[]> {
+    if (depth >= MAX_TREE_DEPTH) return []
+
+    const sftp = await this.getSftp(hostName)
+
+    return new Promise<FileNode[]>((resolve, reject) => {
+      sftp.readdir(dirPath, async (err, list) => {
+        if (err) {
+          reject(new Error(`リモートディレクトリ読み取りエラー (${dirPath}): ${err.message}`))
+          return
+        }
+
+        const nodes: FileNode[] = []
+        for (const entry of list) {
+          if (IGNORE_DIRS.has(entry.filename)) continue
+          // ドットファイルはスキップ（.gitignore等）
+          if (entry.filename.startsWith('.')) continue
+
+          const fullPath = path.posix.join(dirPath, entry.filename)
+          // attrs.mode のディレクトリビット判定
+          const isDir = !!(entry.attrs.mode & 0o40000)
+
+          const node: FileNode = {
+            name: entry.filename,
+            path: fullPath,
+            isDirectory: isDir,
+          }
+
+          if (isDir) {
+            try {
+              node.children = await this.listDirectory(hostName, fullPath, depth + 1)
+            } catch {
+              // サブディレクトリの読み取り失敗は空配列で継続
+              node.children = []
+            }
+          }
+
+          nodes.push(node)
+        }
+
+        // ディレクトリ優先、名前順でソート
+        nodes.sort((a, b) => {
+          if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+          return a.name.localeCompare(b.name)
+        })
+
+        resolve(nodes)
+      })
+    })
+  }
+
+  /**
+   * リモートファイルの内容を読み取り
+   */
+  async readFile(hostName: string, filePath: string): Promise<string> {
+    const sftp = await this.getSftp(hostName)
+
+    // ファイルサイズチェック
+    const stats = await new Promise<{ size: number }>((resolve, reject) => {
+      sftp.stat(filePath, (err, attrs) => {
+        if (err) {
+          reject(new Error(`リモートファイルstat失敗 (${filePath}): ${err.message}`))
+          return
+        }
+        resolve({ size: attrs.size })
+      })
+    })
+
+    if (stats.size > MAX_REMOTE_FILE_SIZE) {
+      throw new Error(`ファイルサイズが上限を超えています (${stats.size} bytes > ${MAX_REMOTE_FILE_SIZE} bytes)`)
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      sftp.readFile(filePath, (err, data) => {
+        if (err) {
+          reject(new Error(`リモートファイル読み取りエラー (${filePath}): ${err.message}`))
+          return
+        }
+        resolve(data.toString('utf-8'))
+      })
+    })
+  }
+
+  /**
+   * リモートファイルにデータを書き込み
+   */
+  async writeFile(hostName: string, filePath: string, content: string): Promise<void> {
+    const sftp = await this.getSftp(hostName)
+
+    return new Promise<void>((resolve, reject) => {
+      sftp.writeFile(filePath, content, 'utf-8', (err) => {
+        if (err) {
+          reject(new Error(`リモートファイル書き込みエラー (${filePath}): ${err.message}`))
+          return
+        }
+        resolve()
+      })
+    })
   }
 }

--- a/packages/server/src/services/ssh-manager.ts
+++ b/packages/server/src/services/ssh-manager.ts
@@ -7,6 +7,27 @@ import { RingBuffer } from './ring-buffer.js'
 const RECONNECT_DELAY_MS = 5000
 
 /**
+ * リモートシェルに注入するOSC 133シェル統合スクリプト（インライン版）
+ * リモートにファイルが存在しないため、コマンドとして直接書き込む
+ */
+const SHELL_INTEGRATION_INLINE = `
+if [ -n "$ZSH_VERSION" ]; then
+  __kurimats_precmd() { local e=$?; [ -n "$__kurimats_cs" ] && printf '\\e]133;D;%s\\a' "$e" && unset __kurimats_cs; printf '\\e]133;A\\a'; }
+  __kurimats_preexec() { __kurimats_cs=1; printf '\\e]133;C\\a'; }
+  PROMPT="\${PROMPT}%{\\e]133;B\\a%}"
+  precmd_functions+=(__kurimats_precmd)
+  preexec_functions+=(__kurimats_preexec)
+elif [ -n "$BASH_VERSION" ]; then
+  __kurimats_pc() { local e=$?; [ -n "$__kurimats_cs" ] && printf '\\e]133;D;%s\\a' "$e" && __kurimats_cs=""; printf '\\e]133;A\\a'; }
+  __kurimats_pe() { [[ "$BASH_COMMAND" == "\$PROMPT_COMMAND" || "$BASH_COMMAND" == __kurimats_* ]] && return; [ -z "$__kurimats_cs" ] && __kurimats_cs=1 && printf '\\e]133;C\\a'; }
+  PROMPT_COMMAND="__kurimats_pc\${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+  PS1="\${PS1}\\[\\e]133;B\\a\\]"
+  trap '__kurimats_pe' DEBUG
+fi
+export KURIMATS_SHELL_INTEGRATION_LOADED=1
+`.trim()
+
+/**
  * リモートSSHセッション情報
  */
 interface SshSession {
@@ -292,8 +313,8 @@ export class SshManager extends EventEmitter {
             finalized: false,
           }
 
-          // 作業ディレクトリの変更
-          channel.write(`cd ${cwd} && clear\n`)
+          // シェル統合スクリプトを注入 + 作業ディレクトリの変更
+          channel.write(`${SHELL_INTEGRATION_INLINE}\ncd ${cwd} && clear\n`)
 
           const onData = (data: Buffer) => {
             const str = data.toString()

--- a/packages/server/src/services/ssh-manager.ts
+++ b/packages/server/src/services/ssh-manager.ts
@@ -3,8 +3,7 @@ import { readFileSync } from 'fs'
 import { EventEmitter } from 'events'
 import type { SshHost, SshConnectionStatus } from '@kurimats/shared'
 import { parseSshConfig } from './ssh-config.js'
-
-const RING_BUFFER_SIZE = 50 * 1024 // 50KB
+import { RingBuffer } from './ring-buffer.js'
 const RECONNECT_DELAY_MS = 5000
 
 /**
@@ -14,7 +13,7 @@ interface SshSession {
   sessionId: string
   hostName: string
   channel: ClientChannel | null
-  ringBuffer: string
+  ringBuffer: RingBuffer
   alive: boolean
   cleanup: () => void
   finalized: boolean
@@ -287,7 +286,7 @@ export class SshManager extends EventEmitter {
             sessionId,
             hostName,
             channel,
-            ringBuffer: '',
+            ringBuffer: new RingBuffer(),
             alive: true,
             cleanup: () => {},
             finalized: false,
@@ -298,20 +297,13 @@ export class SshManager extends EventEmitter {
 
           const onData = (data: Buffer) => {
             const str = data.toString()
-            // リングバッファに蓄積
-            session.ringBuffer += str
-            if (session.ringBuffer.length > RING_BUFFER_SIZE) {
-              session.ringBuffer = session.ringBuffer.slice(-RING_BUFFER_SIZE)
-            }
+            session.ringBuffer.append(str)
             this.emit('data', sessionId, str)
           }
 
           const onStderr = (data: Buffer) => {
             const str = data.toString()
-            session.ringBuffer += str
-            if (session.ringBuffer.length > RING_BUFFER_SIZE) {
-              session.ringBuffer = session.ringBuffer.slice(-RING_BUFFER_SIZE)
-            }
+            session.ringBuffer.append(str)
             this.emit('data', sessionId, str)
           }
 
@@ -362,7 +354,7 @@ export class SshManager extends EventEmitter {
    * リングバッファの内容を取得
    */
   getBuffer(sessionId: string): string {
-    return this.sessions.get(sessionId)?.ringBuffer ?? ''
+    return this.sessions.get(sessionId)?.ringBuffer.getSafeContent() ?? ''
   }
 
   /**

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -105,14 +105,31 @@ export class WorktreeService {
   }
 
   /**
-   * worktreeを削除
+   * worktreeを削除し、対応するkurimats/ブランチも削除する
    */
   remove(repoPath: string, worktreePath: string): void {
+    // worktree削除前にブランチ名を取得
+    const branchName = this.getBranch(worktreePath)
+
     execFileSync('git', ['worktree', 'remove', worktreePath, '--force'], {
       cwd: repoPath,
       encoding: 'utf-8',
       stdio: 'pipe',
     })
+
+    // kurimats/プレフィックスのブランチのみ自動削除（安全策）
+    if (branchName?.startsWith('kurimats/')) {
+      try {
+        execFileSync('git', ['branch', '-D', branchName], {
+          cwd: repoPath,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        })
+        console.log(`🌿 ブランチ削除: ${branchName}`)
+      } catch {
+        // ブランチが既に存在しない場合は無視
+      }
+    }
   }
 
   /**
@@ -124,6 +141,47 @@ export class WorktreeService {
       encoding: 'utf-8',
       stdio: 'pipe',
     })
+  }
+
+  /**
+   * リポジトリ内の孤立したkurimats/ブランチを削除
+   * 現在のworktreeに紐づかないkurimats/*ブランチを一括削除する
+   */
+  cleanupOrphanedBranches(repoPath: string): string[] {
+    // 現在のworktreeが使用中のブランチを取得
+    const activeWorktrees = this.list(repoPath)
+    const activeBranches = new Set(activeWorktrees.map(w => w.branch).filter(Boolean))
+
+    // kurimats/プレフィックスの全ブランチを取得
+    let allBranches: string[]
+    try {
+      const output = execFileSync('git', ['branch', '--list', 'kurimats/*'], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      })
+      allBranches = output.split('\n').map(b => b.trim().replace(/^\* /, '')).filter(Boolean)
+    } catch {
+      return []
+    }
+
+    // 使用中でないブランチを削除
+    const deleted: string[] = []
+    for (const branch of allBranches) {
+      if (!activeBranches.has(branch)) {
+        try {
+          execFileSync('git', ['branch', '-D', branch], {
+            cwd: repoPath,
+            encoding: 'utf-8',
+            stdio: 'pipe',
+          })
+          deleted.push(branch)
+        } catch {
+          // 削除失敗は無視
+        }
+      }
+    }
+    return deleted
   }
 
   /**

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -1,9 +1,13 @@
 /**
  * サーバー起動時の初期化タスク
- * - orphanedセッションをdisconnectedに変更
+ * - orphanedセッション(active)をdisconnectedに変更
+ * - disconnectedセッションのworktree+ブランチを削除してDB更新
  * - ペインツリーに含まれない孤立セッションを削除
+ * - git worktree pruneで物理的な孤立worktreeを除去
+ * - 孤立したkurimats/ブランチを一括削除
  * - worktreeセッションのブランチ名を最新化
  */
+import { existsSync } from 'fs'
 import type { SessionStore } from './services/session-store.js'
 import type { WorktreeService } from './services/worktree-service.js'
 import { collectSessionIds } from './utils/pane-tree.js'
@@ -22,7 +26,31 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
     console.log('✅ orphanedセッションなし')
   }
 
-  // 2. ペインツリーに含まれない孤立セッションを削除
+  // 2. disconnectedセッションのworktreeをクリーンアップ
+  //    アプリ再起動後のdisconnectedは実質再接続不可能なのでworktreeを解放する
+  try {
+    const disconnectedSessions = sessionStore.getAll().filter(s => s.status === 'disconnected' && s.worktreePath)
+    if (disconnectedSessions.length > 0) {
+      console.log(`🧹 ${disconnectedSessions.length}件のdisconnectedセッションのworktreeを解放`)
+      for (const s of disconnectedSessions) {
+        if (s.worktreePath && s.repoPath) {
+          try {
+            worktreeService.remove(s.repoPath, s.worktreePath)
+            console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)
+          } catch {
+            // 既に削除済みの場合は無視
+          }
+          // worktreePathをnullに更新（セッション自体は再接続可能なまま保持）
+          sessionStore.updateWorktreePath(s.id, null)
+        }
+      }
+      console.log('✅ disconnectedセッションのworktree解放完了')
+    }
+  } catch (e) {
+    console.error('⚠️ disconnectedセッションworktree解放中にエラー（サーバー起動は続行）:', e)
+  }
+
+  // 3. ペインツリーに含まれない孤立セッションを削除
   try {
     const workspaces = sessionStore.getAllCmuxWorkspaces()
     const referencedIds = new Set<string>()
@@ -41,7 +69,7 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
         if (s.worktreePath && s.repoPath) {
           try {
             worktreeService.remove(s.repoPath, s.worktreePath)
-            console.log(`   🗑️ worktree削除: ${s.worktreePath}`)
+            console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)
           } catch {
             // 既に削除済みの場合は無視
           }
@@ -57,7 +85,41 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
     console.error('⚠️ 孤立セッション削除中にエラー（サーバー起動は続行）:', e)
   }
 
-  // 3. worktreeセッションのブランチ名を最新化
+  // 4. git worktree prune + 孤立kurimats/ブランチの一括削除
+  try {
+    const allSessions = sessionStore.getAll()
+    const repoPathsWithWorktrees = new Set(
+      allSessions
+        .filter(s => s.repoPath && s.worktreePath)
+        .map(s => s.repoPath),
+    )
+    // 過去にworktreeが存在した可能性があるリポジトリも対象に含める
+    // （全セッションのrepoPathのうち .kurimats-worktrees ディレクトリが存在するもの）
+    for (const s of allSessions) {
+      if (s.repoPath && existsSync(`${s.repoPath}/.kurimats-worktrees`)) {
+        repoPathsWithWorktrees.add(s.repoPath)
+      }
+    }
+
+    for (const repoPath of repoPathsWithWorktrees) {
+      try {
+        worktreeService.prune(repoPath)
+        const deleted = worktreeService.cleanupOrphanedBranches(repoPath)
+        if (deleted.length > 0) {
+          console.log(`🌿 ${repoPath}: ${deleted.length}件の孤立ブランチを削除`)
+          for (const branch of deleted) {
+            console.log(`   ↳ ${branch}`)
+          }
+        }
+      } catch {
+        // リポジトリアクセスエラーは無視（リモートリポジトリ等）
+      }
+    }
+  } catch (e) {
+    console.error('⚠️ orphanedブランチ削除中にエラー（サーバー起動は続行）:', e)
+  }
+
+  // 5. worktreeセッションのブランチ名を最新化
   try {
     const allSessionsForBranch = sessionStore.getAll()
     let branchFixCount = 0

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -335,6 +335,24 @@ export interface CreateStartupTemplateParams {
   envVars?: Record<string, string>
 }
 
+// ========== シェル統合 (OSC 133) ==========
+
+/** シェルの実行状態 */
+export type ShellExecutionState = 'idle' | 'executing'
+
+/**
+ * OSC 133マーカーから得られるシェル状態
+ * ターミナルセッションごとに1つ
+ */
+export interface ShellState {
+  /** シェルの実行状態 */
+  executionState: ShellExecutionState
+  /** 直前コマンドの終了コード（未実行時はnull） */
+  lastExitCode: number | null
+  /** 直前コマンドの終了時刻（通知判定用） */
+  lastCommandFinishedAt: number | null
+}
+
 // ========== 通知 ==========
 
 // Claude通知


### PR DESCRIPTION
## Summary
- CI/CD: Electron自動ビルド・GH_TOKEN修正・tsbuildinfo除去・パストリガー追加
- 機能: ペインツールバー(★・コード表示)追加、PANE_NUMBERによるポート自動分離
- 修正: worktreeライフサイクル(孤立ブランチ自動削除)、SSHパーサーバグ、Node.js ABIバンドル、DB分離、会話履歴永続化
- リファクタ: pre-mergeコード品質改善
- ドキュメント: Electronデプロイ手順追加

closes #87 closes #98 closes #99 closes #105 closes #109 closes #127 closes #133 closes #137

## Test plan
- [ ] `npm run build` が成功すること
- [ ] CI (build-electron.yml) が正常完了すること
- [ ] DMGインストール後の基本動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)