### PR TITLE
fix: ターミナルでmac風キーバインドを一式サポート (closes #161)

### DIFF
--- a/packages/client/src/__tests__/terminal-keybindings.test.ts
+++ b/packages/client/src/__tests__/terminal-keybindings.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { macKeyEventToSequence } from '../utils/terminal-keybindings'
+
+/**
+ * テスト用のイベント生成ヘルパー
+ * macKeyEventToSequenceはtype/metaKey/altKey/ctrlKey/keyしか参照しないため、
+ * jsdom環境なしでプレーンオブジェクトをキャストして注入する
+ */
+function makeEvent(init: {
+  key: string
+  type?: 'keydown' | 'keyup'
+  metaKey?: boolean
+  altKey?: boolean
+  ctrlKey?: boolean
+  shiftKey?: boolean
+}): KeyboardEvent {
+  return {
+    type: init.type ?? 'keydown',
+    key: init.key,
+    metaKey: init.metaKey ?? false,
+    altKey: init.altKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    shiftKey: init.shiftKey ?? false,
+  } as unknown as KeyboardEvent
+}
+
+describe('macKeyEventToSequence', () => {
+  describe('Cmd修飾子（行単位操作）', () => {
+    it('Cmd+Backspace → Ctrl+U (\\x15) 行頭まで削除', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x15')
+    })
+
+    it('Cmd+ArrowLeft → Ctrl+A (\\x01) 行頭へ', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x01')
+    })
+
+    it('Cmd+ArrowRight → Ctrl+E (\\x05) 行末へ', () => {
+      const ev = makeEvent({ key: 'ArrowRight', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x05')
+    })
+
+    it('Cmd+Shift+Backspace（Shift併用）も行頭まで削除', () => {
+      // Shiftはテキスト選択扱いではあるが、xtermバッファ上は選択状態ではないので
+      // 保守的にCmd+Backspaceと同じシーケンスを返す（ユーザー体感優先）
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, shiftKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x15')
+    })
+
+    it('Cmd+任意文字キーは対象外', () => {
+      const ev = makeEvent({ key: 'c', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('Opt修飾子（単語単位操作）', () => {
+    it('Opt+Backspace → Ctrl+W (\\x17) 単語削除', () => {
+      const ev = makeEvent({ key: 'Backspace', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x17')
+    })
+
+    it('Opt+ArrowLeft → ESC+b (\\x1bb) 前単語へ', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x1bb')
+    })
+
+    it('Opt+ArrowRight → ESC+f (\\x1bf) 次単語へ', () => {
+      const ev = makeEvent({ key: 'ArrowRight', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x1bf')
+    })
+
+    it('Opt+文字キー（å入力）は委譲する', () => {
+      // xtermのデフォルト挙動で特殊文字入力させたいのでnullを返す
+      const ev = makeEvent({ key: 'b', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('プラットフォーム/イベント種別の除外', () => {
+    it('isMac=falseでは常にnull（Cmd+Backspace）', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true })
+      expect(macKeyEventToSequence(ev, false)).toBeNull()
+    })
+
+    it('isMac=falseでは常にnull（Opt+ArrowLeft）', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', altKey: true })
+      expect(macKeyEventToSequence(ev, false)).toBeNull()
+    })
+
+    it('keyupイベントは対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, type: 'keyup' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('修飾子なし/複合修飾子', () => {
+    it('修飾子なしBackspaceは委譲（通常の1文字削除）', () => {
+      const ev = makeEvent({ key: 'Backspace' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Cmd+Ctrl+Backspace（複合）は対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, ctrlKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Cmd+Opt+Backspace（複合）は対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Ctrl+Backspace単独は対象外（Ctrlはxtermネイティブで処理される）', () => {
+      const ev = makeEvent({ key: 'Backspace', ctrlKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('修飾子なしArrowLeftは委譲', () => {
+      const ev = makeEvent({ key: 'ArrowLeft' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+})

--- a/packages/client/src/hooks/useTerminalWs.ts
+++ b/packages/client/src/hooks/useTerminalWs.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import type { ClientTerminalMessage, ServerTerminalMessage } from '@kurimats/shared'
+import { isMacPlatform, macKeyEventToSequence } from '../utils/terminal-keybindings'
 
 /**
  * ターミナルWebSocket接続フック
@@ -72,20 +73,44 @@ export function useTerminalWs(sessionId: string | null, terminal: Terminal | nul
     }
   }, [sessionId, terminal])
 
+  // 入力送信ヘルパー（onDataとキーバインドハンドラの両方から使う）
+  const sendInput = useCallback((data: string) => {
+    const ws = wsRef.current
+    if (ws?.readyState === WebSocket.OPEN) {
+      const msg: ClientTerminalMessage = { type: 'input', data }
+      ws.send(JSON.stringify(msg))
+    }
+  }, [])
+
   // 入力送信
   useEffect(() => {
     if (!terminal || !sessionId) return
 
-    const disposable = terminal.onData((data) => {
-      const ws = wsRef.current
-      if (ws?.readyState === WebSocket.OPEN) {
-        const msg: ClientTerminalMessage = { type: 'input', data }
-        ws.send(JSON.stringify(msg))
-      }
-    })
+    const disposable = terminal.onData(sendInput)
 
     return () => disposable.dispose()
-  }, [terminal, sessionId])
+  }, [terminal, sessionId, sendInput])
+
+  // mac風キーバインド（Cmd/Opt + Backspace/矢印）をPTY制御シーケンスに変換
+  // xterm.jsはmetaKey付きキーをブラウザに委ねるためデフォルトではPTYに届かない。
+  // attachCustomKeyEventHandlerで該当キーを拾い、sendInput経由で直接送信する。
+  useEffect(() => {
+    if (!terminal) return
+    const isMac = isMacPlatform()
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      const seq = macKeyEventToSequence(event, isMac)
+      if (seq === null) return true // 対象外キーはxtermのデフォルト処理に委ねる
+      event.preventDefault()
+      sendInput(seq)
+      return false // xtermの以後の処理を抑制
+    })
+
+    return () => {
+      // クリーンアップ時はno-opハンドラに戻す（dispose前の二重処理防止）
+      terminal.attachCustomKeyEventHandler(() => true)
+    }
+  }, [terminal, sendInput])
 
   // リサイズ送信
   useEffect(() => {

--- a/packages/client/src/utils/terminal-keybindings.ts
+++ b/packages/client/src/utils/terminal-keybindings.ts
@@ -1,0 +1,79 @@
+/**
+ * macOS風キーバインドをターミナル制御シーケンスに変換するユーティリティ
+ *
+ * xterm.jsはデフォルトでmetaKey（Cmd）付きのキーをブラウザ/OSに委ね、
+ * altKey付きの文字キーも特殊文字入力として扱うため、Terminal.app/iTerm2が
+ * 行っているような行編集ショートカットがPTYに届かない。
+ * この関数で必要なキーだけを拾い、readline互換の制御シーケンスに変換する。
+ */
+
+/**
+ * macOSプラットフォーム判定
+ * Electron/Chromiumどちらからも確実に判定できるようplatform/userAgentを両方見る
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const platform = (navigator as Navigator & { platform?: string }).platform ?? ''
+  if (/Mac/i.test(platform)) return true
+  return /Mac/i.test(navigator.userAgent)
+}
+
+/**
+ * KeyboardEventをターミナルへ送る制御シーケンスに変換する
+ *
+ * - nullを返した場合、呼び出し側は xterm.js のデフォルト処理に委ねること
+ * - 文字列を返した場合、呼び出し側でWebSocket経由でPTYへ送信し、
+ *   xterm.js のデフォルト処理を抑制すること（attachCustomKeyEventHandlerなら false を返す）
+ *
+ * 変換対象（macのみ）:
+ * | 入力          | 出力     | 意味                       |
+ * |---------------|----------|---------------------------|
+ * | Cmd+Backspace | \x15     | Ctrl+U カーソルから行頭まで削除 |
+ * | Cmd+←         | \x01     | Ctrl+A 行頭へ移動          |
+ * | Cmd+→         | \x05     | Ctrl+E 行末へ移動          |
+ * | Opt+Backspace | \x17     | Ctrl+W 前方の単語を削除     |
+ * | Opt+←         | \x1bb    | ESC+b 前方の単語へ移動      |
+ * | Opt+→         | \x1bf    | ESC+f 次の単語へ移動        |
+ *
+ * Opt+文字キー（Opt+b → å 等）は意図的に対象外。xtermのデフォルトに委ね、
+ * 特殊文字入力ユースケースを温存する。
+ */
+export function macKeyEventToSequence(
+  event: KeyboardEvent,
+  isMac: boolean,
+): string | null {
+  if (!isMac) return null
+  if (event.type !== 'keydown') return null
+
+  const { metaKey, altKey, ctrlKey, key } = event
+
+  // Cmd単独（Ctrl/Alt併用は対象外） → 行頭/行末/行頭まで削除
+  if (metaKey && !altKey && !ctrlKey) {
+    switch (key) {
+      case 'Backspace':
+        return '\x15' // Ctrl+U: 行頭まで削除
+      case 'ArrowLeft':
+        return '\x01' // Ctrl+A: 行頭へ
+      case 'ArrowRight':
+        return '\x05' // Ctrl+E: 行末へ
+      default:
+        return null
+    }
+  }
+
+  // Opt(Alt)単独（Cmd/Ctrl併用は対象外） → 単語削除/単語移動
+  if (altKey && !metaKey && !ctrlKey) {
+    switch (key) {
+      case 'Backspace':
+        return '\x17' // Ctrl+W: 前方の単語を削除
+      case 'ArrowLeft':
+        return '\x1bb' // ESC+b: 前方の単語へ
+      case 'ArrowRight':
+        return '\x1bf' // ESC+f: 次の単語へ
+      default:
+        return null
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- xterm.jsが `metaKey` 付きキーをブラウザ/OS側に委ねるせいで、Cmd+Backspace等のmacOS標準ショートカットがPTYに届かない不具合を修正
- `attachCustomKeyEventHandler` で該当キーを拾い、readline互換の制御シーケンスに変換してWebSocket経由でPTYに送信
- 純関数 `macKeyEventToSequence` に切り出し、17ケースの単体テストで全パターン検証

## 実装するバインド一式

| 入力 | 送信シーケンス | 意味 |
|---|---|---|
| Cmd+Backspace | `\x15` | Ctrl+U 行頭まで削除 |
| Cmd+← | `\x01` | Ctrl+A 行頭へ |
| Cmd+→ | `\x05` | Ctrl+E 行末へ |
| Opt+Backspace | `\x17` | Ctrl+W 前単語削除 |
| Opt+← | `\x1bb` | ESC+b 前単語へ |
| Opt+→ | `\x1bf` | ESC+f 次単語へ |

- Opt+文字キー（`å` 等）はxtermのデフォルトに委譲し特殊文字入力を温存
- 非mac（`isMac=false`）では一切介入せず既存挙動維持
- keyup/複合修飾子（Cmd+Ctrl+Backspace 等）はすべて除外

## 変更ファイル
- `packages/client/src/utils/terminal-keybindings.ts` (新規) — 純関数 `isMacPlatform` / `macKeyEventToSequence`
- `packages/client/src/hooks/useTerminalWs.ts` — `attachCustomKeyEventHandler` 登録 + `sendInput` ヘルパー切り出し
- `packages/client/src/__tests__/terminal-keybindings.test.ts` (新規) — 17ケース

## Test plan
- [x] `npx vitest run packages/client/src/__tests__/terminal-keybindings.test.ts` → 17/17 passed
- [x] `npx tsc --noEmit -p packages/client/tsconfig.json` → エラーなし
- [x] 既存 `terminal-safe-fit.test.ts` 併走 → 31/31 passed
- [x] Playwright動作確認（pane1 dev: server 14001 / client 5181、検証スクリプト `.tmp/playwright/fix/terminal-mac-keybindings-161/verify.mjs`）
  - テスト1: `hello world foo bar baz` を入力 → **Cmd+Backspace で全消去** → ✅ PASS
  - テスト2: `alpha beta gamma` を入力 → **Opt+Backspace で末尾 gamma のみ削除**（beta は残存）→ ✅ PASS
  - テスト3: Opt+← ×3 / Cmd+← / Cmd+→ / Opt+→ の視覚確認（スクショ取得済み）
  - pageErrors: なし
  - 証跡: 15枚のスクリーンショット（01-initial → 14-final-cleaned）

🤖 Generated with [Claude Code](https://claude.com/claude-code)