### PR TITLE
fix: ワークスペース切替時にターミナルが破損する問題を修正 (closes #146)

### DIFF
--- a/packages/client/src/components/panes/PaneContainer.tsx
+++ b/packages/client/src/components/panes/PaneContainer.tsx
@@ -39,11 +39,11 @@ export function PaneContainer() {
         <div className="flex-1 relative">
           {/* 背景（元のツリーは非表示） */}
           <div className="w-full h-full opacity-10 pointer-events-none">
-            <PaneRenderer node={paneTree} />
+            <PaneRenderer key={activeWorkspace.id} node={paneTree} />
           </div>
           {/* ズームオーバーレイ */}
           <div className="absolute inset-0 z-50 bg-surface-0">
-            <PaneLeafView leaf={zoomedNode as PaneLeaf} />
+            <PaneLeafView key={`${activeWorkspace.id}-zoom`} leaf={zoomedNode as PaneLeaf} />
           </div>
           {/* アンズームボタン */}
           <button
@@ -60,7 +60,7 @@ export function PaneContainer() {
 
   return (
     <div className="flex-1 overflow-hidden">
-      <PaneRenderer node={paneTree} />
+      <PaneRenderer key={activeWorkspace.id} node={paneTree} />
     </div>
   )
 }

--- a/packages/client/src/hooks/useTerminalWs.ts
+++ b/packages/client/src/hooks/useTerminalWs.ts
@@ -62,6 +62,8 @@ export function useTerminalWs(sessionId: string | null, terminal: Terminal | nul
 
     ws.onclose = () => {
       if (disposedRef.current) return
+      // 別の接続が既に確立されている場合は再接続しない（stale closure防止）
+      if (ws !== wsRef.current) return
       // 自動再接続（指数バックオフ）
       reconnectTimerRef.current = setTimeout(() => {
         if (!disposedRef.current && sessionId && terminal) connect()


### PR DESCRIPTION
## Summary

- PaneRendererにworkspace IDの`key`を追加し、ワークスペース切替時にペインツリーを完全再マウント
- useTerminalWsの`onclose`にidentity guardを追加し、stale closureによる旧セッションへの再接続を防止

## 根本原因

1. **PaneRendererにkeyがない** → Reactが異なるワークスペースのペインコンポーネントをDOM再利用 → 旧XTerm/WebSocketが残存
2. **useTerminalWsのoncloseにstale closure** → sessionId変更後、旧WebSocketのoncloseが旧sessionへ再接続

## Test plan

- [ ] ワークスペースA → B → A に戻り、ターミナルが正常表示されること
- [ ] 高速連続切替（A→B→A→B→A）でクラッシュしないこと
- [ ] DevToolsコンソールにWebSocketエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)