### PR TITLE
feat(shared/server): DevInstance / SlotAssignment 型・ストア (closes #184)

### DIFF
--- a/packages/server/src/__tests__/dev-instance.test.ts
+++ b/packages/server/src/__tests__/dev-instance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { SessionStore } from '../services/session-store'
+import { calculatePortsForSlot } from '../utils/ports'
 
 describe('DevInstance / SlotAssignment', () => {
   let store: SessionStore
@@ -163,6 +164,41 @@ describe('DevInstance / SlotAssignment', () => {
       expect(all).toHaveLength(2)
       expect(all[0].slotNumber).toBe(0)
       expect(all[1].slotNumber).toBe(1)
+    })
+
+    it('同一 instanceId を複数スロットに割り当てられない（UNIQUE instance_id）', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      // 同じ instance を別スロットに割り当て → UNIQUE 制約違反
+      expect(() => store.assignSlot(1, instance.id)).toThrow()
+    })
+
+    it('存在しない instanceId での assignSlot は FK 制約で拒否される', () => {
+      expect(() => store.assignSlot(0, 'non-existent-id')).toThrow()
+    })
+  })
+
+  describe('異常系', () => {
+    it('存在しない ID の deleteDevInstance は false を返す', () => {
+      const result = store.deleteDevInstance('non-existent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('calculatePortsForSlot', () => {
+    it('スロット0のポートを正しく算出する', () => {
+      const ports = calculatePortsForSlot(0)
+      expect(ports.serverPort).toBe(14000)
+      expect(ports.clientPort).toBe(5180)
+      expect(ports.playwrightPort).toBe(3550)
+    })
+
+    it('スロット3のポートを正しく算出する', () => {
+      const ports = calculatePortsForSlot(3)
+      expect(ports.serverPort).toBe(14003)
+      expect(ports.clientPort).toBe(5183)
+      expect(ports.playwrightPort).toBe(3553)
     })
   })
 })

--- a/packages/server/src/__tests__/dev-instance.test.ts
+++ b/packages/server/src/__tests__/dev-instance.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SessionStore } from '../services/session-store'
+
+describe('DevInstance / SlotAssignment', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  describe('DevInstance CRUD', () => {
+    it('DevInstance を作成して取得できる', () => {
+      const instance = store.createDevInstance({
+        slotNumber: 0,
+        serverPort: 14000,
+        clientPort: 5180,
+        playwrightPort: 3550,
+      })
+
+      expect(instance.id).toBeDefined()
+      expect(instance.slotNumber).toBe(0)
+      expect(instance.serverPort).toBe(14000)
+      expect(instance.clientPort).toBe(5180)
+      expect(instance.playwrightPort).toBe(3550)
+      expect(instance.status).toBe('idle')
+      expect(instance.pid).toBeNull()
+      expect(instance.worktreePath).toBeNull()
+      expect(instance.assignedSessionId).toBeNull()
+    })
+
+    it('スロット番号で DevInstance を取得できる', () => {
+      store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      const retrieved = store.getDevInstance(1)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.slotNumber).toBe(1)
+    })
+
+    it('存在しないスロット番号は null を返す', () => {
+      expect(store.getDevInstance(999)).toBeNull()
+    })
+
+    it('全 DevInstance を取得できる', () => {
+      store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+      store.createDevInstance({ slotNumber: 2, serverPort: 14002, clientPort: 5182, playwrightPort: 3552 })
+
+      const all = store.getAllDevInstances()
+      expect(all).toHaveLength(3)
+      expect(all[0].slotNumber).toBe(0)
+      expect(all[1].slotNumber).toBe(1)
+      expect(all[2].slotNumber).toBe(2)
+    })
+
+    it('状態を更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceStatus(instance.id, 'running', 12345)
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.status).toBe('running')
+      expect(updated!.pid).toBe(12345)
+    })
+
+    it('worktreePath を更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceWorktreePath(instance.id, '/tmp/repo/.kurimats-worktrees/pane0')
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.worktreePath).toBe('/tmp/repo/.kurimats-worktrees/pane0')
+    })
+
+    it('セッションバインディングを更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceSession(instance.id, 'session-123')
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBe('session-123')
+
+      // null でアンバインド
+      store.updateDevInstanceSession(instance.id, null)
+      const unbound = store.getDevInstanceById(instance.id)
+      expect(unbound!.assignedSessionId).toBeNull()
+    })
+
+    it('DevInstance を削除できる（slot_assignment も連動削除）', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      const deleted = store.deleteDevInstance(instance.id)
+      expect(deleted).toBe(true)
+      expect(store.getDevInstance(0)).toBeNull()
+      expect(store.getSlotAssignment(0)).toBeNull()
+    })
+
+    it('同一スロット番号の二重作成は UNIQUE 制約で拒否される', () => {
+      store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      expect(() => {
+        store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      }).toThrow()
+    })
+  })
+
+  describe('SlotAssignment', () => {
+    it('スロットを割り当てて取得できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const assignment = store.assignSlot(0, instance.id)
+
+      expect(assignment.slotNumber).toBe(0)
+      expect(assignment.instanceId).toBe(instance.id)
+      expect(assignment.assignedAt).toBeGreaterThan(0)
+
+      const retrieved = store.getSlotAssignment(0)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.instanceId).toBe(instance.id)
+    })
+
+    it('同一スロットへの二重割り当てが UNIQUE 制約で拒否される', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      store.assignSlot(0, inst1.id)
+
+      // 同じ slotNumber=0 に別の instance を割り当てようとする → UNIQUE 制約違反
+      expect(() => store.assignSlot(0, inst2.id)).toThrow()
+    })
+
+    it('異なるスロットは独立して割り当て可能', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      const a1 = store.assignSlot(0, inst1.id)
+      const a2 = store.assignSlot(1, inst2.id)
+
+      expect(a1.slotNumber).toBe(0)
+      expect(a2.slotNumber).toBe(1)
+    })
+
+    it('スロットを解放できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      store.releaseSlot(0)
+      expect(store.getSlotAssignment(0)).toBeNull()
+
+      // 解放後は再割り当て可能
+      const newAssignment = store.assignSlot(0, instance.id)
+      expect(newAssignment.slotNumber).toBe(0)
+    })
+
+    it('全スロット割り当てを取得できる', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      store.assignSlot(0, inst1.id)
+      store.assignSlot(1, inst2.id)
+
+      const all = store.getAllSlotAssignments()
+      expect(all).toHaveLength(2)
+      expect(all[0].slotNumber).toBe(0)
+      expect(all[1].slotNumber).toBe(1)
+    })
+  })
+})

--- a/packages/server/src/services/session-store-migrations.ts
+++ b/packages/server/src/services/session-store-migrations.ts
@@ -134,4 +134,37 @@ export function runSessionStoreMigrations(db: Database.Database): void {
   try { db.exec('ALTER TABLE cmux_workspaces ADD COLUMN repo_path TEXT NOT NULL DEFAULT \'\'') } catch { /* カラム既存 */ }
   try { db.exec('ALTER TABLE cmux_workspaces ADD COLUMN ssh_host TEXT') } catch { /* カラム既存 */ }
   try { db.exec('ALTER TABLE sessions ADD COLUMN workspace_id TEXT') } catch { /* カラム既存 */ }
+
+  // Phase B: 開発インスタンス / スロット管理テーブル
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS dev_instances (
+      id TEXT PRIMARY KEY,
+      slot_number INTEGER NOT NULL,
+      server_port INTEGER NOT NULL,
+      client_port INTEGER NOT NULL,
+      playwright_port INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'idle',
+      pid INTEGER,
+      worktree_path TEXT,
+      assigned_session_id TEXT,
+      created_at INTEGER NOT NULL,
+      last_active_at INTEGER NOT NULL
+    );
+  `)
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slot_assignments (
+      slot_number INTEGER PRIMARY KEY,
+      instance_id TEXT NOT NULL,
+      assigned_at INTEGER NOT NULL,
+      FOREIGN KEY (instance_id) REFERENCES dev_instances(id)
+    );
+  `)
+
+  // slot_number の一意性を dev_instances テーブル側にも適用
+  // （slot_assignments の PRIMARY KEY で排他、dev_instances 側は重複チェック用インデックス）
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_dev_instances_slot
+    ON dev_instances(slot_number);
+  `)
 }

--- a/packages/server/src/services/session-store-migrations.ts
+++ b/packages/server/src/services/session-store-migrations.ts
@@ -155,9 +155,9 @@ export function runSessionStoreMigrations(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS slot_assignments (
       slot_number INTEGER PRIMARY KEY,
-      instance_id TEXT NOT NULL,
+      instance_id TEXT NOT NULL UNIQUE,
       assigned_at INTEGER NOT NULL,
-      FOREIGN KEY (instance_id) REFERENCES dev_instances(id)
+      FOREIGN KEY (instance_id) REFERENCES dev_instances(id) ON DELETE CASCADE
     );
   `)
 

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3'
 import path from 'path'
 import { mkdirSync } from 'fs'
 import { homedir } from 'os'
-import type { BoardLayoutState, CreateFeedbackParams, CreateProjectParams, CreateSessionParams, CreateSshPresetParams, CreateStartupTemplateParams, CreateCmuxWorkspaceParams, Feedback, LayoutState, PaneNode, Project, Session, SshPreset, StartupTemplate, CmuxWorkspace } from '@kurimats/shared'
+import type { BoardLayoutState, CreateFeedbackParams, CreateProjectParams, CreateSessionParams, CreateSshPresetParams, CreateStartupTemplateParams, CreateCmuxWorkspaceParams, DevInstance, Feedback, LayoutState, PaneNode, Project, Session, SlotAssignment, SshPreset, StartupTemplate, CmuxWorkspace } from '@kurimats/shared'
 import { v4 as uuidv4 } from 'uuid'
 import { loadBoardLayoutState, loadLegacyLayout, saveBoardLayoutState, saveLegacyLayout } from './session-store-layout.js'
 import { mapCmuxWorkspaceRow, mapFeedbackRow, mapProjectRow, mapSessionRow, mapSshPresetRow, mapStartupTemplateRow } from './session-store-mappers.js'
@@ -487,7 +487,119 @@ export class SessionStore {
     return tx(id)
   }
 
+  // ========== DevInstance / SlotAssignment ==========
+
+  /** DevInstance を作成 */
+  createDevInstance(params: {
+    slotNumber: number
+    serverPort: number
+    clientPort: number
+    playwrightPort: number
+  }): DevInstance {
+    const id = uuidv4()
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO dev_instances (id, slot_number, server_port, client_port, playwright_port, status, created_at, last_active_at)
+      VALUES (?, ?, ?, ?, ?, 'idle', ?, ?)
+    `).run(id, params.slotNumber, params.serverPort, params.clientPort, params.playwrightPort, now, now)
+    return this.getDevInstance(params.slotNumber)!
+  }
+
+  /** スロット番号で DevInstance を取得 */
+  getDevInstance(slotNumber: number): DevInstance | null {
+    const row = this.db.prepare('SELECT * FROM dev_instances WHERE slot_number = ?').get(slotNumber) as any
+    return row ? mapDevInstanceRow(row) : null
+  }
+
+  /** ID で DevInstance を取得 */
+  getDevInstanceById(id: string): DevInstance | null {
+    const row = this.db.prepare('SELECT * FROM dev_instances WHERE id = ?').get(id) as any
+    return row ? mapDevInstanceRow(row) : null
+  }
+
+  /** 全 DevInstance を取得 */
+  getAllDevInstances(): DevInstance[] {
+    const rows = this.db.prepare('SELECT * FROM dev_instances ORDER BY slot_number').all() as any[]
+    return rows.map(mapDevInstanceRow)
+  }
+
+  /** DevInstance の状態を更新 */
+  updateDevInstanceStatus(id: string, status: string, pid?: number | null): void {
+    const now = Date.now()
+    if (pid !== undefined) {
+      this.db.prepare('UPDATE dev_instances SET status = ?, pid = ?, last_active_at = ? WHERE id = ?').run(status, pid, now, id)
+    } else {
+      this.db.prepare('UPDATE dev_instances SET status = ?, last_active_at = ? WHERE id = ?').run(status, now, id)
+    }
+  }
+
+  /** DevInstance の worktreePath を更新 */
+  updateDevInstanceWorktreePath(id: string, worktreePath: string | null): void {
+    this.db.prepare('UPDATE dev_instances SET worktree_path = ? WHERE id = ?').run(worktreePath, id)
+  }
+
+  /** DevInstance のセッションバインディングを更新 */
+  updateDevInstanceSession(id: string, sessionId: string | null): void {
+    this.db.prepare('UPDATE dev_instances SET assigned_session_id = ? WHERE id = ?').run(sessionId, id)
+  }
+
+  /** DevInstance を削除 */
+  deleteDevInstance(id: string): boolean {
+    const tx = this.db.transaction((instanceId: string) => {
+      this.db.prepare('DELETE FROM slot_assignments WHERE instance_id = ?').run(instanceId)
+      return this.db.prepare('DELETE FROM dev_instances WHERE id = ?').run(instanceId).changes > 0
+    })
+    return tx(id)
+  }
+
+  /**
+   * スロットを割り当て（UNIQUE 制約で排他制御）
+   * @throws slot_number が既に使用中の場合は UNIQUE constraint エラー
+   */
+  assignSlot(slotNumber: number, instanceId: string): SlotAssignment {
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO slot_assignments (slot_number, instance_id, assigned_at)
+      VALUES (?, ?, ?)
+    `).run(slotNumber, instanceId, now)
+    return { slotNumber, instanceId, assignedAt: now }
+  }
+
+  /** スロットを解放 */
+  releaseSlot(slotNumber: number): void {
+    this.db.prepare('DELETE FROM slot_assignments WHERE slot_number = ?').run(slotNumber)
+  }
+
+  /** スロット割り当てを取得 */
+  getSlotAssignment(slotNumber: number): SlotAssignment | null {
+    const row = this.db.prepare('SELECT * FROM slot_assignments WHERE slot_number = ?').get(slotNumber) as any
+    return row ? { slotNumber: row.slot_number, instanceId: row.instance_id, assignedAt: row.assigned_at } : null
+  }
+
+  /** 全スロット割り当てを取得 */
+  getAllSlotAssignments(): SlotAssignment[] {
+    const rows = this.db.prepare('SELECT * FROM slot_assignments ORDER BY slot_number').all() as any[]
+    return rows.map(row => ({ slotNumber: row.slot_number, instanceId: row.instance_id, assignedAt: row.assigned_at }))
+  }
+
   close(): void {
     this.db.close()
+  }
+}
+
+/** DB行を DevInstance にマップ */
+function mapDevInstanceRow(row: any): DevInstance {
+  return {
+    id: row.id,
+    slotNumber: row.slot_number,
+    serverPort: row.server_port,
+    clientPort: row.client_port,
+    playwrightPort: row.playwright_port,
+    status: row.status,
+    pid: row.pid ?? null,
+    worktreePath: row.worktree_path ?? null,
+    assignedSessionId: row.assigned_session_id ?? null,
+    createdAt: row.created_at,
+    lastActiveAt: row.last_active_at,
   }
 }

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -44,6 +44,7 @@ export class SessionStore {
 
     this.db = new Database(resolvedPath)
     this.db.pragma('journal_mode = WAL')
+    this.db.pragma('foreign_keys = ON')
     this.migrate()
   }
 

--- a/packages/server/src/utils/ports.ts
+++ b/packages/server/src/utils/ports.ts
@@ -14,9 +14,27 @@ export const SERVER_PORT_BASE = 14000
 /** Playwright MCPポートベース値 */
 export const PLAYWRIGHT_PORT_BASE = 3550
 
+/** クライアントポートベース値 */
+export const CLIENT_PORT_BASE = 5180
+
 /**
  * ペイン番号からサービスポートを算出
  */
 export function calculatePort(base: number, paneNumber: number): number {
   return base + paneNumber
+}
+
+/**
+ * スロット番号から全ポートを一括算出
+ */
+export function calculatePortsForSlot(slotNumber: number): {
+  serverPort: number
+  clientPort: number
+  playwrightPort: number
+} {
+  return {
+    serverPort: calculatePort(SERVER_PORT_BASE, slotNumber),
+    clientPort: calculatePort(CLIENT_PORT_BASE, slotNumber),
+    playwrightPort: calculatePort(PLAYWRIGHT_PORT_BASE, slotNumber),
+  }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -426,6 +426,39 @@ export const FEEDBACK_PRIORITY_LABELS: Record<FeedbackPriority, string> = {
   low: '低',
 } as const
 
+// ========== 開発インスタンス / スロット管理 ==========
+
+/** 開発インスタンスの状態 */
+export type DevInstanceStatus = 'idle' | 'running' | 'error'
+
+/** 開発インスタンス（pane 単位の開発環境） */
+export interface DevInstance {
+  id: string
+  /** スロット番号（PANE_NUMBER に対応） */
+  slotNumber: number
+  /** サーバーポート */
+  serverPort: number
+  /** クライアントポート */
+  clientPort: number
+  /** Playwright ポート */
+  playwrightPort: number
+  status: DevInstanceStatus
+  pid: number | null
+  /** persistent develop worktree パス */
+  worktreePath: string | null
+  /** バインドされたセッションID */
+  assignedSessionId: string | null
+  createdAt: number
+  lastActiveAt: number
+}
+
+/** スロット割り当て（UNIQUE 制約で排他制御） */
+export interface SlotAssignment {
+  slotNumber: number
+  instanceId: string
+  assignedAt: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報


### PR DESCRIPTION
## Summary
- `DevInstance` / `SlotAssignment` / `DevInstanceStatus` 型を shared パッケージに追加
- `dev_instances` + `slot_assignments` テーブル（`UNIQUE INDEX` で slot 排他制御）
- `SessionStore` に DevInstance CRUD + SlotAssignment CRUD を追加
- `calculatePortsForSlot()` で server/client/playwright ポート一括算出

## Test plan
- [x] 単体テスト 14ケース全グリーン
- [x] サーバーパッケージ 239テスト全グリーン
- [x] 同一スロット二重作成 → UNIQUE 制約で拒否
- [x] 同一スロット二重割り当て → PRIMARY KEY で拒否
- [ ] DB マイグレーション確認（既存 DB に新テーブル追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)