### PR TITLE
fix: .mcp.json のplaywright設定にtype:httpフィールドを追加 (closes #171)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "playwright": {
+      "type": "http",
       "url": "http://localhost:14550/mcp"
     }
   }


### PR DESCRIPTION
## Summary

- `.mcp.json` の `playwright` エントリに `"type": "http"` を追加
- Claude Code の MCP サーバースキーマでは HTTP トランスポートのリモートサーバーに `type` フィールドが必須
- これが欠けていたため `/doctor` 診断で `[Failed to parse] Project config` エラーが発生していた

Closes #171

## Test plan

- [ ] `cat .mcp.json` で `"type": "http"` が追加されていることを確認
- [ ] `python3 -m json.tool .mcp.json` で JSON が有効であることを確認
- [ ] Claude Code を再起動し `/doctor` 実行 → `[Failed to parse]` エラーが消えていること
- [ ] `/mcp` で `playwright` サーバーが正常接続（status: connected）
- [ ] Playwright MCP 経由で `browser_navigate` 等のブラウザ操作が実行できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)