### PR TITLE
fix: ペイン分割時の番号割当を空き番号方式に変更 (closes #145)

### DIFF
--- a/packages/server/src/__tests__/pane-tree.test.ts
+++ b/packages/server/src/__tests__/pane-tree.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { nextFreePaneNumber } from '../utils/pane-tree'
+import type { PaneLeaf, PaneSplit } from '@kurimats/shared'
+
+/** 単一リーフのペインツリーを作る */
+function leaf(id: string, sessionId: string): PaneLeaf {
+  return { kind: 'leaf', id, sessionId, ratio: 0.5 }
+}
+
+/** 縦分割のスプリットツリーを作る */
+function split(id: string, children: [PaneLeaf, PaneLeaf]): PaneSplit {
+  return { kind: 'split', id, direction: 'vertical', ratio: 0.5, children }
+}
+
+describe('nextFreePaneNumber', () => {
+  it('リーフ1つだけの場合は 1 を返す（初期分割用）', () => {
+    // 実運用では初期ワークスペース直後の分割がこのケース
+    const tree = leaf('p1', 's1')
+    // s1 は "ws-pane1" として既に使用中 → 空いている最小は 2
+    const n = nextFreePaneNumber(tree, 'ws', (id) => (id === 's1' ? 'ws-pane1' : null))
+    expect(n).toBe(2)
+  })
+
+  it('連続使用時は末尾番号を返す', () => {
+    // ws-pane1, ws-pane2 が使用中 → 次は 3
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p2', 's2')])
+    const names: Record<string, string> = { s1: 'ws-pane1', s2: 'ws-pane2' }
+    const n = nextFreePaneNumber(tree, 'ws', (id) => names[id])
+    expect(n).toBe(3)
+  })
+
+  it('pane1 を閉じた後は空いた 1 を返す（Issue #145 の再現シナリオ）', () => {
+    // ペインツリーには pane2, pane3 のみ残り、pane1 は削除済み
+    const tree = split('sp', [leaf('p2', 's2'), leaf('p3', 's3')])
+    const names: Record<string, string> = { s2: 'ws-pane2', s3: 'ws-pane3' }
+    const n = nextFreePaneNumber(tree, 'ws', (id) => names[id])
+    // countLeaves+1 だと 3 を返して ws-pane3 と衝突していた
+    expect(n).toBe(1)
+  })
+
+  it('中抜けがある場合は最小の空き番号を返す', () => {
+    // pane1, pane3 が使用中 → 2 が空き
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p3', 's3')])
+    const names: Record<string, string> = { s1: 'ws-pane1', s3: 'ws-pane3' }
+    const n = nextFreePaneNumber(tree, 'ws', (id) => names[id])
+    expect(n).toBe(2)
+  })
+
+  it('2桁以上のペイン番号も扱える', () => {
+    // pane1..pane10 まで使用中 → 11 が次
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p10', 's10')])
+    const names: Record<string, string> = {}
+    for (let i = 1; i <= 10; i++) names[`s${i}`] = `ws-pane${i}`
+    // ツリー上はs1,s10しか参照していなくても、使用済み番号はs*マップで決まる
+    // -> ここでの意図は regex の \d+ が2桁に対応することの確認
+    const onlyTwo = nextFreePaneNumber(tree, 'ws', (id) => names[id])
+    expect(onlyTwo).toBe(2) // ツリー参照はs1(1)とs10(10)のみ、2が空き
+  })
+
+  it('ワークスペース名が変わった場合、旧名のセッションは集計から外れる', () => {
+    // 旧名 "foo" のセッションが残っていても、新名 "bar" での分割は 1 から始まる
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p2', 's2')])
+    const names: Record<string, string> = { s1: 'foo-pane1', s2: 'foo-pane2' }
+    const n = nextFreePaneNumber(tree, 'bar', (id) => names[id])
+    expect(n).toBe(1)
+  })
+
+  it('ワークスペース名に正規表現メタ文字が含まれてもエスケープされる', () => {
+    // ws名 "a.b" は regex 的に "a任意b" にならないこと
+    // "a.b-pane1" のみ使用中 → 次は 2
+    // "aXb-pane1" というノイズがあっても引っかかってはいけない
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p2', 's2')])
+    const names: Record<string, string> = { s1: 'a.b-pane1', s2: 'aXb-pane1' }
+    const n = nextFreePaneNumber(tree, 'a.b', (id) => names[id])
+    expect(n).toBe(2) // a.b-pane1 のみカウント、aXb-pane1 はノイズ扱い
+  })
+
+  it('getSessionName が null を返すリーフはスキップ', () => {
+    // 孤立/未解決セッションがあっても落ちない
+    const tree = split('sp', [leaf('p1', 's1'), leaf('p2', 's-missing')])
+    const n = nextFreePaneNumber(tree, 'ws', (id) => (id === 's1' ? 'ws-pane1' : null))
+    expect(n).toBe(2)
+  })
+})

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -12,6 +12,7 @@ import {
   findLeaf,
   findFirstLeafId,
   containsLeafId,
+  nextFreePaneNumber,
   rebalanceRatios,
   splitLeafInTree,
   closeLeafInTree,
@@ -160,9 +161,14 @@ export function createWorkspacesRouter(
 
     let session: Session | null = null
     try {
-      // ペイン数をカウントしてユニーク名を作成
-      const paneCount = countLeaves(workspace.paneTree)
-      const sessionName = `${workspace.name}-pane${paneCount + 1}`
+      // 既存セッション名から空いている最小のペイン番号を算出してユニーク名を作成
+      // （`countLeaves + 1` 方式だと pane1 削除→分割で番号が重複するため）
+      const paneNumber = nextFreePaneNumber(
+        workspace.paneTree,
+        workspace.name,
+        (id) => store.getById(id)?.name,
+      )
+      const sessionName = `${workspace.name}-pane${paneNumber}`
 
       // 新セッション+PTY/SSH+Claude Code起動（独自worktree付き）
       const created = await createWorkspaceSession(

--- a/packages/server/src/utils/pane-tree.ts
+++ b/packages/server/src/utils/pane-tree.ts
@@ -28,6 +28,49 @@ export function countLeaves(node: PaneNode): number {
   return countLeaves(node.children[0]) + countLeaves(node.children[1])
 }
 
+/** 正規表現メタ文字をエスケープ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * `${workspaceName}-paneN` 形式で既に使われている番号を避け、
+ * 空いている最小の正整数（1以上）を返す。
+ *
+ * 既存のペイン数 + 1 ではなく「空き番号」を返すことで、
+ * pane1 を削除した後に分割した際の名前衝突を防ぐ。
+ *
+ * @param tree 対象ワークスペースのペインツリー
+ * @param workspaceName ワークスペース名（現在の名前）
+ * @param getSessionName sessionId からセッション名を解決する関数
+ */
+export function nextFreePaneNumber(
+  tree: PaneNode,
+  workspaceName: string,
+  getSessionName: (sessionId: string) => string | null | undefined,
+): number {
+  const pattern = new RegExp(`^${escapeRegExp(workspaceName)}-pane(\\d+)$`)
+  const used = new Set<number>()
+
+  const walk = (node: PaneNode): void => {
+    if (node.kind === 'leaf') {
+      const name = getSessionName(node.sessionId)
+      if (name) {
+        const match = name.match(pattern)
+        if (match) used.add(parseInt(match[1], 10))
+      }
+      return
+    }
+    walk(node.children[0])
+    walk(node.children[1])
+  }
+  walk(tree)
+
+  let n = 1
+  while (used.has(n)) n++
+  return n
+}
+
 /** IDでリーフを検索 */
 export function findLeaf(node: PaneNode, leafId: string): PaneLeaf | null {
   if (node.kind === 'leaf') return node.id === leafId ? node : null


### PR DESCRIPTION
## Summary

- `nextFreePaneNumber` ヘルパーを `pane-tree.ts` に追加し、既存セッション名から `${workspace.name}-paneN` の空き番号を計算する
- `workspaces.ts` の split-pane ルートを `countLeaves + 1` 方式から新方式に切替 → pane1 削除後の分割で名前が重複する問題 (#145) を解消
- ユニットテスト `pane-tree.test.ts` を追加（Issue の再現シナリオ含む8ケース）

## 背景

現状の `packages/server/src/routes/workspaces.ts:164-165` では:

\`\`\`ts
const paneCount = countLeaves(workspace.paneTree)
const sessionName = \`\${workspace.name}-pane\${paneCount + 1}\`
\`\`\`

再現:
1. ws作成 → \`ws-pane1\`
2. 分割×2 → \`ws-pane2\`, \`ws-pane3\`
3. pane1削除（leaves=2）
4. 分割 → \`ws-pane3\` ← **重複**

新 worktree の作成先が同一ディレクトリ・同一ブランチ (\`kurimats/ws-pane3\`) になり危険。

## 修正方針

Issue #145 のとおり「既存セッション名から番号を抽出し、空いている最小の正整数を割り当てる」方式に変更:

- 上記シナリオの手順4では \`ws-pane1\` が再利用される
- 中抜けがない場合は末尾+1 と同じ挙動
- ワークスペース名の正規表現メタ文字は \`escapeRegExp\` でエスケープ
- ツリー上で解決不可能なセッション（null 返却）はスキップ

## Test plan

- [x] \`npx vitest run packages/server\` 全16ファイル199テスト通過
- [x] \`npx tsc -p packages/server/tsconfig.json --noEmit\` エラーなし
- [ ] ローカル Electron 起動で Issue 再現シナリオを手動確認（ws作成→2回分割→pane1削除→再分割で \`pane1\` が割当されること、worktreeディレクトリも重複しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)