### PR TITLE
fix: .mcp.json のplaywrightにtype:httpを追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "playwright": {
+      "type": "http",
       "url": "http://localhost:14550/mcp"
     }
   }


### PR DESCRIPTION
## Summary

- Claude Code `/doctor` で `.mcp.json` がスキーマ違反として検出されていた問題を修正
- HTTPトランスポートのリモートMCPサーバーには `type: "http"` フィールドが必須のため追加

## 修正内容

```diff
 {
   "mcpServers": {
     "playwright": {
+      "type": "http",
       "url": "http://localhost:14550/mcp"
     }
   }
 }
```

## 参考

[Claude Code MCP ドキュメント](https://code.claude.com/docs/en/mcp) の "Project scope" セクションのスキーマ例に準拠。

closes #172

## Test plan

- [ ] マージ後、Claude Code を再起動して `/doctor` を実行
- [ ] `MCP Config Diagnostics` セクションに `.mcp.json` のスキーマエラーが出ないことを確認
- [ ] `/mcp` コマンドで playwright サーバーが正常接続されていることを確認
- [ ] Playwright MCP 経由で `browser_navigate` 等のツールが呼べることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)