### PR TITLE
release: v3.5 — ツールバー改善・キーバインド修正・環境変数リーク修正

### DIFF
--- a/packages/client/src/__tests__/favorite-animations.test.ts
+++ b/packages/client/src/__tests__/favorite-animations.test.ts
@@ -11,6 +11,7 @@ import {
   isSessionVisible,
   shouldBadgeBounce,
   shouldStarburst,
+  FAVORITE_BUTTON_CLASSES,
 } from '../components/animations/favorite-animation-config'
 
 // ===================================================================
@@ -297,5 +298,50 @@ describe('スターバースト発火条件', () => {
 
   it('お気に入り解除時（true→false）にはバーストしない', () => {
     expect(shouldStarburst(true)).toBe(false)
+  })
+})
+
+// ===================================================================
+// お気に入りボタン視認性 className テスト（#143 再発防止）
+// ===================================================================
+describe('FAVORITE_BUTTON_CLASSES（#143 再発防止）', () => {
+  describe('非お気に入り時の className', () => {
+    const inactive = FAVORITE_BUTTON_CLASSES.inactive
+
+    it('text-transparent を使わない（完全不可視の禁止）', () => {
+      expect(inactive).not.toContain('text-transparent')
+    })
+
+    it('極薄 opacity（/10 〜 /50）を使わない（bg-surface-1 で 3:1 未満となるため）', () => {
+      // 旧実装 text-text-muted/30 は実効コントラスト 1.44:1 で WCAG 3:1 未達だった
+      expect(inactive).not.toMatch(/text-text-muted\/(10|20|30|40|50)\b/)
+    })
+
+    it('text-text-muted を 100% alpha で使う（📁 ボタンと同等の視認性）', () => {
+      // Tailwind の class 名として opacity 指定なしの text-text-muted が含まれていること
+      expect(inactive).toMatch(/(^|\s)text-text-muted(\s|$)/)
+    })
+
+    it('group-hover でのみ表示される挙動（発見困難）を使わない', () => {
+      // 旧実装は group-hover:text-text-muted で toolbar 全体ホバー時のみ表示していた
+      expect(inactive).not.toContain('group-hover:')
+    })
+
+    it('hover 時に yellow プレビュー色へ遷移する（お気に入り色の予告）', () => {
+      expect(inactive).toMatch(/hover:text-yellow-\d{3}/)
+    })
+  })
+
+  describe('お気に入り時の className', () => {
+    const active = FAVORITE_BUTTON_CLASSES.active
+
+    it('text-yellow-500 を使う（明確なアクティブ色）', () => {
+      expect(active).toContain('text-yellow-500')
+    })
+
+    it('text-transparent / 極薄 opacity を使わない', () => {
+      expect(active).not.toContain('text-transparent')
+      expect(active).not.toMatch(/text-yellow-500\/(10|20|30|40|50)\b/)
+    })
   })
 })

--- a/packages/client/src/__tests__/pane-toolbar.test.tsx
+++ b/packages/client/src/__tests__/pane-toolbar.test.tsx
@@ -95,17 +95,34 @@ describe('PaneToolbar', () => {
     expect(html).toContain('bg-gray-400')
   })
 
-  it('isActive=true の場合はツールバー背景を bg-surface-2 に切り替える', () => {
+  it('isActive=true の場合はツールバー背景を bg-surface-2 + border-b-accent に切り替える', () => {
     const html = renderHtml({ session: baseSession, isActive: true })
     expect(html).toContain('bg-surface-2')
     expect(html).toContain('border-b-accent')
     expect(html).not.toContain('bg-surface-1')
   })
 
-  it('isActive=false（デフォルト）の場合は bg-surface-1 を使う', () => {
+  it('isActive=false（デフォルト）の場合は bg-surface-1 + border-b-border-light を使う', () => {
     const html = renderHtml({ session: baseSession })
     expect(html).toContain('bg-surface-1')
+    expect(html).toContain('border-b-border-light')
     expect(html).not.toContain('bg-surface-2')
+  })
+
+  it('ツールバー背景はペイン content bg (bg-surface-0) と同じトークンを使わない', () => {
+    // 非アクティブでも surface-0 と同じ色だと視認不能になる（#165 の症状）
+    const htmlInactive = renderHtml({ session: baseSession })
+    const htmlActive = renderHtml({ session: baseSession, isActive: true })
+    expect(htmlInactive).not.toMatch(/\bbg-surface-0\b/)
+    expect(htmlActive).not.toMatch(/\bbg-surface-0\b/)
+  })
+
+  it('下辺は 2px の border-b-2 で分離線を確保する', () => {
+    // 1px では xterm 背景との同化で見えないケースが発生したため border-b-2 に格上げ
+    const htmlInactive = renderHtml({ session: baseSession })
+    const htmlActive = renderHtml({ session: baseSession, isActive: true })
+    expect(htmlInactive).toContain('border-b-2')
+    expect(htmlActive).toContain('border-b-2')
   })
 
   it('ペイン境界強調のため border-x を常時付与する', () => {

--- a/packages/client/src/__tests__/terminal-keybindings.test.ts
+++ b/packages/client/src/__tests__/terminal-keybindings.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { macKeyEventToSequence } from '../utils/terminal-keybindings'
+
+/**
+ * テスト用のイベント生成ヘルパー
+ * macKeyEventToSequenceはtype/metaKey/altKey/ctrlKey/keyしか参照しないため、
+ * jsdom環境なしでプレーンオブジェクトをキャストして注入する
+ */
+function makeEvent(init: {
+  key: string
+  type?: 'keydown' | 'keyup'
+  metaKey?: boolean
+  altKey?: boolean
+  ctrlKey?: boolean
+  shiftKey?: boolean
+}): KeyboardEvent {
+  return {
+    type: init.type ?? 'keydown',
+    key: init.key,
+    metaKey: init.metaKey ?? false,
+    altKey: init.altKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    shiftKey: init.shiftKey ?? false,
+  } as unknown as KeyboardEvent
+}
+
+describe('macKeyEventToSequence', () => {
+  describe('Cmd修飾子（行単位操作）', () => {
+    it('Cmd+Backspace → Ctrl+U (\\x15) 行頭まで削除', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x15')
+    })
+
+    it('Cmd+ArrowLeft → Ctrl+A (\\x01) 行頭へ', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x01')
+    })
+
+    it('Cmd+ArrowRight → Ctrl+E (\\x05) 行末へ', () => {
+      const ev = makeEvent({ key: 'ArrowRight', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x05')
+    })
+
+    it('Cmd+Shift+Backspace（Shift併用）も行頭まで削除', () => {
+      // Shiftはテキスト選択扱いではあるが、xtermバッファ上は選択状態ではないので
+      // 保守的にCmd+Backspaceと同じシーケンスを返す（ユーザー体感優先）
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, shiftKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x15')
+    })
+
+    it('Cmd+任意文字キーは対象外', () => {
+      const ev = makeEvent({ key: 'c', metaKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('Opt修飾子（単語単位操作）', () => {
+    it('Opt+Backspace → Ctrl+W (\\x17) 単語削除', () => {
+      const ev = makeEvent({ key: 'Backspace', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x17')
+    })
+
+    it('Opt+ArrowLeft → ESC+b (\\x1bb) 前単語へ', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x1bb')
+    })
+
+    it('Opt+ArrowRight → ESC+f (\\x1bf) 次単語へ', () => {
+      const ev = makeEvent({ key: 'ArrowRight', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBe('\x1bf')
+    })
+
+    it('Opt+文字キー（å入力）は委譲する', () => {
+      // xtermのデフォルト挙動で特殊文字入力させたいのでnullを返す
+      const ev = makeEvent({ key: 'b', altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('プラットフォーム/イベント種別の除外', () => {
+    it('isMac=falseでは常にnull（Cmd+Backspace）', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true })
+      expect(macKeyEventToSequence(ev, false)).toBeNull()
+    })
+
+    it('isMac=falseでは常にnull（Opt+ArrowLeft）', () => {
+      const ev = makeEvent({ key: 'ArrowLeft', altKey: true })
+      expect(macKeyEventToSequence(ev, false)).toBeNull()
+    })
+
+    it('keyupイベントは対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, type: 'keyup' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+
+  describe('修飾子なし/複合修飾子', () => {
+    it('修飾子なしBackspaceは委譲（通常の1文字削除）', () => {
+      const ev = makeEvent({ key: 'Backspace' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Cmd+Ctrl+Backspace（複合）は対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, ctrlKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Cmd+Opt+Backspace（複合）は対象外', () => {
+      const ev = makeEvent({ key: 'Backspace', metaKey: true, altKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('Ctrl+Backspace単独は対象外（Ctrlはxtermネイティブで処理される）', () => {
+      const ev = makeEvent({ key: 'Backspace', ctrlKey: true })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+
+    it('修飾子なしArrowLeftは委譲', () => {
+      const ev = makeEvent({ key: 'ArrowLeft' })
+      expect(macKeyEventToSequence(ev, true)).toBeNull()
+    })
+  })
+})

--- a/packages/client/src/__tests__/v2-stack-upgrade.test.ts
+++ b/packages/client/src/__tests__/v2-stack-upgrade.test.ts
@@ -109,6 +109,55 @@ describe('v2 ダークテーマ CSS設定', () => {
     expect(indexCss).toContain('--color-tile-header')
     expect(indexCss).toContain('--color-tile-border')
   })
+
+  // #175 の再発防止:
+  // surface-N は純粋な elevation ラダーでなければならない（N が大きいほど明るい）。
+  // 過去に surface-1 (#0b0f13) が surface-0 (#0f1419) より暗く設定されており、
+  // ペインツールバーが視覚的に消えるバグ (#165 -> #175) が発生した。
+  describe('surface カラースケールが luminance 昇順のラダーになっている', () => {
+    /** #rrggbb を相対輝度 (WCAG 相当の簡易版) に変換する */
+    function parseLuminance(hex: string): number {
+      const m = hex.match(/^#([0-9a-f]{6})$/i)
+      if (!m) throw new Error(`invalid hex: ${hex}`)
+      const n = parseInt(m[1], 16)
+      const r = ((n >> 16) & 0xff) / 255
+      const g = ((n >> 8) & 0xff) / 255
+      const b = (n & 0xff) / 255
+      // sRGB → 線形化してから Rec.709 重み付けで輝度を求める
+      const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4)
+      return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    }
+
+    /** index.css から --color-<name> の #rrggbb 値を抽出 */
+    function extractColor(css: string, name: string): string {
+      const re = new RegExp(`--color-${name}:\\s*(#[0-9a-f]{6})`, 'i')
+      const m = css.match(re)
+      if (!m) throw new Error(`token not found: ${name}`)
+      return m[1]
+    }
+
+    it('surface-0 < surface-1 < surface-2 < surface-3 の luminance 順である', () => {
+      const s0 = parseLuminance(extractColor(indexCss, 'surface-0'))
+      const s1 = parseLuminance(extractColor(indexCss, 'surface-1'))
+      const s2 = parseLuminance(extractColor(indexCss, 'surface-2'))
+      const s3 = parseLuminance(extractColor(indexCss, 'surface-3'))
+      expect(s1).toBeGreaterThan(s0)
+      expect(s2).toBeGreaterThan(s1)
+      expect(s3).toBeGreaterThan(s2)
+    })
+
+    it('dark chrome 用途のトークン --color-chrome が定義されている', () => {
+      // Sidebar/ActivityBar/StatusBar/Overlay 等の content より暗い shell 色は
+      // surface ラダーから独立した chrome トークンで扱う
+      expect(indexCss).toMatch(/--color-chrome:\s*#[0-9a-f]{6}/i)
+    })
+
+    it('--color-chrome は surface-0 (content bg) より暗い', () => {
+      const content = parseLuminance(extractColor(indexCss, 'surface-0'))
+      const chrome = parseLuminance(extractColor(indexCss, 'chrome'))
+      expect(chrome).toBeLessThan(content)
+    })
+  })
 })
 
 describe('v2 アニメーション設定のframer-motion v12互換性', () => {

--- a/packages/client/src/components/animations/FavoriteAnimations.tsx
+++ b/packages/client/src/components/animations/FavoriteAnimations.tsx
@@ -11,6 +11,7 @@ import {
   badgeBounceVariants,
   shouldStarburst,
   shouldBadgeBounce,
+  FAVORITE_BUTTON_CLASSES,
 } from './favorite-animation-config'
 
 // 設定・ロジックを再エクスポート（Sidebar等から参照）
@@ -23,6 +24,7 @@ export {
   gatherVariants,
   disperseVariants,
   badgeBounceVariants,
+  FAVORITE_BUTTON_CLASSES,
 } from './favorite-animation-config'
 
 // --- コンポーネント ---
@@ -85,13 +87,13 @@ export function AnimatedFavoriteButton({
     }
   }, [showBurst])
 
+  // #143: 非お気に入り時の className は定数化し、3:1 未満の極薄色を再び入れないよう
+  // 回帰テストで固定する (favorite-animations.test.ts)
   return (
     <span
       onClick={handleClick}
       className={`relative flex-shrink-0 transition-colors cursor-pointer ${
-        isFavorite
-          ? 'text-yellow-500'
-          : 'text-text-muted/30 group-hover:text-text-muted'
+        isFavorite ? FAVORITE_BUTTON_CLASSES.active : FAVORITE_BUTTON_CLASSES.inactive
       }`}
       title={isFavorite ? 'お気に入り解除' : 'お気に入りに追加'}
       data-testid="favorite-button"

--- a/packages/client/src/components/animations/favorite-animation-config.ts
+++ b/packages/client/src/components/animations/favorite-animation-config.ts
@@ -8,6 +8,29 @@
 /** スターバーストのパーティクル数 */
 export const STARBURST_PARTICLE_COUNT = 8
 
+/**
+ * お気に入りボタンの className 定数
+ *
+ * #143 再発防止:
+ * 旧実装では非お気に入り時に `text-text-muted/30 group-hover:text-text-muted` を使用していたが、
+ * 30% alpha を bg-surface-1 (#151b22) とブレンドすると実効コントラスト比 ≈ 1.44:1 となり
+ * WCAG 2.1 UI コンポーネント最低 3:1 を大きく下回り、ボタンが「発見できない」状態になっていた。
+ *
+ * 本定数では以下を保証する:
+ * - 非お気に入り: text-text-muted (#64748b) を 100% alpha で使用 (bg-surface-1 上 3.64:1)
+ *   → 📁 ファイルツリーボタンと同等の視認性
+ * - hover では yellow-400 に遷移し「お気に入り色のプレビュー」のセマンティクスを与える
+ * - お気に入り: text-yellow-500 (明確なアクティブ色)
+ *
+ * group-hover: は削除した (ツールバー全体ホバーで初めて表示される挙動は #143 で否定された)。
+ */
+export const FAVORITE_BUTTON_CLASSES = {
+  /** 非お気に入り時: 📁 と同じ text-text-muted ベース + yellow hover プレビュー */
+  inactive: 'text-text-muted hover:text-yellow-400',
+  /** お気に入り時: 明確な yellow アクティブ色 */
+  active: 'text-yellow-500 hover:text-yellow-400',
+} as const
+
 /** パーティクルの放射角度を計算 */
 export function calculateParticleAngles(count: number): number[] {
   return Array.from({ length: count }, (_, i) => (360 / count) * i)

--- a/packages/client/src/components/board/BoardCanvas.tsx
+++ b/packages/client/src/components/board/BoardCanvas.tsx
@@ -407,7 +407,7 @@ function BoardCanvasInner() {
       )}
 
       {zoomIndicator !== null && (
-        <div className="absolute bottom-4 right-4 px-3 py-1.5 bg-surface-1/90 border border-border rounded-lg text-xs text-text-secondary font-mono animate-fade-in pointer-events-none z-10">
+        <div className="absolute bottom-4 right-4 px-3 py-1.5 bg-chrome/90 border border-border rounded-lg text-xs text-text-secondary font-mono animate-fade-in pointer-events-none z-10">
           {zoomIndicator}%
         </div>
       )}

--- a/packages/client/src/components/board/CanvasToolbar.tsx
+++ b/packages/client/src/components/board/CanvasToolbar.tsx
@@ -39,7 +39,7 @@ export function CanvasToolbar({
   const isFiltered = filter.favoritesOnly || filter.status !== 'all' || filter.projectId !== null
 
   return (
-    <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-surface-1/90 backdrop-blur-sm border border-border rounded-lg px-2 py-1.5 shadow-lg">
+    <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-chrome/90 backdrop-blur-sm border border-border rounded-lg px-2 py-1.5 shadow-lg">
       {/* フィルタボタン */}
       <div className="relative">
         <button
@@ -56,7 +56,7 @@ export function CanvasToolbar({
 
         {/* フィルタドロップダウン */}
         {showFilters && (
-          <div className="absolute top-full left-0 mt-1 bg-surface-1 border border-border rounded-lg shadow-xl p-3 min-w-[200px] space-y-3">
+          <div className="absolute top-full left-0 mt-1 bg-chrome border border-border rounded-lg shadow-xl p-3 min-w-[200px] space-y-3">
             {/* お気に入りフィルタ */}
             <label className="flex items-center gap-2 text-xs text-text-primary cursor-pointer">
               <input

--- a/packages/client/src/components/board/ContextMenu.tsx
+++ b/packages/client/src/components/board/ContextMenu.tsx
@@ -54,7 +54,7 @@ export function NodeContextMenu({
   return (
     <div
       ref={menuRef}
-      className="fixed bg-surface-1 border border-border rounded-lg shadow-xl py-1 z-[100] min-w-[180px]"
+      className="fixed bg-chrome border border-border rounded-lg shadow-xl py-1 z-[100] min-w-[180px]"
       style={{ left: position.x, top: position.y }}
     >
       {isRenaming ? (
@@ -151,7 +151,7 @@ export function CanvasContextMenu({
   return (
     <div
       ref={menuRef}
-      className="fixed bg-surface-1 border border-border rounded-lg shadow-xl py-1 z-[100] min-w-[180px]"
+      className="fixed bg-chrome border border-border rounded-lg shadow-xl py-1 z-[100] min-w-[180px]"
       style={{ left: position.x, top: position.y }}
     >
       <MenuItem

--- a/packages/client/src/components/command-palette/CommandPalette.tsx
+++ b/packages/client/src/components/command-palette/CommandPalette.tsx
@@ -131,7 +131,7 @@ export function CommandPalette() {
       <div className="absolute inset-0 bg-black/40" />
 
       <div
-        className="relative w-full max-w-[600px] bg-surface-1 rounded-lg shadow-2xl border border-border overflow-hidden animate-slide-down"
+        className="relative w-full max-w-[600px] bg-chrome rounded-lg shadow-2xl border border-border overflow-hidden animate-slide-down"
         style={{ maxHeight: '60vh' }}
         onClick={e => e.stopPropagation()}
       >

--- a/packages/client/src/components/feedback/FeedbackPanel.tsx
+++ b/packages/client/src/components/feedback/FeedbackPanel.tsx
@@ -67,7 +67,7 @@ export function FeedbackPanel({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" onClick={onClose}>
       <div
-        className="bg-surface-1 rounded-lg shadow-xl w-[640px] max-h-[80vh] flex flex-col"
+        className="bg-chrome rounded-lg shadow-xl w-[640px] max-h-[80vh] flex flex-col"
         onClick={e => e.stopPropagation()}
       >
         {/* ヘッダー */}
@@ -154,7 +154,7 @@ export function FeedbackPanel({ onClose }: { onClose: () => void }) {
           ) : (
             <div className="divide-y divide-border">
               {feedbackList.map(fb => (
-                <div key={fb.id} className="px-5 py-3 hover:bg-surface-1 transition-colors group" data-testid="feedback-item">
+                <div key={fb.id} className="px-5 py-3 hover:bg-chrome transition-colors group" data-testid="feedback-item">
                   <div className="flex items-start gap-2">
                     <span className="text-sm flex-shrink-0">{categoryIcon(fb.category)}</span>
                     <div className="flex-1 min-w-0">

--- a/packages/client/src/components/layout/PanelContainer.tsx
+++ b/packages/client/src/components/layout/PanelContainer.tsx
@@ -61,7 +61,7 @@ export function PanelContainer() {
   return (
     <div className="flex flex-col h-full">
       {/* 自動整列ボタン */}
-      <div className="flex items-center gap-1 px-2 py-1 bg-surface-1 border-b border-border">
+      <div className="flex items-center gap-1 px-2 py-1 bg-chrome border-b border-border">
         <span className="text-xs text-text-muted mr-1">配置:</span>
         {AUTO_LAYOUT_OPTIONS.map(({ mode: layoutMode, label }) => (
           <button

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -252,7 +252,7 @@ export function Sidebar() {
   )
 
   return (
-    <div className="w-60 bg-surface-1 border-r border-border flex flex-col h-full">
+    <div className="w-60 bg-chrome border-r border-border flex flex-col h-full">
       <div className="px-3 py-2.5 border-b border-border flex items-center justify-between">
         <h1 className="text-sm font-bold text-text-primary">Kurimats</h1>
         <button

--- a/packages/client/src/components/layout/StatusBar.tsx
+++ b/packages/client/src/components/layout/StatusBar.tsx
@@ -10,7 +10,7 @@ export function StatusBar() {
   const paneCount = activeWs ? countLeaves(activeWs.paneTree) : 0
 
   return (
-    <div className="h-7 bg-surface-1 border-t border-border flex items-center px-3 text-[11px] text-text-secondary gap-4">
+    <div className="h-7 bg-chrome border-t border-border flex items-center px-3 text-[11px] text-text-secondary gap-4">
       {/* アクティブワークスペース名 */}
       {activeWs ? (
         <>

--- a/packages/client/src/components/layout/sidebar/SidebarParts.tsx
+++ b/packages/client/src/components/layout/sidebar/SidebarParts.tsx
@@ -131,7 +131,7 @@ export function SidebarCreateSessionForm({
   }
 
   return (
-    <div className="p-3 border-b border-border space-y-2 bg-surface-1">
+    <div className="p-3 border-b border-border space-y-2 bg-chrome">
       <input
         type="text"
         placeholder="セッション名"

--- a/packages/client/src/components/navigator/ActivityBar.tsx
+++ b/packages/client/src/components/navigator/ActivityBar.tsx
@@ -32,7 +32,7 @@ export function ActivityBar({ activeSection, onSectionToggle, totalNotifications
   ]
 
   return (
-    <div className="w-12 h-full bg-surface-1 border-r border-border flex flex-col items-center py-2 flex-shrink-0">
+    <div className="w-12 h-full bg-chrome border-r border-border flex flex-col items-center py-2 flex-shrink-0">
       {/* 上部アイコン */}
       <div className="flex flex-col items-center gap-1">
         {items.map(item => (

--- a/packages/client/src/components/navigator/WorkspaceItem.tsx
+++ b/packages/client/src/components/navigator/WorkspaceItem.tsx
@@ -155,7 +155,7 @@ function WorkspaceContextMenu({
       {/* 背景クリックで閉じる */}
       <div className="fixed inset-0 z-40" onClick={onClose} />
 
-      <div className="absolute right-0 top-full z-50 bg-surface-1 border border-border
+      <div className="absolute right-0 top-full z-50 bg-chrome border border-border
                       rounded shadow-lg py-1 min-w-36">
         <button
           className="w-full px-3 py-1 text-xs text-text-primary hover:bg-surface-2 text-left"

--- a/packages/client/src/components/navigator/WorkspaceNavigator.tsx
+++ b/packages/client/src/components/navigator/WorkspaceNavigator.tsx
@@ -125,7 +125,7 @@ export function WorkspaceNavigator({ activeSection }: WorkspaceNavigatorProps) {
     : 'ワークスペース'
 
   return (
-    <div className="w-60 h-full bg-surface-1 border-r border-border flex flex-col flex-shrink-0">
+    <div className="w-60 h-full bg-chrome border-r border-border flex flex-col flex-shrink-0">
       {/* ヘッダー */}
       <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
         <span className="text-xs font-medium text-text-primary uppercase tracking-wider">

--- a/packages/client/src/components/notifications/NotificationToast.tsx
+++ b/packages/client/src/components/notifications/NotificationToast.tsx
@@ -18,7 +18,7 @@ export function NotificationToast() {
       {unread.length > 1 && (
         <button
           onClick={clearNotifications}
-          className="self-end text-[10px] text-text-muted hover:text-text-secondary px-2 py-0.5 bg-surface-1 rounded border border-border transition-colors"
+          className="self-end text-[10px] text-text-muted hover:text-text-secondary px-2 py-0.5 bg-chrome rounded border border-border transition-colors"
         >
           全て閉じる
         </button>
@@ -27,7 +27,7 @@ export function NotificationToast() {
       {unread.slice(0, 5).map(notification => (
         <div
           key={notification.id}
-          className="bg-surface-1 border border-accent/30 rounded-lg shadow-lg p-3 flex items-start gap-2 animate-slide-in"
+          className="bg-chrome border border-accent/30 rounded-lg shadow-lg p-3 flex items-start gap-2 animate-slide-in"
         >
           <span className="text-accent text-sm flex-shrink-0 mt-0.5">●</span>
           <div className="flex-1 min-w-0">

--- a/packages/client/src/components/overlays/CodeViewerOverlay.tsx
+++ b/packages/client/src/components/overlays/CodeViewerOverlay.tsx
@@ -63,7 +63,7 @@ export function CodeViewerOverlay({ filePath, onClose, sshHost }: Props) {
     <OverlayContainer isOpen={true} onClose={onClose} title={fileName}>
       <div className="flex flex-col h-full">
         {/* ツールバー */}
-        <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-surface-1">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-chrome">
           <span className="text-xs text-text-muted truncate flex-1">{filePath}</span>
           <div className="flex items-center gap-2 ml-4">
             <button

--- a/packages/client/src/components/overlays/FileTreeOverlay.tsx
+++ b/packages/client/src/components/overlays/FileTreeOverlay.tsx
@@ -64,7 +64,7 @@ export function FileTreeOverlay({ onClose }: Props) {
       <div className="flex flex-col h-full">
         {/* 作業ディレクトリ表示 */}
         {workingDir && (
-          <div className="px-4 py-2 text-xs text-text-muted bg-surface-1 border-b border-border truncate">
+          <div className="px-4 py-2 text-xs text-text-muted bg-chrome border-b border-border truncate">
             {workingDir}
           </div>
         )}
@@ -76,7 +76,7 @@ export function FileTreeOverlay({ onClose }: Props) {
             value={filter}
             onChange={e => setFilter(e.target.value)}
             placeholder="ファイルを検索..."
-            className="w-full px-3 py-1.5 text-sm bg-surface-1 border border-border rounded text-text-primary placeholder-text-muted outline-none focus:border-accent"
+            className="w-full px-3 py-1.5 text-sm bg-chrome border border-border rounded text-text-primary placeholder-text-muted outline-none focus:border-accent"
             autoFocus
           />
         </div>

--- a/packages/client/src/components/overlays/MarkdownOverlay.tsx
+++ b/packages/client/src/components/overlays/MarkdownOverlay.tsx
@@ -110,7 +110,7 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen, ss
     <OverlayContainer isOpen={true} onClose={onClose} title="Markdown プレビュー" fullScreen={fullScreen}>
       <div className="flex flex-col h-full">
         {/* ファイルパス入力 */}
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-1">
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-chrome">
           <input
             type="text"
             value={filePath}
@@ -151,7 +151,7 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen, ss
                   <textarea
                     value={content}
                     onChange={e => handleContentChange(e.target.value)}
-                    className="w-full h-full p-4 text-sm font-mono text-text-primary bg-surface-1 resize-none outline-none custom-scrollbar"
+                    className="w-full h-full p-4 text-sm font-mono text-text-primary bg-chrome resize-none outline-none custom-scrollbar"
                     spellCheck={false}
                   />
                 </div>
@@ -163,8 +163,8 @@ export function MarkdownOverlay({ onClose, filePath: initialPath, fullScreen, ss
                   prose-headings:text-text-primary prose-headings:font-semibold
                   prose-p:text-text-primary prose-p:leading-relaxed
                   prose-a:text-accent prose-a:no-underline hover:prose-a:underline
-                  prose-code:text-accent prose-code:bg-surface-1 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
-                  prose-pre:bg-surface-1 prose-pre:border prose-pre:border-border
+                  prose-code:text-accent prose-code:bg-chrome prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+                  prose-pre:bg-chrome prose-pre:border prose-pre:border-border
                   prose-blockquote:border-accent prose-blockquote:text-text-secondary
                   prose-strong:text-text-primary
                   prose-li:text-text-primary

--- a/packages/client/src/components/overlays/OverlayContainer.tsx
+++ b/packages/client/src/components/overlays/OverlayContainer.tsx
@@ -39,7 +39,7 @@ export function OverlayContainer({ isOpen, onClose, title, children, fullScreen 
       {/* パネル */}
       <div
         ref={panelRef}
-        className={`relative h-full bg-surface-1 shadow-2xl flex flex-col animate-slide-in ${
+        className={`relative h-full bg-chrome shadow-2xl flex flex-col animate-slide-in ${
           fullScreen ? 'w-full' : 'w-1/2 max-w-[700px] min-w-[400px]'
         }`}
       >

--- a/packages/client/src/components/panes/PaneContextMenu.tsx
+++ b/packages/client/src/components/panes/PaneContextMenu.tsx
@@ -91,7 +91,7 @@ export function PaneContextMenu({ paneId, x, y, onClose }: PaneContextMenuProps)
   return (
     <div
       ref={menuRef}
-      className="fixed z-[100] bg-surface-1 border border-border rounded-lg shadow-lg py-1 min-w-48"
+      className="fixed z-[100] bg-chrome border border-border rounded-lg shadow-lg py-1 min-w-48"
       style={{ left: adjustedPos.x, top: adjustedPos.y }}
     >
       {items.map((item, i) =>

--- a/packages/client/src/components/panes/PaneToolbar.tsx
+++ b/packages/client/src/components/panes/PaneToolbar.tsx
@@ -29,15 +29,17 @@ export function PaneToolbar({ session, isActive = false }: PaneToolbarProps) {
     openOverlay('file-tree', { sessionId: session.id })
   }, [openOverlay, session.id])
 
-  // アクティブ/非アクティブで背景色と下線を切替。
-  // ペイン境界の視認性向上のため border-x を常時付与する。
+  // アクティブ/非アクティブで背景色と下線色を切替。
+  // - 背景は surface-0 (content) より一段明るい surface-1/2 を使い、バー本体を視認可能にする
+  // - 下辺は border-b-2 に格上げし、accent / border-light の 2px ラインで分離線として機能させる
+  // - ペイン境界の視認性向上のため border-x も常時付与する
   const activeClasses = isActive
     ? 'bg-surface-2 border-b-accent'
-    : 'bg-surface-1 border-b-border'
+    : 'bg-surface-1 border-b-border-light'
 
   return (
     <div
-      className={`group flex items-center gap-1 border-x border-b border-x-border px-2 h-6 flex-shrink-0 transition-colors ${activeClasses}`}
+      className={`group flex items-center gap-1 border-x border-b-2 border-x-border px-2 h-6 flex-shrink-0 transition-colors ${activeClasses}`}
       data-testid="pane-toolbar"
     >
       {/* ステータスインジケータ */}

--- a/packages/client/src/components/project/ProjectSettingsPanel.tsx
+++ b/packages/client/src/components/project/ProjectSettingsPanel.tsx
@@ -45,7 +45,7 @@ export function ProjectSettingsPanel({ project, onClose, onUpdated }: Props) {
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" onClick={onClose}>
       <div
-        className="bg-surface-1 rounded-lg shadow-xl w-[480px] max-h-[70vh] flex flex-col"
+        className="bg-chrome rounded-lg shadow-xl w-[480px] max-h-[70vh] flex flex-col"
         onClick={e => e.stopPropagation()}
       >
         {/* ヘッダー */}

--- a/packages/client/src/hooks/useTerminalWs.ts
+++ b/packages/client/src/hooks/useTerminalWs.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import type { ClientTerminalMessage, ServerTerminalMessage } from '@kurimats/shared'
+import { isMacPlatform, macKeyEventToSequence } from '../utils/terminal-keybindings'
 
 /**
  * ターミナルWebSocket接続フック
@@ -72,20 +73,44 @@ export function useTerminalWs(sessionId: string | null, terminal: Terminal | nul
     }
   }, [sessionId, terminal])
 
+  // 入力送信ヘルパー（onDataとキーバインドハンドラの両方から使う）
+  const sendInput = useCallback((data: string) => {
+    const ws = wsRef.current
+    if (ws?.readyState === WebSocket.OPEN) {
+      const msg: ClientTerminalMessage = { type: 'input', data }
+      ws.send(JSON.stringify(msg))
+    }
+  }, [])
+
   // 入力送信
   useEffect(() => {
     if (!terminal || !sessionId) return
 
-    const disposable = terminal.onData((data) => {
-      const ws = wsRef.current
-      if (ws?.readyState === WebSocket.OPEN) {
-        const msg: ClientTerminalMessage = { type: 'input', data }
-        ws.send(JSON.stringify(msg))
-      }
-    })
+    const disposable = terminal.onData(sendInput)
 
     return () => disposable.dispose()
-  }, [terminal, sessionId])
+  }, [terminal, sessionId, sendInput])
+
+  // mac風キーバインド（Cmd/Opt + Backspace/矢印）をPTY制御シーケンスに変換
+  // xterm.jsはmetaKey付きキーをブラウザに委ねるためデフォルトではPTYに届かない。
+  // attachCustomKeyEventHandlerで該当キーを拾い、sendInput経由で直接送信する。
+  useEffect(() => {
+    if (!terminal) return
+    const isMac = isMacPlatform()
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      const seq = macKeyEventToSequence(event, isMac)
+      if (seq === null) return true // 対象外キーはxtermのデフォルト処理に委ねる
+      event.preventDefault()
+      sendInput(seq)
+      return false // xtermの以後の処理を抑制
+    })
+
+    return () => {
+      // クリーンアップ時はno-opハンドラに戻す（dispose前の二重処理防止）
+      terminal.attachCustomKeyEventHandler(() => true)
+    }
+  }, [terminal, sendInput])
 
   // リサイズ送信
   useEffect(() => {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -2,11 +2,16 @@
 
 /* Collaboratorスタイル ダークテーマ */
 @theme {
-  /* 背景色（チャコール/スレート系） */
+  /* 背景色（チャコール/スレート系）
+     surface-N は純粋な elevation ラダー: N が大きいほど明るい（luminance 昇順）
+     サイドバー等の "dark chrome / popover" 用途は --color-chrome を使う */
   --color-surface-0: #0f1419;
-  --color-surface-1: #0b0f13;
+  --color-surface-1: #151b22;
   --color-surface-2: #1a2332;
   --color-surface-3: #243044;
+
+  /* ダーク chrome（Sidebar/ActivityBar/StatusBar/Overlay 等の content より暗い shell 色） */
+  --color-chrome: #0b0f13;
 
   /* アクセント（ティール/グリーン系） */
   --color-accent: #2dd4bf;

--- a/packages/client/src/utils/terminal-keybindings.ts
+++ b/packages/client/src/utils/terminal-keybindings.ts
@@ -1,0 +1,79 @@
+/**
+ * macOS風キーバインドをターミナル制御シーケンスに変換するユーティリティ
+ *
+ * xterm.jsはデフォルトでmetaKey（Cmd）付きのキーをブラウザ/OSに委ね、
+ * altKey付きの文字キーも特殊文字入力として扱うため、Terminal.app/iTerm2が
+ * 行っているような行編集ショートカットがPTYに届かない。
+ * この関数で必要なキーだけを拾い、readline互換の制御シーケンスに変換する。
+ */
+
+/**
+ * macOSプラットフォーム判定
+ * Electron/Chromiumどちらからも確実に判定できるようplatform/userAgentを両方見る
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const platform = (navigator as Navigator & { platform?: string }).platform ?? ''
+  if (/Mac/i.test(platform)) return true
+  return /Mac/i.test(navigator.userAgent)
+}
+
+/**
+ * KeyboardEventをターミナルへ送る制御シーケンスに変換する
+ *
+ * - nullを返した場合、呼び出し側は xterm.js のデフォルト処理に委ねること
+ * - 文字列を返した場合、呼び出し側でWebSocket経由でPTYへ送信し、
+ *   xterm.js のデフォルト処理を抑制すること（attachCustomKeyEventHandlerなら false を返す）
+ *
+ * 変換対象（macのみ）:
+ * | 入力          | 出力     | 意味                       |
+ * |---------------|----------|---------------------------|
+ * | Cmd+Backspace | \x15     | Ctrl+U カーソルから行頭まで削除 |
+ * | Cmd+←         | \x01     | Ctrl+A 行頭へ移動          |
+ * | Cmd+→         | \x05     | Ctrl+E 行末へ移動          |
+ * | Opt+Backspace | \x17     | Ctrl+W 前方の単語を削除     |
+ * | Opt+←         | \x1bb    | ESC+b 前方の単語へ移動      |
+ * | Opt+→         | \x1bf    | ESC+f 次の単語へ移動        |
+ *
+ * Opt+文字キー（Opt+b → å 等）は意図的に対象外。xtermのデフォルトに委ね、
+ * 特殊文字入力ユースケースを温存する。
+ */
+export function macKeyEventToSequence(
+  event: KeyboardEvent,
+  isMac: boolean,
+): string | null {
+  if (!isMac) return null
+  if (event.type !== 'keydown') return null
+
+  const { metaKey, altKey, ctrlKey, key } = event
+
+  // Cmd単独（Ctrl/Alt併用は対象外） → 行頭/行末/行頭まで削除
+  if (metaKey && !altKey && !ctrlKey) {
+    switch (key) {
+      case 'Backspace':
+        return '\x15' // Ctrl+U: 行頭まで削除
+      case 'ArrowLeft':
+        return '\x01' // Ctrl+A: 行頭へ
+      case 'ArrowRight':
+        return '\x05' // Ctrl+E: 行末へ
+      default:
+        return null
+    }
+  }
+
+  // Opt(Alt)単独（Cmd/Ctrl併用は対象外） → 単語削除/単語移動
+  if (altKey && !metaKey && !ctrlKey) {
+    switch (key) {
+      case 'Backspace':
+        return '\x17' // Ctrl+W: 前方の単語を削除
+      case 'ArrowLeft':
+        return '\x1bb' // ESC+b: 前方の単語へ
+      case 'ArrowRight':
+        return '\x1bf' // ESC+f: 次の単語へ
+      default:
+        return null
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
closes #180

## 含まれる変更

- fix: ★お気に入りボタン非アクティブ時の視認性を WCAG 3:1 まで改善 (#143)
- fix: surface スケールを elevation ラダーに修復しペインツールバーを視認可能に (#175)
- fix: ターミナルでmac風キーバインドを一式サポート (#161)
- feat: PaneToolbar に 📁ファイルツリーボタンを追加 (#166)
- feat: PaneToolbar視認性改善（★常時表示・ペイン境界・アクティブ強調）(#165)
- fix: ペイン分割時の番号割当を空き番号方式に変更 (#145)
- fix: PTYがCMUX_*環境変数を子shellにリークしてworktree cwdが上書きされる問題を修正 (#159)
- chore: Playwright MCP を launchd 常駐 + HTTP 接続方式に移行 (#157)
- chore: PR作成/マージ時にPlaywright動作確認を強制するhookを追加 (#155)
- fix: フィードバックボタンが反応しない問題を修正 (#153)

## 動作確認

- [ ] DMGインストール後 `/Applications/kurimats.app` から起動確認
- [ ] API疎通確認（`curl http://localhost:13001/api/ssh/hosts`）
- [ ] ワークスペース作成・ペイン分割の基本操作
- [ ] ツールバーボタン（お気に入り・ファイルツリー）の視認性・操作
- [ ] ターミナルmacキーバインド動作