### PR TITLE
feat(server): ProcessSupervisor + ensurePersistentDevelopWorktree (closes #185)

### DIFF
--- a/packages/server/src/__tests__/process-supervisor.test.ts
+++ b/packages/server/src/__tests__/process-supervisor.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ProcessSupervisor } from '../services/process-supervisor'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('ProcessSupervisor', () => {
+  let supervisor: ProcessSupervisor
+
+  beforeEach(() => {
+    supervisor = new ProcessSupervisor({
+      checkIntervalMs: 50,  // テスト用に短縮
+      healthyThreshold: 2,
+      maxRestarts: 1,
+    })
+  })
+
+  afterEach(() => {
+    supervisor.stopAll()
+  })
+
+  describe('基本操作', () => {
+    it('プロセスを監視開始できる', () => {
+      const spawnFn: SpawnFn = (_onExit) => process.pid // 自分自身のPIDを返す
+
+      supervisor.supervise('inst-1', spawnFn)
+
+      const status = supervisor.getStatus('inst-1')
+      expect(status).not.toBeNull()
+      expect(status!.instanceId).toBe('inst-1')
+      expect(status!.pid).toBe(process.pid)
+      expect(status!.status).toBe('starting')
+    })
+
+    it('同じIDで二重登録するとエラー', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+
+      expect(() => supervisor.supervise('inst-1', () => process.pid)).toThrow('既に監視中')
+    })
+
+    it('stop で監視を停止できる', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+      supervisor.stop('inst-1')
+
+      expect(supervisor.getStatus('inst-1')).toBeNull()
+    })
+
+    it('getAllStatuses で全状態を取得できる', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+      supervisor.supervise('inst-2', () => process.pid)
+
+      const all = supervisor.getAllStatuses()
+      expect(all).toHaveLength(2)
+    })
+  })
+
+  describe('ヘルスチェック', () => {
+    it('連続成功で healthy に遷移する', async () => {
+      const healthyPromise = new Promise<void>((resolve) => {
+        supervisor.on('healthy', (id) => {
+          if (id === 'inst-1') resolve()
+        })
+      })
+
+      supervisor.supervise('inst-1', () => process.pid)
+
+      // healthyThreshold=2, checkIntervalMs=50 なので ~100ms で healthy
+      await healthyPromise
+      expect(supervisor.getStatus('inst-1')!.status).toBe('healthy')
+    })
+  })
+
+  describe('second shot（再起動）', () => {
+    it('プロセス終了時に 1 回再起動する', async () => {
+      let exitCallback: ((code: number | null) => void) | null = null
+      let spawnCount = 0
+
+      const spawnFn: SpawnFn = (onExit) => {
+        spawnCount++
+        exitCallback = onExit
+        return process.pid
+      }
+
+      const restartingPromise = new Promise<number>((resolve) => {
+        supervisor.on('restarting', (_id, count) => resolve(count))
+      })
+
+      supervisor.supervise('inst-1', spawnFn)
+      expect(spawnCount).toBe(1)
+
+      // プロセス終了をシミュレート
+      exitCallback!(1)
+
+      const restartCount = await restartingPromise
+      expect(restartCount).toBe(1)
+      expect(spawnCount).toBe(2) // 再起動で2回目
+    })
+
+    it('再起動上限到達で error 状態に遷移する', async () => {
+      let exitCallback: ((code: number | null) => void) | null = null
+
+      const spawnFn: SpawnFn = (onExit) => {
+        exitCallback = onExit
+        return process.pid
+      }
+
+      const errorPromise = new Promise<void>((resolve) => {
+        supervisor.on('error', () => resolve())
+      })
+
+      supervisor.supervise('inst-1', spawnFn)
+
+      // 1回目の終了 → 再起動
+      exitCallback!(1)
+
+      // 少し待って2回目の終了 → error
+      await new Promise(r => setTimeout(r, 10))
+      exitCallback!(1)
+
+      await errorPromise
+      expect(supervisor.getStatus('inst-1')!.status).toBe('error')
+    })
+  })
+
+  describe('spawn 失敗', () => {
+    it('spawn 関数が例外を投げると error 状態になる', () => {
+      const errorPromise = new Promise<void>((resolve) => {
+        supervisor.on('error', () => resolve())
+      })
+
+      const spawnFn: SpawnFn = () => {
+        throw new Error('起動失敗')
+      }
+
+      supervisor.supervise('inst-1', spawnFn)
+      expect(supervisor.getStatus('inst-1')!.status).toBe('error')
+    })
+  })
+})

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -479,4 +479,49 @@ describe('runStartupTasks', () => {
       expect(worktreeService.getBranch).toHaveBeenCalledWith('/tmp/repo/.kurimats-worktrees/pane1')
     })
   })
+
+  describe('persistent develop worktree の保護', () => {
+    it('段階2で persistent develop worktree が削除されない', () => {
+      const session = store.create({
+        name: 'persistent-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane0',
+        baseBranch: 'kurimats/persistent-develop-pane0',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+      store.updateStatus(session.id, 'disconnected')
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
+
+      // persistent develop worktree は削除されない
+      const updated = store.getById(session.id)
+      expect(updated?.worktreePath).toBe('/tmp/repo/.kurimats-worktrees/persistent-develop-pane0')
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+    })
+
+    it('段階3で persistent develop worktree を持つ孤立セッションが保護される', () => {
+      const ws = store.createCmuxWorkspace(
+        { name: 'test-ws', repoPath: '/tmp/repo' },
+        { kind: 'leaf', id: 'pane-a', sessionId: 'some-other-session', ratio: 1 },
+      )
+      const orphan = store.create({
+        name: 'persistent-orphan',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+        isRemote: false,
+        workspaceId: ws.id,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
+
+      // persistent develop worktree は worktreeService.remove されない
+      expect(worktreeService.remove).not.toHaveBeenCalledWith(
+        '/tmp/repo',
+        '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+      )
+    })
+  })
 })

--- a/packages/server/src/services/process-supervisor.ts
+++ b/packages/server/src/services/process-supervisor.ts
@@ -1,0 +1,211 @@
+/**
+ * ProcessSupervisor — プロセスの生存監視と自動再起動
+ *
+ * 3-snapshot ヘルスチェック:
+ * - 3回連続でプロセス生存を確認 → 健全
+ * - 異常検出 → second shot（1回再起動）
+ * - second shot 後も異常 → error 状態に遷移
+ */
+import { EventEmitter } from 'events'
+
+/** 監視対象プロセスの状態 */
+export type SupervisedStatus = 'starting' | 'healthy' | 'restarting' | 'error' | 'stopped'
+
+/** 監視対象の情報 */
+export interface SupervisedProcess {
+  instanceId: string
+  status: SupervisedStatus
+  pid: number | null
+  restartCount: number
+  lastCheckedAt: number | null
+  consecutiveOk: number
+}
+
+/** Supervisor の設定 */
+export interface SupervisorOptions {
+  /** ヘルスチェック間隔（ms） */
+  checkIntervalMs?: number
+  /** 健全判定に必要な連続成功回数 */
+  healthyThreshold?: number
+  /** 最大再起動回数 */
+  maxRestarts?: number
+}
+
+const DEFAULT_OPTIONS: Required<SupervisorOptions> = {
+  checkIntervalMs: 5000,
+  healthyThreshold: 3,
+  maxRestarts: 1,
+}
+
+/**
+ * spawn 関数の型: プロセスを起動して PID を返す
+ * プロセス終了時に onExit コールバックを呼ぶ
+ */
+export type SpawnFn = (onExit: (code: number | null) => void) => number
+
+export class ProcessSupervisor extends EventEmitter {
+  private processes = new Map<string, SupervisedProcess>()
+  private timers = new Map<string, ReturnType<typeof setInterval>>()
+  private spawnFns = new Map<string, SpawnFn>()
+  private options: Required<SupervisorOptions>
+
+  constructor(options?: SupervisorOptions) {
+    super()
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * プロセスの監視を開始する
+   * @param instanceId 管理対象のインスタンスID
+   * @param spawnFn プロセス起動関数
+   */
+  supervise(instanceId: string, spawnFn: SpawnFn): void {
+    if (this.processes.has(instanceId)) {
+      throw new Error(`インスタンス ${instanceId} は既に監視中です`)
+    }
+
+    this.spawnFns.set(instanceId, spawnFn)
+
+    const proc: SupervisedProcess = {
+      instanceId,
+      status: 'starting',
+      pid: null,
+      restartCount: 0,
+      lastCheckedAt: null,
+      consecutiveOk: 0,
+    }
+    this.processes.set(instanceId, proc)
+
+    this.startProcess(instanceId)
+  }
+
+  /**
+   * 監視を停止する
+   */
+  stop(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc) return
+
+    // タイマー停止
+    const timer = this.timers.get(instanceId)
+    if (timer) {
+      clearInterval(timer)
+      this.timers.delete(instanceId)
+    }
+
+    proc.status = 'stopped'
+    this.processes.delete(instanceId)
+    this.spawnFns.delete(instanceId)
+    this.emit('stopped', instanceId)
+  }
+
+  /**
+   * 全監視を停止する
+   */
+  stopAll(): void {
+    for (const id of [...this.processes.keys()]) {
+      this.stop(id)
+    }
+  }
+
+  /**
+   * 監視中プロセスの状態を取得する
+   */
+  getStatus(instanceId: string): SupervisedProcess | null {
+    return this.processes.get(instanceId) ?? null
+  }
+
+  /**
+   * 全監視中プロセスの状態を取得する
+   */
+  getAllStatuses(): SupervisedProcess[] {
+    return [...this.processes.values()]
+  }
+
+  /** プロセスを起動して監視を開始する */
+  private startProcess(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    const spawnFn = this.spawnFns.get(instanceId)
+    if (!proc || !spawnFn) return
+
+    try {
+      const pid = spawnFn((code) => {
+        this.handleExit(instanceId, code)
+      })
+      proc.pid = pid
+      proc.status = 'starting'
+      proc.consecutiveOk = 0
+
+      // ヘルスチェックタイマーを開始
+      this.startHealthCheck(instanceId)
+      this.emit('started', instanceId, pid)
+    } catch (e) {
+      proc.status = 'error'
+      proc.pid = null
+      this.emit('error', instanceId, e)
+    }
+  }
+
+  /** プロセス終了時のハンドラ */
+  private handleExit(instanceId: string, code: number | null): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc || proc.status === 'stopped') return
+
+    // ヘルスチェック停止
+    const timer = this.timers.get(instanceId)
+    if (timer) {
+      clearInterval(timer)
+      this.timers.delete(instanceId)
+    }
+
+    proc.pid = null
+    this.emit('exit', instanceId, code)
+
+    // second shot: 再起動可能か判定
+    if (proc.restartCount < this.options.maxRestarts) {
+      proc.status = 'restarting'
+      proc.restartCount++
+      console.warn(`⚠️ ProcessSupervisor: ${instanceId} が終了 (code=${code})。再起動します (${proc.restartCount}/${this.options.maxRestarts})`)
+      this.emit('restarting', instanceId, proc.restartCount)
+      this.startProcess(instanceId)
+    } else {
+      proc.status = 'error'
+      console.error(`❌ ProcessSupervisor: ${instanceId} が再起動上限に到達。error 状態に遷移します。`)
+      this.emit('error', instanceId, new Error(`再起動上限 (${this.options.maxRestarts}) に到達`))
+    }
+  }
+
+  /** ヘルスチェックタイマーを開始する */
+  private startHealthCheck(instanceId: string): void {
+    // 既存のタイマーがあれば停止
+    const existing = this.timers.get(instanceId)
+    if (existing) clearInterval(existing)
+
+    const timer = setInterval(() => {
+      this.checkHealth(instanceId)
+    }, this.options.checkIntervalMs)
+
+    this.timers.set(instanceId, timer)
+  }
+
+  /** ヘルスチェック: PID が生存しているか確認 */
+  private checkHealth(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc || !proc.pid) return
+
+    proc.lastCheckedAt = Date.now()
+
+    try {
+      process.kill(proc.pid, 0) // signal 0 で生存確認
+      proc.consecutiveOk++
+
+      if (proc.consecutiveOk >= this.options.healthyThreshold && proc.status !== 'healthy') {
+        proc.status = 'healthy'
+        this.emit('healthy', instanceId)
+      }
+    } catch {
+      // PID が死んでいる → handleExit が呼ばれるはずだが、念のため
+      proc.consecutiveOk = 0
+    }
+  }
+}

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -224,9 +224,11 @@ export class WorktreeService {
 
   /**
    * パスが persistent develop worktree かどうか判定する
+   * パスセグメント境界で判定し、部分一致の誤判定を防ぐ
    */
   static isPersistentDevelop(worktreePath: string): boolean {
-    return worktreePath.includes('persistent-develop-pane')
+    const segments = worktreePath.split(path.sep)
+    return segments.some(seg => seg.startsWith('persistent-develop-pane'))
   }
 
   /**

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -165,10 +165,10 @@ export class WorktreeService {
       return []
     }
 
-    // 使用中でないブランチを削除
+    // 使用中でないブランチを削除（persistent develop ブランチは除外）
     const deleted: string[] = []
     for (const branch of allBranches) {
-      if (!activeBranches.has(branch)) {
+      if (!activeBranches.has(branch) && !WorktreeService.isPersistentDevelopBranch(branch)) {
         try {
           execFileSync('git', ['branch', '-D', branch], {
             cwd: repoPath,
@@ -182,6 +182,58 @@ export class WorktreeService {
       }
     }
     return deleted
+  }
+
+  /**
+   * persistent develop worktree を確保する（冪等）
+   * 存在すればそのまま返し、なければ作成する。
+   * 命名規則: .kurimats-worktrees/persistent-develop-paneN/
+   * ブランチ: kurimats/persistent-develop-paneN
+   */
+  ensurePersistentDevelopWorktree(repoPath: string, slotNumber: number, baseBranch = 'develop'): string {
+    const name = `persistent-develop-pane${slotNumber}`
+    const worktreeBase = path.join(repoPath, WORKTREE_DIR)
+    const worktreePath = path.join(worktreeBase, name)
+
+    if (existsSync(worktreePath)) {
+      return worktreePath
+    }
+
+    // worktree ディレクトリがなければ作成
+    mkdirSync(worktreeBase, { recursive: true })
+
+    const branchName = `kurimats/${name}`
+    try {
+      execFileSync('git', ['worktree', 'add', worktreePath, '-b', branchName, baseBranch], {
+        cwd: repoPath, encoding: 'utf-8', stdio: 'pipe',
+      })
+    } catch {
+      // ブランチが既に存在する場合、ブランチなしで追加
+      try {
+        execFileSync('git', ['worktree', 'add', worktreePath, branchName], {
+          cwd: repoPath, encoding: 'utf-8', stdio: 'pipe',
+        })
+      } catch (e) {
+        throw new Error(`persistent develop worktree の作成に失敗: ${e}`)
+      }
+    }
+
+    console.log(`🌿 persistent develop worktree 作成: ${worktreePath}`)
+    return worktreePath
+  }
+
+  /**
+   * パスが persistent develop worktree かどうか判定する
+   */
+  static isPersistentDevelop(worktreePath: string): boolean {
+    return worktreePath.includes('persistent-develop-pane')
+  }
+
+  /**
+   * ブランチ名が persistent develop のものかどうか判定する
+   */
+  static isPersistentDevelopBranch(branchName: string): boolean {
+    return branchName.startsWith('kurimats/persistent-develop-pane')
   }
 
   /**

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -14,7 +14,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import type { PaneNode } from '@kurimats/shared'
 import type { SessionStore } from './services/session-store.js'
-import type { WorktreeService } from './services/worktree-service.js'
+import { WorktreeService } from './services/worktree-service.js'
 import { collectSessionIds } from './utils/pane-tree.js'
 
 /** StartupGuard の判定結果 */
@@ -157,6 +157,11 @@ function phase2_cleanupDisconnectedWorktrees(sessionStore: SessionStore, worktre
       console.log(`🧹 ${disconnectedSessions.length}件のdisconnectedセッションのworktreeを解放`)
       for (const s of disconnectedSessions) {
         if (s.worktreePath && s.repoPath) {
+          // persistent develop worktree は削除しない
+          if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
+            console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
+            continue
+          }
           try {
             worktreeService.remove(s.repoPath, s.worktreePath)
             console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)
@@ -190,6 +195,11 @@ function phase3_deleteOrphanedSessions(sessionStore: SessionStore, worktreeServi
       console.log(`🧹 ${orphanedCleanup.length}件の孤立セッションを削除します`)
       for (const s of orphanedCleanup) {
         if (s.worktreePath && s.repoPath) {
+          // persistent develop worktree は削除しない
+          if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
+            console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
+            continue
+          }
           try {
             worktreeService.remove(s.repoPath, s.worktreePath)
             console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -195,7 +195,8 @@ function phase3_deleteOrphanedSessions(sessionStore: SessionStore, worktreeServi
       console.log(`🧹 ${orphanedCleanup.length}件の孤立セッションを削除します`)
       for (const s of orphanedCleanup) {
         if (s.worktreePath && s.repoPath) {
-          // persistent develop worktree は削除しない
+          // persistent develop worktree は worktree もセッションも削除しない
+          // （DevInstanceManager が管理するため、孤立判定の対象外）
           if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
             console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
             continue


### PR DESCRIPTION
## Summary
- **ProcessSupervisor**: 3-snapshot ヘルスチェック + second shot 再起動（maxRestarts=1、連続失敗で error 状態遷移）
- **ensurePersistentDevelopWorktree**: slot ごとの永続 develop worktree（冪等、命名: `persistent-develop-paneN`）
- **startup.ts 保護**: 段階2/3 で persistent develop worktree の削除を自動スキップ
- **cleanupOrphanedBranches 保護**: `kurimats/persistent-develop-*` ブランチを削除対象から除外
- v4 Critical「branch 自動 -D」の除外規則を確立

## Test plan
- [x] ProcessSupervisor テスト 8ケース全グリーン（基本/健全/再起動/error/spawn失敗）
- [x] startup.ts persistent 保護テスト 2ケース追加
- [x] サーバーパッケージ 254テスト全グリーン
- [ ] persistent develop worktree の手動永続性確認

## 動作確認
- [x] `npx vitest run packages/server` — 254テスト / 19ファイル全グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)