### PR TITLE
fix: PTYがCMUX_*環境変数を子shellにリークしてworktree cwdが上書きされる問題を修正 (closes #159)

### DIFF
--- a/packages/server/src/__tests__/pty-manager.test.ts
+++ b/packages/server/src/__tests__/pty-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { PtyManager, type PtyBackend } from '../services/pty-manager.js'
+import { PtyManager, buildPtyEnv, type PtyBackend } from '../services/pty-manager.js'
 
 describe('PtyManager', () => {
   let manager: PtyManager
@@ -273,6 +273,47 @@ describe('PtyManager', () => {
   })
 
   // ========================================
+  // CMUX_*環境変数リーク防止テスト
+  // ========================================
+  describe('CMUX_*環境変数リーク防止', () => {
+    it('子shellにCMUX_WORKSPACE_IDが伝わらない（実spawn）', async () => {
+      // 親プロセスに cmux 由来の env を仕込む
+      const originalCmuxWs = process.env.CMUX_WORKSPACE_ID
+      const originalCmuxSock = process.env.CMUX_SOCKET_PATH
+      process.env.CMUX_WORKSPACE_ID = 'test-ws-id-leak-check'
+      process.env.CMUX_SOCKET_PATH = '/tmp/fake-cmux.sock'
+
+      try {
+        const output: string[] = []
+        const collect = (sessionId: string, data: string) => {
+          if (sessionId === 'cmux-leak') output.push(data)
+        }
+        manager.on('data', collect)
+
+        await manager.spawn('cmux-leak', '/tmp', 120, 30, '/bin/sh', [
+          '-c',
+          'echo CWS=[${CMUX_WORKSPACE_ID:-empty}] CSOCK=[${CMUX_SOCKET_PATH:-empty}] KS=[${KURIMATS_SHELL_INTEGRATION:-empty}]',
+        ])
+
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        manager.removeListener('data', collect)
+
+        const joined = output.join('')
+        // CMUX_* は剥がされているので empty になる
+        expect(joined).toContain('CWS=[empty]')
+        expect(joined).toContain('CSOCK=[empty]')
+        // kurimats 側で付与する env は届く
+        expect(joined).toContain('KS=[1]')
+      } finally {
+        if (originalCmuxWs === undefined) delete process.env.CMUX_WORKSPACE_ID
+        else process.env.CMUX_WORKSPACE_ID = originalCmuxWs
+        if (originalCmuxSock === undefined) delete process.env.CMUX_SOCKET_PATH
+        else process.env.CMUX_SOCKET_PATH = originalCmuxSock
+      }
+    }, 10000)
+  })
+
+  // ========================================
   // Playwrightポート割当テスト
   // ========================================
   describe('Playwrightポート割当', () => {
@@ -304,6 +345,69 @@ describe('PtyManager', () => {
       expect(uniquePorts).toContain('3552')
       expect(uniquePorts).toContain('3553')
     }, 10000)
+  })
+})
+
+// ========================================
+// buildPtyEnv 単体テスト
+// ========================================
+describe('buildPtyEnv', () => {
+  it('CMUX_で始まるキーを全て除外する', () => {
+    const env = buildPtyEnv({
+      HOME: '/home/user',
+      CMUX_WORKSPACE_ID: 'ws-1',
+      CMUX_SOCKET_PATH: '/tmp/cmux.sock',
+      CMUX_TAB_ID: 'tab-1',
+      PATH: '/usr/bin',
+    })
+    expect(env.HOME).toBe('/home/user')
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.CMUX_WORKSPACE_ID).toBeUndefined()
+    expect(env.CMUX_SOCKET_PATH).toBeUndefined()
+    expect(env.CMUX_TAB_ID).toBeUndefined()
+  })
+
+  it('CMUX_以外のキーは維持する（GHOSTTY_ 等を含む）', () => {
+    const env = buildPtyEnv({
+      GHOSTTY_BIN_DIR: '/Applications/cmux.app/Contents/MacOS',
+      CMUX_BUNDLE_ID: 'com.cmuxterm.app',
+      USER: 'alice',
+    })
+    expect(env.GHOSTTY_BIN_DIR).toBe('/Applications/cmux.app/Contents/MacOS')
+    expect(env.USER).toBe('alice')
+    expect(env.CMUX_BUNDLE_ID).toBeUndefined()
+  })
+
+  it('overridesが後勝ちで反映される', () => {
+    const env = buildPtyEnv(
+      { HOME: '/old', TERM: 'dumb' },
+      { TERM: 'xterm-256color', KURIMATS_SHELL_INTEGRATION: '1' },
+    )
+    expect(env.HOME).toBe('/old')
+    expect(env.TERM).toBe('xterm-256color')
+    expect(env.KURIMATS_SHELL_INTEGRATION).toBe('1')
+  })
+
+  it('overridesでundefinedの値はスキップされる', () => {
+    const env = buildPtyEnv(
+      { HOME: '/home/user' },
+      { EXTRA: undefined, KURIMATS_SHELL_INTEGRATION: '1' },
+    )
+    expect(env.EXTRA).toBeUndefined()
+    expect(env.HOME).toBe('/home/user')
+    expect(env.KURIMATS_SHELL_INTEGRATION).toBe('1')
+  })
+
+  it('親envでundefinedの値はスキップされる', () => {
+    const env = buildPtyEnv({ HOME: '/home/user', OPTIONAL: undefined })
+    expect(env.HOME).toBe('/home/user')
+    expect(env.OPTIONAL).toBeUndefined()
+  })
+
+  it('overridesを省略しても動作する', () => {
+    const env = buildPtyEnv({ HOME: '/home/user', CMUX_X: 'y' })
+    expect(env.HOME).toBe('/home/user')
+    expect(env.CMUX_X).toBeUndefined()
   })
 })
 

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -63,6 +63,37 @@ const PANE_NUMBER = process.env.PANE_NUMBER != null
   ? parseInt(process.env.PANE_NUMBER, 10)
   : null
 
+/**
+ * PTYに渡す環境変数を組み立てる
+ *
+ * 親プロセスの env を継承しつつ、kurimats ペインに不適切な外部ターミナル
+ * （cmux 等）由来の env を除外する。kurimats.app が cmux.app のタブ内から
+ * 起動された場合、親プロセスには `CMUX_WORKSPACE_ID` 等が継承されており、
+ * そのまま子 shell に渡るとユーザーの `.zshrc` 側の cmux 向け cwd 継承
+ * ロジックが発動し、PTY の cwd（worktree パス）を主リポに上書きしてしまう。
+ * kurimats ペインは概念的に cmux ペインではないため、`CMUX_*` 系は剥がす。
+ *
+ * @param parentEnv 親プロセスの env（通常 `process.env`）
+ * @param overrides kurimats が上書き/追加したい env（後勝ち）
+ */
+export function buildPtyEnv(
+  parentEnv: NodeJS.ProcessEnv,
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(parentEnv)) {
+    if (value === undefined) continue
+    // cmux など外部ターミナル由来の env は持ち込まない
+    if (key.startsWith('CMUX_')) continue
+    env[key] = value
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) continue
+    env[key] = value
+  }
+  return env
+}
+
 // node-ptyの動的読み込み結果をキャッシュ
 let nodePty: INodePty | null = null
 let nodePtyChecked = false
@@ -194,14 +225,13 @@ export class PtyManager extends EventEmitter {
       cols,
       rows,
       cwd,
-      env: {
-        ...process.env,
+      env: buildPtyEnv(process.env, {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
         ...(PANE_NUMBER != null ? { PANE_NUMBER: String(PANE_NUMBER) } : {}),
         KURIMATS_SHELL_INTEGRATION: '1',
-      } as Record<string, string>,
+      }),
     })
 
     // シェル統合スクリプトをPTY起動直後にsource
@@ -264,8 +294,7 @@ export class PtyManager extends EventEmitter {
     const child = cpSpawn('python3', [PTY_HELPER_PATH, cmd, ...cmdArgs], {
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
+      env: buildPtyEnv(process.env, {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         ...(playwrightPort ? { PLAYWRIGHT_MCP_PORT: String(playwrightPort) } : {}),
@@ -276,7 +305,7 @@ export class PtyManager extends EventEmitter {
         PTY_COLS: String(cols),
         PTY_ROWS: String(rows),
         KURIMATS_SHELL_INTEGRATION: '1',
-      },
+      }),
     })
 
     // シェル統合スクリプトをPTY起動直後にsource


### PR DESCRIPTION
closes #159

## Summary

- `kurimats.app` を `cmux.app` のタブ内から起動すると、親プロセス env に `CMUX_WORKSPACE_ID` 等が継承され、PTY へそのまま伝播していた。
- その結果、ユーザーの `~/.zshrc` にある cmux 向け cwd 継承ロジックが kurimats ペインでも発動し、PTY 起動時の cwd（worktree パス）が主リポに `cd` で上書きされていた。
- `buildPtyEnv()` ヘルパーを新設し、子 shell に渡す env から `CMUX_*` を剥がすよう統一（`_spawnWithNodePty` / `_spawnWithChildProcess` の env 構築を DRY 化）。

## Test plan

- [x] `npx vitest run packages/server/src/__tests__/pty-manager.test.ts` — 38/38 passed（新規7件を含む）
- [x] `npx vitest run packages/server` — 191/191 passed
- [x] `buildPtyEnv` 単体テスト: `CMUX_*` 除外 / 他キー維持 / overrides 後勝ち / undefined スキップ
- [x] 実 spawn テスト: `process.env.CMUX_WORKSPACE_ID` セット → 子 shell では空、`KURIMATS_SHELL_INTEGRATION=1` は届く
- [ ] マージ後、本番 Electron アプリへデプロイ（CLAUDE.md の8ステップ手順）し、Playwright でペインごとに worktree ブランチが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)