### PR TITLE
feat(server/electron): LeaderLock — 重複起動防止の二層ロック (closes #183)

### DIFF
--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -89,6 +89,13 @@ function waitForUrl(url: string, retries: number, intervalMs: number): Promise<v
   })
 }
 
+// Electron single-instance lock: 二重起動を防止
+const gotTheLock = app.requestSingleInstanceLock()
+if (!gotTheLock) {
+  console.log('⚠️ 別の kurimats インスタンスが既に起動中です。終了します。')
+  app.quit()
+}
+
 // 設定ストア
 const store = new Store()
 
@@ -175,6 +182,14 @@ function setupMenu(): void {
   const menu = Menu.buildFromTemplate(template as any)
   Menu.setApplicationMenu(menu)
 }
+
+// 2回目の起動試行時: 既存ウィンドウにフォーカス
+app.on('second-instance', () => {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    mainWindow.focus()
+  }
+})
 
 // アプリケーション起動
 app.whenReady().then(async () => {

--- a/packages/server/src/__tests__/leader-lock.test.ts
+++ b/packages/server/src/__tests__/leader-lock.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, existsSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs'
 import path from 'path'
 import { tmpdir } from 'os'
-import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath } from '../services/leader-lock'
+import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath, registerLockCleanup } from '../services/leader-lock'
 import type { LockInfo } from '../services/leader-lock'
 
 /** テスト用の一時ディレクトリを作成 */
@@ -168,11 +168,57 @@ describe('LeaderLock', () => {
   })
 
   describe('破損した lockfile の処理', () => {
-    it('不正な JSON の lockfile は新規取得として扱われる', () => {
+    it('不正な JSON の lockfile は stale 扱いで新規取得される', () => {
       writeFileSync(lockfilePath, 'not valid json', 'utf-8')
 
       const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
       expect(result.acquired).toBe(true)
+    })
+  })
+
+  describe('原子的取得（排他的作成）', () => {
+    it('lockfile が存在しない場合は排他的作成で一発取得', () => {
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+
+      // lockfile が正しく書かれている
+      const info = readLock(lockfilePath)
+      expect(info!.pid).toBe(process.pid)
+    })
+
+    it('stale lock を unlink → 再度排他的作成で取得', () => {
+      // stale lock を作成（存在しない PID）
+      const staleLock: LockInfo = {
+        pid: 2147483647,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      // 排他的取得 → stale 検出 → unlink → 再取得
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+      expect(readLock(lockfilePath)!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('registerLockCleanup', () => {
+    it('exit イベントのみ登録し SIGINT/SIGTERM ハンドラは登録しない', () => {
+      // registerLockCleanup が SIGINT/SIGTERM を登録しないことを確認
+      // (index.ts の shutdown() が graceful shutdown を担当するため)
+      const exitListenersBefore = process.listenerCount('exit')
+      const sigintListenersBefore = process.listenerCount('SIGINT')
+      const sigtermListenersBefore = process.listenerCount('SIGTERM')
+
+      // 一時的な lockfile で cleanup を登録
+      const tempLockPath = path.join(tempDir, 'cleanup-test.lock')
+      registerLockCleanup({ paneNumber: 99, lockfilePath: tempLockPath })
+
+      expect(process.listenerCount('exit')).toBe(exitListenersBefore + 1)
+      expect(process.listenerCount('SIGINT')).toBe(sigintListenersBefore) // 増えない
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermListenersBefore) // 増えない
     })
   })
 })

--- a/packages/server/src/__tests__/leader-lock.test.ts
+++ b/packages/server/src/__tests__/leader-lock.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, existsSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath } from '../services/leader-lock'
+import type { LockInfo } from '../services/leader-lock'
+
+/** テスト用の一時ディレクトリを作成 */
+function createTempDir(): string {
+  const dir = path.join(tmpdir(), `leader-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('LeaderLock', () => {
+  let tempDir: string
+  let lockfilePath: string
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+    lockfilePath = path.join(tempDir, 'test.lock')
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // テスト後のクリーンアップ失敗は無視
+    }
+  })
+
+  describe('acquireLock / releaseLock 基本サイクル', () => {
+    it('lockfile が存在しない場合に取得成功する', () => {
+      const result = acquireLock({
+        port: 14000,
+        paneNumber: 0,
+        type: 'dev',
+        lockfilePath,
+      })
+
+      expect(result.acquired).toBe(true)
+      expect(existsSync(lockfilePath)).toBe(true)
+
+      // lockfile の内容を確認
+      const info = readLock(lockfilePath)
+      expect(info).not.toBeNull()
+      expect(info!.pid).toBe(process.pid)
+      expect(info!.port).toBe(14000)
+      expect(info!.paneNumber).toBe(0)
+      expect(info!.type).toBe('dev')
+    })
+
+    it('releaseLock で lockfile が削除される', () => {
+      acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(true)
+
+      releaseLock({ paneNumber: 0, lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(false)
+    })
+
+    it('releaseLock は自分の PID でない lock を削除しない', () => {
+      // 他プロセスの lock を偽装
+      const fakeLock: LockInfo = {
+        pid: 999999,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: new Date().toISOString(),
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(fakeLock), 'utf-8')
+
+      // 自分の PID と異なるので削除されない
+      releaseLock({ paneNumber: 0, lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(true)
+    })
+  })
+
+  describe('二重取得の拒否', () => {
+    it('有効な lock が存在する場合に取得失敗する', () => {
+      // 自プロセスの PID で lock を取得（自プロセスは当然生きている）
+      const first = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(first.acquired).toBe(true)
+
+      // 同じ lockfile に対して2回目の取得 → 失敗
+      const second = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(second.acquired).toBe(false)
+      expect(second.existingLock).toBeDefined()
+      expect(second.existingLock!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('stale lock の自動回収', () => {
+    it('存在しない PID の lockfile を上書き取得できる', () => {
+      // 存在しない PID で lock を偽装
+      const staleLock: LockInfo = {
+        pid: 2147483647, // 存在しないPID
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      // stale lock を上書きして取得成功
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+
+      // 新しい lock が自分の PID
+      const info = readLock(lockfilePath)
+      expect(info!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('PANE_NUMBER 別の lock 分離', () => {
+    it('異なる paneNumber の lockfile は独立している', () => {
+      const lockPath0 = path.join(tempDir, 'pane0.lock')
+      const lockPath1 = path.join(tempDir, 'pane1.lock')
+
+      const result0 = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath: lockPath0 })
+      const result1 = acquireLock({ port: 14001, paneNumber: 1, type: 'dev', lockfilePath: lockPath1 })
+
+      expect(result0.acquired).toBe(true)
+      expect(result1.acquired).toBe(true)
+    })
+  })
+
+  describe('isLocked', () => {
+    it('有効な lock が存在する場合に LockInfo を返す', () => {
+      acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+
+      const info = isLocked(0, lockfilePath)
+      expect(info).not.toBeNull()
+      expect(info!.pid).toBe(process.pid)
+    })
+
+    it('lock が存在しない場合に null を返す', () => {
+      const info = isLocked(0, lockfilePath)
+      expect(info).toBeNull()
+    })
+
+    it('stale lock は null を返す', () => {
+      const staleLock: LockInfo = {
+        pid: 2147483647,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      const info = isLocked(0, lockfilePath)
+      expect(info).toBeNull()
+    })
+  })
+
+  describe('getLockfilePath', () => {
+    it('paneNumber=null → server.lock', () => {
+      expect(getLockfilePath(null)).toMatch(/server\.lock$/)
+    })
+
+    it('paneNumber=0 → server-dev.lock', () => {
+      expect(getLockfilePath(0)).toMatch(/server-dev\.lock$/)
+    })
+
+    it('paneNumber=3 → server-pane3.lock', () => {
+      expect(getLockfilePath(3)).toMatch(/server-pane3\.lock$/)
+    })
+  })
+
+  describe('破損した lockfile の処理', () => {
+    it('不正な JSON の lockfile は新規取得として扱われる', () => {
+      writeFileSync(lockfilePath, 'not valid json', 'utf-8')
+
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,7 @@ import { createWorkspacesRouter } from './routes/workspaces.js'
 import { CanvasStore } from './services/canvas-store.js'
 import { SERVER_PORT_BASE, calculatePort } from './utils/ports.js'
 import { runStartupTasks } from './startup.js'
+import { acquireLock, registerLockCleanup } from './services/leader-lock.js'
 
 // PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
 // 設定時は既存PORT環境変数より優先。未設定時のみPORTにフォールバック
@@ -33,6 +34,20 @@ const HOST = process.env.HOST || 'localhost'
 
 // トークン認証（リモートアクセス用、オプション）
 const AUTH_TOKEN = process.env.AUTH_TOKEN || ''
+
+// LeaderLock: 重複サーバー起動を防止
+const lockResult = acquireLock({
+  port: PORT,
+  paneNumber: PANE_NUMBER,
+  type: PANE_NUMBER != null ? 'dev' : 'electron',
+})
+if (!lockResult.acquired) {
+  const info = lockResult.existingLock!
+  console.error(`❌ LeaderLock: サーバーは既に起動中です (PID=${info.pid}, port=${info.port}, 起動=${info.startedAt})`)
+  process.exit(1)
+}
+registerLockCleanup({ paneNumber: PANE_NUMBER })
+console.log(`🔒 LeaderLock: 取得成功 (PID=${process.pid}, port=${PORT})`)
 
 // サービス初期化
 const ptyManager = new PtyManager()

--- a/packages/server/src/services/leader-lock.ts
+++ b/packages/server/src/services/leader-lock.ts
@@ -3,8 +3,11 @@
  *
  * lockfile にはPID・ポート・pane番号・起動時刻を記録し、
  * stale lock の自動回収もサポートする。
+ *
+ * 原子性: openSync('wx') で排他的作成を行い、2プロセス同時起動時の race を防止。
+ * シグナル: 'exit' イベントのみで cleanup。SIGINT/SIGTERM は index.ts の shutdown() に委譲。
  */
-import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, openSync, closeSync, constants } from 'fs'
 import path from 'path'
 import { homedir } from 'os'
 
@@ -35,7 +38,7 @@ export interface LockResult {
 
 /**
  * PANE_NUMBER に応じた lockfile パスを算出
- * DB ファイルと同じディレクトリ（~/.kurimats/）に配���
+ * DB ファイルと同じディレクトリ（~/.kurimats/）に配置
  */
 export function getLockfilePath(paneNumber: number | null): string {
   const baseDir = path.join(homedir(), '.kurimats')
@@ -45,7 +48,7 @@ export function getLockfilePath(paneNumber: number | null): string {
 }
 
 /**
- * PID が生存し��いるかを確認する
+ * PID が生存しているかを確認する
  */
 function isPidAlive(pid: number): boolean {
   try {
@@ -70,11 +73,30 @@ export function readLock(lockfilePath: string): LockInfo | null {
 }
 
 /**
+ * lockfile を排他的に書き込む（openSync 'wx' で原子的作成）
+ * @returns true: 書き込み成功、false: ファイルが既に存在（EEXIST）
+ */
+function writeExclusive(lockfilePath: string, lockInfo: LockInfo): boolean {
+  try {
+    const fd = openSync(lockfilePath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL)
+    const content = JSON.stringify(lockInfo, null, 2)
+    writeFileSync(fd, content, 'utf-8')
+    closeSync(fd)
+    return true
+  } catch (e: any) {
+    if (e.code === 'EEXIST') return false
+    throw e
+  }
+}
+
+/**
  * lock を取得する
  *
- * 1. lockfile が存在しない → 新規作成して取得成功
- * 2. lockfile が存在 + PID が生存 → 取得失敗（既に別インスタンスが稼働中）
- * 3. lockfile が存在 + PID が死亡 → stale lock として上書き取得
+ * 原子性を確保するフロー:
+ * 1. openSync('wx') で排他的作成を試みる → 成功なら取得完了
+ * 2. EEXIST → 既存 lock を読み取り PID 生存チェック
+ * 3. PID 生存 → 取得失敗
+ * 4. PID 死亡（stale） → unlink して再度 openSync('wx') を試みる
  */
 export function acquireLock(options: LockOptions): LockResult {
   const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
@@ -85,18 +107,6 @@ export function acquireLock(options: LockOptions): LockResult {
     mkdirSync(dir, { recursive: true })
   }
 
-  // 既存 lock を確認
-  const existing = readLock(lockfilePath)
-  if (existing) {
-    if (isPidAlive(existing.pid)) {
-      // 有効な lock が存在 → 取得失敗
-      return { acquired: false, existingLock: existing }
-    }
-    // stale lock → 上書き
-    console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing.pid})。上書きします。`)
-  }
-
-  // lockfile を書き込み
   const lockInfo: LockInfo = {
     pid: process.pid,
     port: options.port,
@@ -105,8 +115,34 @@ export function acquireLock(options: LockOptions): LockResult {
     type: options.type,
   }
 
-  writeFileSync(lockfilePath, JSON.stringify(lockInfo, null, 2), 'utf-8')
-  return { acquired: true }
+  // 1回目: 排他的作成を試みる
+  if (writeExclusive(lockfilePath, lockInfo)) {
+    return { acquired: true }
+  }
+
+  // lockfile が既に存在 → 読み取り
+  const existing = readLock(lockfilePath)
+  if (existing && isPidAlive(existing.pid)) {
+    // 有効な lock が存在 → 取得失敗
+    return { acquired: false, existingLock: existing }
+  }
+
+  // stale lock または破損ファイル → 削除して再試行
+  console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing?.pid ?? '不明'})。上書きします。`)
+  try {
+    unlinkSync(lockfilePath)
+  } catch {
+    // 別プロセスが先に消した場合は無視
+  }
+
+  // 2回目: 排他的作成を再試行
+  if (writeExclusive(lockfilePath, lockInfo)) {
+    return { acquired: true }
+  }
+
+  // 2回目も失敗 → 別プロセスが先に取得した
+  const winner = readLock(lockfilePath)
+  return { acquired: false, existingLock: winner ?? undefined }
 }
 
 /**
@@ -139,10 +175,11 @@ export function isLocked(paneNumber: number | null, lockfilePath?: string): Lock
 
 /**
  * process exit 時に lockfile を自動解放するハンドラを登録する
+ *
+ * 注意: SIGINT/SIGTERM ハンドラは登録しない。
+ * index.ts の shutdown() が ptyManager.killAll() 等のグレースフル処理を行った後に
+ * process.exit(0) を呼び、それが 'exit' イベントをトリガーして lock を解放する。
  */
 export function registerLockCleanup(options: { paneNumber: number | null; lockfilePath?: string }): void {
-  const cleanup = () => releaseLock(options)
-  process.on('exit', cleanup)
-  process.on('SIGINT', () => { cleanup(); process.exit(0) })
-  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
+  process.on('exit', () => releaseLock(options))
 }

--- a/packages/server/src/services/leader-lock.ts
+++ b/packages/server/src/services/leader-lock.ts
@@ -1,0 +1,148 @@
+/**
+ * LeaderLock — サーバーインスタンスの重複起動を防止する lockfile 機構
+ *
+ * lockfile にはPID・ポート・pane番号・起動時刻を記録し、
+ * stale lock の自動回収もサポートする。
+ */
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs'
+import path from 'path'
+import { homedir } from 'os'
+
+/** lockfile に記録する情報 */
+export interface LockInfo {
+  pid: number
+  port: number
+  paneNumber: number | null
+  startedAt: string
+  type: 'electron' | 'dev'
+}
+
+/** lock 取得オプション */
+export interface LockOptions {
+  port: number
+  paneNumber: number | null
+  type: 'electron' | 'dev'
+  /** lockfile パスを直接指定（テスト用） */
+  lockfilePath?: string
+}
+
+/** lock 取得結果 */
+export interface LockResult {
+  acquired: boolean
+  /** 取得失敗時: 既存 lock の情報 */
+  existingLock?: LockInfo
+}
+
+/**
+ * PANE_NUMBER に応じた lockfile パスを算出
+ * DB ファイルと同じディレクトリ（~/.kurimats/）に配���
+ */
+export function getLockfilePath(paneNumber: number | null): string {
+  const baseDir = path.join(homedir(), '.kurimats')
+  if (paneNumber === null) return path.join(baseDir, 'server.lock')
+  if (paneNumber === 0) return path.join(baseDir, 'server-dev.lock')
+  return path.join(baseDir, `server-pane${paneNumber}.lock`)
+}
+
+/**
+ * PID が生存し��いるかを確認する
+ */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 既存の lockfile を読み取る
+ * @returns LockInfo または null（ファイルなし・パースエラー時）
+ */
+export function readLock(lockfilePath: string): LockInfo | null {
+  try {
+    const content = readFileSync(lockfilePath, 'utf-8')
+    return JSON.parse(content) as LockInfo
+  } catch {
+    return null
+  }
+}
+
+/**
+ * lock を取得する
+ *
+ * 1. lockfile が存在しない → 新規作成して取得成功
+ * 2. lockfile が存在 + PID が生存 → 取得失敗（既に別インスタンスが稼働中）
+ * 3. lockfile が存在 + PID が死亡 → stale lock として上書き取得
+ */
+export function acquireLock(options: LockOptions): LockResult {
+  const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
+  const dir = path.dirname(lockfilePath)
+
+  // ディレクトリがなければ作成
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  // 既存 lock を確認
+  const existing = readLock(lockfilePath)
+  if (existing) {
+    if (isPidAlive(existing.pid)) {
+      // 有効な lock が存在 → 取得失敗
+      return { acquired: false, existingLock: existing }
+    }
+    // stale lock → 上書き
+    console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing.pid})。上書きします。`)
+  }
+
+  // lockfile を書き込み
+  const lockInfo: LockInfo = {
+    pid: process.pid,
+    port: options.port,
+    paneNumber: options.paneNumber,
+    startedAt: new Date().toISOString(),
+    type: options.type,
+  }
+
+  writeFileSync(lockfilePath, JSON.stringify(lockInfo, null, 2), 'utf-8')
+  return { acquired: true }
+}
+
+/**
+ * lock を解放する（lockfile を削除）
+ */
+export function releaseLock(options: { paneNumber: number | null; lockfilePath?: string }): void {
+  const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
+  try {
+    // 自分の PID が書かれた lock のみ削除（他プロセスの lock を誤削除しない）
+    const existing = readLock(lockfilePath)
+    if (existing && existing.pid === process.pid) {
+      unlinkSync(lockfilePath)
+    }
+  } catch {
+    // ファイルが既に存在しない場合は無視
+  }
+}
+
+/**
+ * 現在の lock 状態を取得する
+ */
+export function isLocked(paneNumber: number | null, lockfilePath?: string): LockInfo | null {
+  const filePath = lockfilePath ?? getLockfilePath(paneNumber)
+  const info = readLock(filePath)
+  if (!info) return null
+  // PID が死んでいれば stale → null 扱い
+  if (!isPidAlive(info.pid)) return null
+  return info
+}
+
+/**
+ * process exit 時に lockfile を自動解放するハンドラを登録する
+ */
+export function registerLockCleanup(options: { paneNumber: number | null; lockfilePath?: string }): void {
+  const cleanup = () => releaseLock(options)
+  process.on('exit', cleanup)
+  process.on('SIGINT', () => { cleanup(); process.exit(0) })
+  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
+}


### PR DESCRIPTION
## Summary
- **Server lockfile**: `openSync('wx')` による原子的排他作成。PID/port/pane/起動時刻を記録、stale lock 自動回収
- **Electron single-instance**: `requestSingleInstanceLock()` + `second-instance` で既存ウィンドウにフォーカス
- **取得順序**: Electron lock → server lockfile → StartupGuard → runStartupTasks
- Codex Critical 2件対応済み（原子的取得 race 防止 + signal ハンドラ衝突回避）

## Test plan
- [x] 単体テスト 16ケース全グリーン
- [x] サーバーパッケージ 225テスト全グリーン
- [x] 手動: 同一 PANE_NUMBER で 2回目起動 → 即座にエラー終了
- [x] 手動: 異なる PANE_NUMBER → 独立起動成功
- [x] 手動: kill 後に lock 自動解放
- [ ] Electron double-launch テスト（本番デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)