### PR TITLE
feat: PaneToolbar に 📁ファイルツリーボタンを追加 (closes #166)

### DIFF
--- a/packages/client/src/__tests__/pane-toolbar.test.tsx
+++ b/packages/client/src/__tests__/pane-toolbar.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../components/animations/FavoriteAnimations', () => ({
 }))
 
 const mockToggleFavorite = vi.fn()
+const mockOpenOverlay = vi.fn()
 
 vi.mock('../stores/session-store', () => ({
   useSessionStore: (selector: any) => selector({
@@ -32,6 +33,12 @@ vi.mock('../stores/session-store', () => ({
 vi.mock('../stores/pane-store', () => ({
   usePaneStore: (selector: any) => selector({
     addSurface: vi.fn(),
+  }),
+}))
+
+vi.mock('../stores/overlay-store', () => ({
+  useOverlayStore: (selector: any) => selector({
+    openOverlay: mockOpenOverlay,
   }),
 }))
 
@@ -111,5 +118,35 @@ describe('PaneToolbar', () => {
   it('data-testid="pane-toolbar" を公開してテストから参照可能にする', () => {
     const html = renderHtml({ session: baseSession })
     expect(html).toContain('data-testid="pane-toolbar"')
+  })
+
+  describe('ファイルツリー起動ボタン（📁）', () => {
+    it('📁ボタンが描画され data-testid と title を公開する', () => {
+      const html = renderHtml({ session: baseSession })
+      expect(html).toContain('data-testid="file-tree-button"')
+      expect(html).toContain('title="ファイルツリーを開く"')
+      expect(html).toContain('aria-label="ファイルツリーを開く"')
+      expect(html).toContain('📁')
+    })
+
+    it('📁ボタンは常時視認できる色（text-transparent を使わない）', () => {
+      const html = renderHtml({ session: baseSession })
+      // file-tree-button を含む <button ...> タグ全体を抽出する
+      const tagMatch = html.match(/<button[^>]*data-testid="file-tree-button"[^>]*>/)
+      expect(tagMatch).toBeTruthy()
+      const buttonTag = tagMatch?.[0] ?? ''
+      // ★と違い、最初から薄く見える text-text-muted を使う
+      expect(buttonTag).toContain('text-text-muted')
+      expect(buttonTag).not.toContain('text-transparent')
+    })
+
+    it('📁ボタンは右寄せボタン群の中で★より左に配置される', () => {
+      const html = renderHtml({ session: baseSession })
+      const fileTreePos = html.indexOf('data-testid="file-tree-button"')
+      const favoritePos = html.indexOf('data-testid="favorite-button"')
+      expect(fileTreePos).toBeGreaterThan(0)
+      expect(favoritePos).toBeGreaterThan(0)
+      expect(fileTreePos).toBeLessThan(favoritePos)
+    })
   })
 })

--- a/packages/client/src/components/panes/PaneToolbar.tsx
+++ b/packages/client/src/components/panes/PaneToolbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { Session } from '@kurimats/shared'
 import { useSessionStore } from '../../stores/session-store'
+import { useOverlayStore } from '../../stores/overlay-store'
 import { AnimatedFavoriteButton } from '../animations/FavoriteAnimations'
 
 interface PaneToolbarProps {
@@ -11,16 +12,22 @@ interface PaneToolbarProps {
 
 /**
  * ペイン上部のツールバー
- * セッション名・ブランチ表示 + お気に入り★
+ * セッション名・ブランチ表示 + 📁ファイルツリー起動 + お気に入り★
  * - isActive=true のとき背景色を強調して現在フォーカスペインを視覚化
  * - ペイン境界を明示するため左右に border を付与
+ * - 📁クリックでFileTreeOverlayを開き、MD/コードの全画面ビューアへの導線を提供
  */
 export function PaneToolbar({ session, isActive = false }: PaneToolbarProps) {
   const toggleFavorite = useSessionStore(s => s.toggleFavorite)
+  const openOverlay = useOverlayStore(s => s.openOverlay)
 
   const handleToggleFavorite = useCallback(() => {
     toggleFavorite(session.id)
   }, [toggleFavorite, session.id])
+
+  const handleOpenFileTree = useCallback(() => {
+    openOverlay('file-tree', { sessionId: session.id })
+  }, [openOverlay, session.id])
 
   // アクティブ/非アクティブで背景色と下線を切替。
   // ペイン境界の視認性向上のため border-x を常時付与する。
@@ -52,6 +59,18 @@ export function PaneToolbar({ session, isActive = false }: PaneToolbarProps) {
 
       {/* 右寄せボタン群 */}
       <div className="ml-auto flex items-center gap-1 flex-shrink-0">
+        {/* ファイルツリー起動 → FileTreeOverlay経由で全画面MD/コードビューアを開く */}
+        <button
+          type="button"
+          onClick={handleOpenFileTree}
+          className="flex-shrink-0 leading-none text-xs text-text-muted hover:text-accent transition-colors cursor-pointer"
+          title="ファイルツリーを開く"
+          aria-label="ファイルツリーを開く"
+          data-testid="file-tree-button"
+        >
+          📁
+        </button>
+
         {/* お気に入りトグル */}
         <AnimatedFavoriteButton
           isFavorite={session.isFavorite}


### PR DESCRIPTION
## Summary
- #149 で実装済みの全画面ビューア（FileTreeOverlay / CodeViewerOverlay / MarkdownOverlay）は従来ボード表示 (SessionNode) の 📁 からしか起動できなかった
- ペイン表示モードから同等の導線を提供するため、PaneToolbar に 📁 ボタンを追加
- クリックで `useOverlayStore.openOverlay('file-tree', { sessionId })` を呼び、選択した `.md` は全画面 MarkdownOverlay、それ以外は CodeViewerOverlay で開く

## 変更ファイル
- `packages/client/src/components/panes/PaneToolbar.tsx` — `useOverlayStore` import、`handleOpenFileTree` 追加、右寄せボタン群の先頭（★の左）に 📁 ボタン配置
- `packages/client/src/__tests__/pane-toolbar.test.tsx` — `overlay-store` の mock 追加、📁 ボタンに関する単体テスト3件追加

## UX 配慮
- 📁 ボタンは `text-text-muted hover:text-accent` で **常時視認可能**。#143 の反省を踏まえて透明・半透明は使わない
- `title` / `aria-label` / `data-testid="file-tree-button"` を付与
- ★ の左に配置してボタン群が論理的な順序で並ぶ

## Test plan
- [x] `npx vitest run packages/client/src/__tests__/pane-toolbar.test.tsx` → 11/11 passed
- [x] `npx tsc --noEmit -p packages/client/tsconfig.json` → エラー無し
- [x] Playwright動作確認（dev server pane1、2ペインワークスペース）
  - [x] 📁 ボタンが 2 個表示される（`data-testid="file-tree-button"` × 2）
  - [x] title="ファイルツリーを開く" / aria-label 一致
  - [x] className に `text-text-muted` を含み `text-transparent` を含まない
  - [x] 📁 クリックで FileTreeOverlay が開き「ファイルツリー」タイトルと検索入力が表示
  - [x] pageErrors 0
  - 証跡: `.tmp/playwright/feat/pane-toolbar-file-button-166/` にスクショ10枚 + result.json
- [ ] 手動確認（レビュー時）: 
  - [ ] `.md` ファイルクリック → 全画面 MarkdownOverlay
  - [ ] `.ts` ファイルクリック → CodeViewerOverlay
  - [ ] ESC で閉じる

## ベースブランチと依存関係
- ベース: `feat/pane-toolbar-visibility-165` （PR #167）
- スタック構成。PR #167 がマージされたら本PRを develop へリベースします

🤖 Generated with [Claude Code](https://claude.com/claude-code)