### PR TITLE
fix: ★お気に入りボタンの視認性を WCAG 3:1 まで改善 (closes #143)

### DIFF
--- a/packages/client/src/__tests__/favorite-animations.test.ts
+++ b/packages/client/src/__tests__/favorite-animations.test.ts
@@ -11,6 +11,7 @@ import {
   isSessionVisible,
   shouldBadgeBounce,
   shouldStarburst,
+  FAVORITE_BUTTON_CLASSES,
 } from '../components/animations/favorite-animation-config'
 
 // ===================================================================
@@ -297,5 +298,50 @@ describe('スターバースト発火条件', () => {
 
   it('お気に入り解除時（true→false）にはバーストしない', () => {
     expect(shouldStarburst(true)).toBe(false)
+  })
+})
+
+// ===================================================================
+// お気に入りボタン視認性 className テスト（#143 再発防止）
+// ===================================================================
+describe('FAVORITE_BUTTON_CLASSES（#143 再発防止）', () => {
+  describe('非お気に入り時の className', () => {
+    const inactive = FAVORITE_BUTTON_CLASSES.inactive
+
+    it('text-transparent を使わない（完全不可視の禁止）', () => {
+      expect(inactive).not.toContain('text-transparent')
+    })
+
+    it('極薄 opacity（/10 〜 /50）を使わない（bg-surface-1 で 3:1 未満となるため）', () => {
+      // 旧実装 text-text-muted/30 は実効コントラスト 1.44:1 で WCAG 3:1 未達だった
+      expect(inactive).not.toMatch(/text-text-muted\/(10|20|30|40|50)\b/)
+    })
+
+    it('text-text-muted を 100% alpha で使う（📁 ボタンと同等の視認性）', () => {
+      // Tailwind の class 名として opacity 指定なしの text-text-muted が含まれていること
+      expect(inactive).toMatch(/(^|\s)text-text-muted(\s|$)/)
+    })
+
+    it('group-hover でのみ表示される挙動（発見困難）を使わない', () => {
+      // 旧実装は group-hover:text-text-muted で toolbar 全体ホバー時のみ表示していた
+      expect(inactive).not.toContain('group-hover:')
+    })
+
+    it('hover 時に yellow プレビュー色へ遷移する（お気に入り色の予告）', () => {
+      expect(inactive).toMatch(/hover:text-yellow-\d{3}/)
+    })
+  })
+
+  describe('お気に入り時の className', () => {
+    const active = FAVORITE_BUTTON_CLASSES.active
+
+    it('text-yellow-500 を使う（明確なアクティブ色）', () => {
+      expect(active).toContain('text-yellow-500')
+    })
+
+    it('text-transparent / 極薄 opacity を使わない', () => {
+      expect(active).not.toContain('text-transparent')
+      expect(active).not.toMatch(/text-yellow-500\/(10|20|30|40|50)\b/)
+    })
   })
 })

--- a/packages/client/src/components/animations/FavoriteAnimations.tsx
+++ b/packages/client/src/components/animations/FavoriteAnimations.tsx
@@ -11,6 +11,7 @@ import {
   badgeBounceVariants,
   shouldStarburst,
   shouldBadgeBounce,
+  FAVORITE_BUTTON_CLASSES,
 } from './favorite-animation-config'
 
 // 設定・ロジックを再エクスポート（Sidebar等から参照）
@@ -23,6 +24,7 @@ export {
   gatherVariants,
   disperseVariants,
   badgeBounceVariants,
+  FAVORITE_BUTTON_CLASSES,
 } from './favorite-animation-config'
 
 // --- コンポーネント ---
@@ -85,13 +87,13 @@ export function AnimatedFavoriteButton({
     }
   }, [showBurst])
 
+  // #143: 非お気に入り時の className は定数化し、3:1 未満の極薄色を再び入れないよう
+  // 回帰テストで固定する (favorite-animations.test.ts)
   return (
     <span
       onClick={handleClick}
       className={`relative flex-shrink-0 transition-colors cursor-pointer ${
-        isFavorite
-          ? 'text-yellow-500'
-          : 'text-text-muted/30 group-hover:text-text-muted'
+        isFavorite ? FAVORITE_BUTTON_CLASSES.active : FAVORITE_BUTTON_CLASSES.inactive
       }`}
       title={isFavorite ? 'お気に入り解除' : 'お気に入りに追加'}
       data-testid="favorite-button"

--- a/packages/client/src/components/animations/favorite-animation-config.ts
+++ b/packages/client/src/components/animations/favorite-animation-config.ts
@@ -8,6 +8,29 @@
 /** スターバーストのパーティクル数 */
 export const STARBURST_PARTICLE_COUNT = 8
 
+/**
+ * お気に入りボタンの className 定数
+ *
+ * #143 再発防止:
+ * 旧実装では非お気に入り時に `text-text-muted/30 group-hover:text-text-muted` を使用していたが、
+ * 30% alpha を bg-surface-1 (#151b22) とブレンドすると実効コントラスト比 ≈ 1.44:1 となり
+ * WCAG 2.1 UI コンポーネント最低 3:1 を大きく下回り、ボタンが「発見できない」状態になっていた。
+ *
+ * 本定数では以下を保証する:
+ * - 非お気に入り: text-text-muted (#64748b) を 100% alpha で使用 (bg-surface-1 上 3.64:1)
+ *   → 📁 ファイルツリーボタンと同等の視認性
+ * - hover では yellow-400 に遷移し「お気に入り色のプレビュー」のセマンティクスを与える
+ * - お気に入り: text-yellow-500 (明確なアクティブ色)
+ *
+ * group-hover: は削除した (ツールバー全体ホバーで初めて表示される挙動は #143 で否定された)。
+ */
+export const FAVORITE_BUTTON_CLASSES = {
+  /** 非お気に入り時: 📁 と同じ text-text-muted ベース + yellow hover プレビュー */
+  inactive: 'text-text-muted hover:text-yellow-400',
+  /** お気に入り時: 明確な yellow アクティブ色 */
+  active: 'text-yellow-500 hover:text-yellow-400',
+} as const
+
 /** パーティクルの放射角度を計算 */
 export function calculateParticleAngles(count: number): number[] {
   return Array.from({ length: count }, (_, i) => (360 / count) * i)


### PR DESCRIPTION
## Summary
- `FavoriteAnimations.tsx` の ★ボタン非アクティブ時 className を `text-text-muted/30 group-hover:text-text-muted` から `text-text-muted hover:text-yellow-400` に変更
- 30% alpha ブレンド後のコントラスト比 **1.44:1** (WCAG 3:1 未達) → 100% alpha で **3.64:1** (WCAG AA 最小達成)
- className を `favorite-animation-config.ts` の `FAVORITE_BUTTON_CLASSES` 定数に集約し、再発防止テストを追加
- `group-hover:` 廃止 (ツールバー全体ホバー時のみ表示される発見困難パターンの除去)

closes #143

## 設計判断の記録
- **📂コード表示ボタン**: #143 は旧 📂 ボタン透明化も指摘していたが、#166 で 📁 ファイルツリーボタンに置換済みのため本PRでは対応しない
- **MD プレビューボタン追加**: `feedback_preview_design` に従い「📁→ファイルツリー→MD全画面」が設計上の正として確定しているため、ツールバーに MD ボタンは追加しない

## Test plan
- [x] `npx vitest run packages/client` で全 238 件グリーン (新規テスト 7 件追加)
- [x] `FAVORITE_BUTTON_CLASSES.inactive` が以下を満たすことを自動検証
  - [x] `text-transparent` を使わない
  - [x] `text-text-muted/(10|20|30|40|50)` 極薄 opacity を使わない
  - [x] `text-text-muted` を 100% alpha で含む
  - [x] `group-hover:` を使わない
  - [x] `hover:text-yellow-*` への遷移を持つ
- [x] `FAVORITE_BUTTON_CLASSES.active` が `text-yellow-500` を維持することを検証
- [ ] (レビュー後) Playwright / デスクトップアプリで目視確認: 未お気に入りペインでも ★ が発見可能な明度で常時表示されること、ホバーで黄色に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)