### PR TITLE
feat(server): DevInstanceManager + async cleanup (Phase D, closes #186)

### DIFF
--- a/packages/server/src/__tests__/dev-instance-manager.test.ts
+++ b/packages/server/src/__tests__/dev-instance-manager.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('DevInstanceManager', () => {
+  let store: SessionStore
+  let manager: DevInstanceManager
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    manager = new DevInstanceManager(store, {
+      checkIntervalMs: 100,
+      maxRestarts: 1,
+    })
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    store.close()
+  })
+
+  /** ダミーの spawnFn: PID を返し、プロセスが生存しているように振る舞う */
+  function createDummySpawnFn(pid = 99999): SpawnFn {
+    return (_onExit) => pid
+  }
+
+  describe('startInstance', () => {
+    it('スロットにインスタンスを作成して監視を開始する', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      expect(instance).toBeDefined()
+      expect(instance.slotNumber).toBe(0)
+      expect(instance.serverPort).toBe(14000)
+      expect(instance.clientPort).toBe(5180)
+      expect(instance.playwrightPort).toBe(3550)
+      expect(instance.status).toBe('idle')
+    })
+
+    it('slot が既に使用中の場合はエラーになる', () => {
+      manager.startInstance(0, createDummySpawnFn())
+
+      expect(() => {
+        manager.startInstance(0, createDummySpawnFn())
+      }).toThrow()
+    })
+
+    it('異なるスロットは独立して起動できる', () => {
+      const inst1 = manager.startInstance(0, createDummySpawnFn(100))
+      const inst2 = manager.startInstance(1, createDummySpawnFn(101))
+
+      expect(inst1.slotNumber).toBe(0)
+      expect(inst2.slotNumber).toBe(1)
+      expect(manager.getAllInstances()).toHaveLength(2)
+    })
+
+    it('slot 割り当て失敗時に DevInstance がロールバックされる', () => {
+      // スロット0を先に手動で占有
+      const preInstance = store.createDevInstance({
+        slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550,
+      })
+      store.assignSlot(0, preInstance.id)
+
+      // 同じスロット0で startInstance → UNIQUE 制約エラー + DevInstance ロールバック
+      expect(() => {
+        manager.startInstance(0, createDummySpawnFn())
+      }).toThrow()
+
+      // 元の割り当ては残っている
+      expect(store.getSlotAssignment(0)!.instanceId).toBe(preInstance.id)
+    })
+
+    it('spawnFn がエラーを投げた場合はロールバックされる', () => {
+      const failingSpawnFn: SpawnFn = () => {
+        throw new Error('spawn 失敗')
+      }
+
+      // error イベントを受け取る（EventEmitter の unhandled error 防止）
+      manager.on('error', () => { /* テスト用 */ })
+
+      expect(() => {
+        manager.startInstance(0, failingSpawnFn)
+      }).toThrow('インスタンス起動失敗')
+
+      // ロールバック: slot も DevInstance も残っていない
+      expect(store.getSlotAssignment(0)).toBeNull()
+      expect(store.getDevInstance(0)).toBeNull()
+    })
+  })
+
+  describe('stopInstance', () => {
+    it('インスタンスを停止し��リソースを解放する', () => {
+      manager.startInstance(0, createDummySpawnFn())
+
+      manager.stopInstance(0)
+
+      expect(manager.getInstance(0)).toBeNull()
+      expect(store.getSlotAssignment(0)).toBeNull()
+      expect(store.getDevInstance(0)).toBeNull()
+    })
+
+    it('存在しないスロットの停止は安全に無視される', () => {
+      expect(() => manager.stopInstance(999)).not.toThrow()
+    })
+  })
+
+  describe('stopInstanceById', () => {
+    it('インスタンス ID で停止できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.stopInstanceById(instance.id)
+
+      expect(manager.getInstance(0)).toBeNull()
+    })
+  })
+
+  describe('stopAll', () => {
+    it('全インスタンスを停止する', () => {
+      manager.startInstance(0, createDummySpawnFn(100))
+      manager.startInstance(1, createDummySpawnFn(101))
+      manager.startInstance(2, createDummySpawnFn(102))
+
+      manager.stopAll()
+
+      expect(manager.getAllInstances()).toHaveLength(0)
+    })
+  })
+
+  describe('getAllInstances / getRunningInstances', () => {
+    it('全インスタンスを取得できる', () => {
+      manager.startInstance(0, createDummySpawnFn())
+      manager.startInstance(1, createDummySpawnFn())
+
+      expect(manager.getAllInstances()).toHaveLength(2)
+    })
+
+    it('running 状態のインスタンスのみ取得できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      // 初期状態は idle なので running には含まれない
+      expect(manager.getRunningInstances()).toHaveLength(0)
+
+      // 手動で running に変更
+      store.updateDevInstanceStatus(instance.id, 'running')
+      expect(manager.getRunningInstances()).toHaveLength(1)
+    })
+  })
+
+  describe('updateWorktreePath', () => {
+    it('DevInstance の worktreePath を更新できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.updateWorktreePath(instance.id, '/tmp/worktree')
+
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.worktreePath).toBe('/tmp/worktree')
+    })
+  })
+
+  describe('updateSessionBinding', () => {
+    it('DevInstance にセッションをバインドできる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.updateSessionBinding(instance.id, 'session-abc')
+
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBe('session-abc')
+    })
+  })
+
+  describe('イベント中継', () => {
+    it('supervisor の stopped イベントを中継する', () => {
+      const handler = vi.fn()
+      manager.on('stopped', handler)
+
+      const instance = manager.startInstance(0, createDummySpawnFn())
+      manager.stopInstance(0)
+
+      expect(handler).toHaveBeenCalledWith(instance.id)
+    })
+  })
+})

--- a/packages/server/src/__tests__/session-dev-binding-service.test.ts
+++ b/packages/server/src/__tests__/session-dev-binding-service.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import { SessionDevBindingService } from '../services/session-dev-binding-service'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('SessionDevBindingService', () => {
+  let store: SessionStore
+  let manager: DevInstanceManager
+  let service: SessionDevBindingService
+
+  const dummySpawn: SpawnFn = (_onExit) => 99999
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    manager = new DevInstanceManager(store, { checkIntervalMs: 100 })
+    service = new SessionDevBindingService(store, manager)
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    store.close()
+  })
+
+  /** テスト用セッションを作成する */
+  function createSession(name = 'test-session') {
+    return store.create({
+      name,
+      repoPath: '/tmp/repo',
+    })
+  }
+
+  describe('bind', () => {
+    it('セッションと DevInstance をバインドできる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+
+      const bound = service.getBindingForSession(session.id)
+      expect(bound).not.toBeNull()
+      expect(bound!.id).toBe(instance.id)
+      expect(bound!.assignedSessionId).toBe(session.id)
+    })
+
+    it('存在しないセッションへのバインドはエラー', () => {
+      const instance = manager.startInstance(0, dummySpawn)
+
+      expect(() => {
+        service.bind('non-existent', instance.id)
+      }).toThrow('セッション non-existent が見つかりません')
+    })
+
+    it('存在しないインスタンスへのバインドはエラー', () => {
+      const session = createSession()
+
+      expect(() => {
+        service.bind(session.id, 'non-existent')
+      }).toThrow('DevInstance non-existent が見つかりません')
+    })
+
+    it('既に別のセッションがバインドされているインスタンスへのバインドはエラー', () => {
+      const session1 = createSession('session-1')
+      const session2 = createSession('session-2')
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session1.id, instance.id)
+
+      expect(() => {
+        service.bind(session2.id, instance.id)
+      }).toThrow('既にセッション')
+    })
+
+    it('同じセッションの再バインドは成功する（冪等）', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      // 同じセッションで再度バインド → エラーにならない
+      expect(() => service.bind(session.id, instance.id)).not.toThrow()
+    })
+  })
+
+  describe('unbind', () => {
+    it('セッションのバインドを解除できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      service.unbind(session.id)
+
+      expect(service.getBindingForSession(session.id)).toBeNull()
+
+      // DevInstance 側もアンバインドされている
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBeNull()
+    })
+
+    it('バインドされていないセッションの unbind は安全に無視される', () => {
+      expect(() => service.unbind('non-existent')).not.toThrow()
+    })
+  })
+
+  describe('unbindByInstance', () => {
+    it('インスタンス ID でバインドを解除できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      service.unbindByInstance(instance.id)
+
+      expect(service.isBound(session.id)).toBe(false)
+    })
+  })
+
+  describe('getBindingForSession', () => {
+    it('バインドされていない場合は null を返す', () => {
+      const session = createSession()
+      expect(service.getBindingForSession(session.id)).toBeNull()
+    })
+  })
+
+  describe('getBoundSessionId', () => {
+    it('バインドされたセッション ID を取得できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+
+      expect(service.getBoundSessionId(instance.id)).toBe(session.id)
+    })
+
+    it('バインドされていない場合は null を返す', () => {
+      const instance = manager.startInstance(0, dummySpawn)
+      expect(service.getBoundSessionId(instance.id)).toBeNull()
+    })
+  })
+
+  describe('isBound', () => {
+    it('バインドされている場合は true を返す', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      expect(service.isBound(session.id)).toBe(true)
+    })
+
+    it('バインドされていない場合は false を返す', () => {
+      const session = createSession()
+      expect(service.isBound(session.id)).toBe(false)
+    })
+  })
+})

--- a/packages/server/src/__tests__/session-lifecycle.test.ts
+++ b/packages/server/src/__tests__/session-lifecycle.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { cleanupSession, retryTombstoneCleanup } from '../services/session-lifecycle'
+
+/** PtyManager のモック */
+function createMockPtyManager() {
+  return {
+    kill: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    backend: 'node-pty' as const,
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    killAll: vi.fn(),
+  } as any
+}
+
+/** SshManager のモック */
+function createMockSshManager() {
+  return {
+    kill: vi.fn(),
+    hasSession: vi.fn().mockReturnValue(false),
+    connect: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    disconnectAll: vi.fn(),
+    getHosts: vi.fn().mockReturnValue([]),
+  } as any
+}
+
+/** WorktreeService のモック */
+function createMockWorktreeService(removeThrows = false) {
+  return {
+    remove: removeThrows
+      ? vi.fn().mockImplementation(() => { throw new Error('worktree 削除失敗') })
+      : vi.fn(),
+    create: vi.fn().mockReturnValue('/tmp/worktree'),
+    getBranch: vi.fn().mockReturnValue('main'),
+    isGitRepo: vi.fn().mockReturnValue(true),
+    list: vi.fn().mockReturnValue([]),
+    prune: vi.fn(),
+    cleanupOrphanedBranches: vi.fn().mockReturnValue([]),
+    ensurePersistentDevelopWorktree: vi.fn().mockReturnValue('/tmp/persistent'),
+  } as any
+}
+
+describe('cleanupSession (async)', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('正常な cleanup: PTY kill → worktree 削除 → DB 削除', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/test',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // PTY が kill されている
+    expect(ptyManager.kill).toHaveBeenCalledWith(session.id)
+    // worktree が削除されている
+    expect(worktreeService.remove).toHaveBeenCalledWith('/tmp/repo', '/tmp/repo/.kurimats-worktrees/test')
+    // DB から削除されている
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('worktree 削除失敗 → tombstone に遷移（DB は残る）', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/test',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService(true) // remove が例外を投げる
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // DB にはまだ残っていて tombstone 状態
+    const remaining = store.getById(session.id)
+    expect(remaining).not.toBeNull()
+    expect(remaining!.status).toBe('tombstone')
+  })
+
+  it('worktree なしのセッションは直接 DB 削除', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      // worktreePath なし
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(store.getById(session.id)).toBeNull()
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+  })
+
+  it('存在しないセッション ID は安全に無視される', async () => {
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await expect(
+      cleanupSession(store, ptyManager, sshManager, worktreeService, 'non-existent'),
+    ).resolves.not.toThrow()
+  })
+
+  it('SSH セッションの場合は sshManager.kill が呼ばれる', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      sshHost: 'remote-host',
+      isRemote: true,
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    sshManager.hasSession.mockReturnValue(true)
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(sshManager.kill).toHaveBeenCalledWith(session.id)
+    expect(ptyManager.kill).not.toHaveBeenCalled()
+  })
+
+  it('persistent develop worktree はセッション削除時に worktree を残す', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // worktree は削除されない
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+    // セッションは DB から削除される
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('cleanup 中は cleaning 状態を経由する', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+    })
+
+    // worktreeService.remove を遅延させて cleaning 状態を確認
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    // cleanupSession 開始直後に状態を確認するため、pty.kill のモックで状態をキャプチャ
+    let statusDuringKill: string | undefined
+    ptyManager.kill.mockImplementation(() => {
+      statusDuringKill = store.getById(session.id)?.status
+    })
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(statusDuringKill).toBe('cleaning')
+  })
+})
+
+describe('retryTombstoneCleanup', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('tombstone セッションの worktree を削除して DB から消す', () => {
+    const session = store.create({
+      name: 'tombstone-test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/tombstone',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    expect(worktreeService.remove).toHaveBeenCalled()
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('tombstone retry でも worktree 削除失敗の場合は残留する', () => {
+    const session = store.create({
+      name: 'tombstone-test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/stuck',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService(true) // remove が例外
+    retryTombstoneCleanup(store, worktreeService)
+
+    // DB に残留
+    const remaining = store.getById(session.id)
+    expect(remaining).not.toBeNull()
+    expect(remaining!.status).toBe('tombstone')
+  })
+
+  it('tombstone がない場合は何もしない', () => {
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+  })
+
+  it('persistent develop の tombstone は worktree を削除せず DB から消す', () => {
+    const session = store.create({
+      name: 'persistent-tombstone',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    // worktree は削除されない
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+    // DB からは削除される
+    expect(store.getById(session.id)).toBeNull()
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,8 @@ import { PtyManager } from './services/pty-manager.js'
 import { SshManager } from './services/ssh-manager.js'
 import { WorktreeService } from './services/worktree-service.js'
 import { SessionStore } from './services/session-store.js'
+import { DevInstanceManager } from './services/dev-instance-manager.js'
+import { SessionDevBindingService } from './services/session-dev-binding-service.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -55,6 +57,11 @@ const sshManager = new SshManager()
 const worktreeService = new WorktreeService()
 const sessionStore = new SessionStore()
 const canvasStore = new CanvasStore()
+const devInstanceManager = new DevInstanceManager(sessionStore)
+devInstanceManager.on('error', (instanceId: string, err: unknown) => {
+  console.error(`❌ DevInstance ${instanceId} エラー:`, err)
+})
+const bindingService = new SessionDevBindingService(sessionStore, devInstanceManager)
 
 const markDisconnected = (sessionId: string) => {
   const session = sessionStore.getById(sessionId)
@@ -100,7 +107,7 @@ app.use('/api/layout', createLayoutRouter(sessionStore, canvasStore))
 app.use('/api/tab', createTabRouter(sessionStore, ptyManager, sshManager, worktreeService))
 app.use('/api/ssh', createSshRouter(sshManager, sessionStore))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
-app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService))
+app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService, devInstanceManager, bindingService))
 
 // 本番時: 静的ファイル配信（Electronビルド or スタンドアロン）
 const STATIC_DIR = process.env.STATIC_DIR
@@ -175,6 +182,7 @@ server.listen(PORT, HOST, () => {
 // グレースフルシャットダウン
 function shutdown() {
   console.log('\nシャットダウン中...')
+  devInstanceManager.shutdown()
   ptyManager.killAll()
   sshManager.disconnectAll()
   sessionStore.close()

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -58,15 +58,20 @@ export function createSessionsRouter(
   })
 
   // セッション終了
-  router.delete('/:id', (req, res) => {
+  router.delete('/:id', async (req, res) => {
     const session = store.getById(req.params.id)
     if (!session) {
       res.status(404).json({ error: 'セッションが見つかりません' })
       return
     }
 
-    cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
-    res.json({ ok: true })
+    try {
+      await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+      res.json({ ok: true })
+    } catch (e) {
+      console.error(`セッション終了エラー "${session.name}":`, e)
+      res.status(500).json({ error: `セッション終了に失敗: ${e}` })
+    }
   })
 
   // セッション再接続（PTY再spawn）

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -2,7 +2,9 @@ import { Router } from 'express'
 import type { SessionStore } from '../services/session-store.js'
 import type { PtyManager } from '../services/pty-manager.js'
 import type { SshManager } from '../services/ssh-manager.js'
-import type { WorktreeService } from '../services/worktree-service.js'
+import { WorktreeService } from '../services/worktree-service.js'
+import type { DevInstanceManager } from '../services/dev-instance-manager.js'
+import type { SessionDevBindingService } from '../services/session-dev-binding-service.js'
 import type { PaneNode, PaneLeaf, SplitDirection, Session } from '@kurimats/shared'
 import { createAndSpawnSession, cleanupSession } from '../services/session-lifecycle.js'
 import {
@@ -49,11 +51,39 @@ async function createWorkspaceSession(
   return { session, paneId }
 }
 
+/**
+ * ローカルリポジトリの場合、pane のスロット番号に対応する
+ * persistent develop worktree を確保して DevInstance に記録する
+ */
+function ensurePersistentDevelop(
+  worktreeService: WorktreeService,
+  devInstanceManager: DevInstanceManager | undefined,
+  repoPath: string,
+  sshHost: string | null | undefined,
+  slotNumber: number,
+): void {
+  if (!devInstanceManager) return
+  if (sshHost) return // リモートの場合はスキップ
+  if (!worktreeService.isGitRepo(repoPath)) return
+
+  try {
+    const worktreePath = worktreeService.ensurePersistentDevelopWorktree(repoPath, slotNumber)
+    const instance = devInstanceManager.getInstance(slotNumber)
+    if (instance) {
+      devInstanceManager.updateWorktreePath(instance.id, worktreePath)
+    }
+  } catch (e) {
+    console.warn(`⚠️ persistent develop worktree 確保失敗 (スロット${slotNumber}): ${e}`)
+  }
+}
+
 export function createWorkspacesRouter(
   store: SessionStore,
   ptyManager: PtyManager,
   sshManager: SshManager,
   worktreeService: WorktreeService,
+  devInstanceManager?: DevInstanceManager,
+  bindingService?: SessionDevBindingService,
 ): Router {
   const router = Router()
 
@@ -122,6 +152,22 @@ export function createWorkspacesRouter(
         paneTree,
         workspaceId,
       )
+
+      // persistent develop worktree を確保（ローカルリポジトリのみ）
+      const paneNumber = process.env.PANE_NUMBER != null
+        ? parseInt(process.env.PANE_NUMBER, 10)
+        : null
+      if (paneNumber != null) {
+        ensurePersistentDevelop(worktreeService, devInstanceManager, repoPath, sshHost, paneNumber)
+
+        // セッションと DevInstance をバインド
+        if (bindingService && devInstanceManager) {
+          const instance = devInstanceManager.getInstance(paneNumber)
+          if (instance) {
+            try { bindingService.bind(session.id, instance.id) } catch { /* バインド失敗は非致命的 */ }
+          }
+        }
+      }
 
       res.status(201).json(workspace)
     } catch (e) {
@@ -194,7 +240,7 @@ export function createWorkspacesRouter(
 
       const splitTree = splitLeafInTree(workspace.paneTree, paneId, direction, newLeaf)
       if (!splitTree) {
-        cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
         res.status(400).json({ error: '指定されたペインが見つかりません' })
         return
       }
@@ -212,7 +258,7 @@ export function createWorkspacesRouter(
       })
     } catch (e) {
       if (session) {
-        cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
       }
       console.error('ペイン分割エラー:', e)
       res.status(500).json({ error: `ペイン分割に失敗: ${e}` })
@@ -220,7 +266,7 @@ export function createWorkspacesRouter(
   })
 
   // ペイン閉じ（セッション/PTY/worktreeも連動削除）
-  router.post('/:id/close-pane', (req, res) => {
+  router.post('/:id/close-pane', async (req, res) => {
     const { paneId } = req.body as { paneId: string }
     if (!paneId) {
       res.status(400).json({ error: 'paneId は必須です' })
@@ -263,9 +309,14 @@ export function createWorkspacesRouter(
     // DB更新
     store.updateCmuxPaneTree(workspace.id, rebalanced, newActivePaneId)
 
-    // セッション/PTY/worktreeをクリーンアップ
+    // セッション/PTY/worktreeをクリーンアップ（失敗してもペインツリーは更新済み）
     if (sessionId) {
-      cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      if (bindingService) bindingService.unbind(sessionId)
+      try {
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      } catch (e) {
+        console.error(`ペイン閉じ時のセッション cleanup エラー (${sessionId}):`, e)
+      }
     }
 
     res.json({
@@ -312,17 +363,22 @@ export function createWorkspacesRouter(
   })
 
   // ワークスペース削除（全セッション/PTY/worktreeも連動クリーンアップ）
-  router.delete('/:id', (req, res) => {
+  router.delete('/:id', async (req, res) => {
     const workspace = store.getCmuxWorkspace(req.params.id)
     if (!workspace) {
       res.status(404).json({ error: 'ワークスペースが見つかりません' })
       return
     }
 
-    // ペインツリー内の全セッションをクリーンアップ
+    // ペインツリー内の全セッションをクリーンアップ（個別失敗は続行）
     const sessionIds = collectSessionIds(workspace.paneTree)
     for (const sessionId of sessionIds) {
-      cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      if (bindingService) bindingService.unbind(sessionId)
+      try {
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      } catch (e) {
+        console.error(`ワークスペース削除時のセッション cleanup エラー (${sessionId}):`, e)
+      }
     }
 
     const deleted = store.deleteCmuxWorkspace(req.params.id)

--- a/packages/server/src/services/dev-instance-manager.ts
+++ b/packages/server/src/services/dev-instance-manager.ts
@@ -1,0 +1,197 @@
+/**
+ * DevInstanceManager — DevInstance/Slot ストアと ProcessSupervisor の統合管理
+ *
+ * 責務:
+ * - スロット割り当て + DevInstance 作成 + プロセス監視の一括管理
+ * - インスタンス停止時のリソース解放（supervisor 停止 + slot 解放 + DB 削除）
+ * - 起動中インスタンスの一覧取得
+ */
+import { EventEmitter } from 'events'
+import type { DevInstance } from '@kurimats/shared'
+import type { SessionStore } from './session-store.js'
+import { ProcessSupervisor, type SpawnFn } from './process-supervisor.js'
+import { calculatePortsForSlot } from '../utils/ports.js'
+
+export interface DevInstanceManagerOptions {
+  /** ProcessSupervisor のヘルスチェック間隔（ms） */
+  checkIntervalMs?: number
+  /** 最大再起動回数 */
+  maxRestarts?: number
+}
+
+export class DevInstanceManager extends EventEmitter {
+  private store: SessionStore
+  private supervisor: ProcessSupervisor
+
+  constructor(store: SessionStore, options?: DevInstanceManagerOptions) {
+    super()
+    this.store = store
+    this.supervisor = new ProcessSupervisor({
+      checkIntervalMs: options?.checkIntervalMs,
+      maxRestarts: options?.maxRestarts,
+    })
+
+    // supervisor イベントを中継
+    this.supervisor.on('healthy', (instanceId: string) => {
+      this.store.updateDevInstanceStatus(instanceId, 'running')
+      this.emit('healthy', instanceId)
+    })
+    this.supervisor.on('error', (instanceId: string, err: unknown) => {
+      this.store.updateDevInstanceStatus(instanceId, 'error')
+      this.emit('error', instanceId, err)
+    })
+    this.supervisor.on('stopped', (instanceId: string) => {
+      this.emit('stopped', instanceId)
+    })
+  }
+
+  /**
+   * スロットにインスタンスを作成して監視を開始する
+   *
+   * 1. ポート計算
+   * 2. slot_assignments に排他的に割り当て
+   * 3. dev_instances に DB レコード作成
+   * 4. spawnFn でプロセス起動 → supervisor 監視開始
+   *
+   * @param slotNumber スロット番号（PANE_NUMBER に対応）
+   * @param spawnFn プロセス起動関数
+   * @returns 作成された DevInstance
+   * @throws スロットが既に使用中の場合は UNIQUE constraint エラー
+   */
+  startInstance(slotNumber: number, spawnFn: SpawnFn): DevInstance {
+    // ポート算出
+    const ports = calculatePortsForSlot(slotNumber)
+
+    // スロット排他割り当て（UNIQUE 制約で競合検出）
+    // DevInstance を先に作成してから slot を割り当てる
+    const instance = this.store.createDevInstance({
+      slotNumber,
+      ...ports,
+    })
+
+    try {
+      this.store.assignSlot(slotNumber, instance.id)
+    } catch (e) {
+      // slot 割り当て失敗 → DevInstance ロールバック
+      this.store.deleteDevInstance(instance.id)
+      throw e
+    }
+
+    // supervisor で監視開始
+    try {
+      this.supervisor.supervise(instance.id, spawnFn)
+    } catch (e) {
+      // supervisor 開始失敗 → slot + DevInstance ロールバック
+      this.store.releaseSlot(slotNumber)
+      this.store.deleteDevInstance(instance.id)
+      throw e
+    }
+
+    // spawnFn が即座にエラーを起こした場合（supervisor が catch → emit）
+    const status = this.supervisor.getStatus(instance.id)
+    if (status?.status === 'error') {
+      this.supervisor.stop(instance.id)
+      this.store.releaseSlot(slotNumber)
+      this.store.deleteDevInstance(instance.id)
+      throw new Error(`インスタンス起動失敗 (スロット${slotNumber}): spawnFn がエラーを返しました`)
+    }
+
+    return instance
+  }
+
+  /**
+   * インスタンスを停止してリソースを解放する
+   *
+   * 1. supervisor 停止
+   * 2. slot 解放
+   * 3. DB レコード削除
+   */
+  stopInstance(slotNumber: number): void {
+    const instance = this.store.getDevInstance(slotNumber)
+    if (!instance) return
+
+    // supervisor 停止（プロセス kill も含む）
+    this.supervisor.stop(instance.id)
+
+    // slot 解放
+    this.store.releaseSlot(slotNumber)
+
+    // DB レコード削除
+    this.store.deleteDevInstance(instance.id)
+  }
+
+  /**
+   * インスタンス ID で停止する
+   */
+  stopInstanceById(instanceId: string): void {
+    const instance = this.store.getDevInstanceById(instanceId)
+    if (!instance) return
+    this.stopInstance(instance.slotNumber)
+  }
+
+  /**
+   * 全インスタンスを停止する
+   */
+  stopAll(): void {
+    const instances = this.store.getAllDevInstances()
+    for (const instance of instances) {
+      this.stopInstance(instance.slotNumber)
+    }
+  }
+
+  /**
+   * 指定スロットの DevInstance を取得する
+   */
+  getInstance(slotNumber: number): DevInstance | null {
+    return this.store.getDevInstance(slotNumber)
+  }
+
+  /**
+   * ID で DevInstance を取得する
+   */
+  getInstanceById(instanceId: string): DevInstance | null {
+    return this.store.getDevInstanceById(instanceId)
+  }
+
+  /**
+   * 全 DevInstance を取得する
+   */
+  getAllInstances(): DevInstance[] {
+    return this.store.getAllDevInstances()
+  }
+
+  /**
+   * 実行中（running）の DevInstance を取得する
+   */
+  getRunningInstances(): DevInstance[] {
+    return this.store.getAllDevInstances().filter(i => i.status === 'running')
+  }
+
+  /**
+   * supervisor の状態を取得する
+   */
+  getSupervisorStatus(instanceId: string) {
+    return this.supervisor.getStatus(instanceId)
+  }
+
+  /**
+   * DevInstance の worktreePath を更新する
+   */
+  updateWorktreePath(instanceId: string, worktreePath: string | null): void {
+    this.store.updateDevInstanceWorktreePath(instanceId, worktreePath)
+  }
+
+  /**
+   * DevInstance のセッションバインディングを更新する
+   */
+  updateSessionBinding(instanceId: string, sessionId: string | null): void {
+    this.store.updateDevInstanceSession(instanceId, sessionId)
+  }
+
+  /**
+   * シャットダウン: 全 supervisor を停止（DB レコードは残す）
+   */
+  shutdown(): void {
+    this.supervisor.stopAll()
+  }
+}

--- a/packages/server/src/services/session-dev-binding-service.ts
+++ b/packages/server/src/services/session-dev-binding-service.ts
@@ -1,0 +1,93 @@
+/**
+ * SessionDevBindingService — Session ↔ DevInstance のバインディング管理
+ *
+ * 責務:
+ * - セッションと DevInstance の 1:1 紐付け
+ * - バインド/アンバインドの整合性保証（双方向更新）
+ * - バインディング情報の参照
+ */
+import type { DevInstance } from '@kurimats/shared'
+import type { SessionStore } from './session-store.js'
+import type { DevInstanceManager } from './dev-instance-manager.js'
+
+export class SessionDevBindingService {
+  private store: SessionStore
+  private instanceManager: DevInstanceManager
+
+  constructor(store: SessionStore, instanceManager: DevInstanceManager) {
+    this.store = store
+    this.instanceManager = instanceManager
+  }
+
+  /**
+   * セッションと DevInstance をバインドする
+   *
+   * 双方向に紐付けを設定:
+   * - DevInstance.assignedSessionId = sessionId
+   * - （Session 側は workspaceId 等で間接参照）
+   *
+   * @throws セッションまたはインスタンスが存在しない場合
+   */
+  bind(sessionId: string, instanceId: string): void {
+    const session = this.store.getById(sessionId)
+    if (!session) {
+      throw new Error(`セッション ${sessionId} が見つかりません`)
+    }
+
+    const instance = this.instanceManager.getInstanceById(instanceId)
+    if (!instance) {
+      throw new Error(`DevInstance ${instanceId} が見つかりません`)
+    }
+
+    // 既に他のセッションがバインドされている場合はエラー
+    if (instance.assignedSessionId && instance.assignedSessionId !== sessionId) {
+      throw new Error(
+        `DevInstance ${instanceId} は既にセッション ${instance.assignedSessionId} にバインドされています`,
+      )
+    }
+
+    this.instanceManager.updateSessionBinding(instanceId, sessionId)
+  }
+
+  /**
+   * セッションのバインドを解除する
+   *
+   * セッション ID からバインドされた DevInstance を探してアンバインドする
+   */
+  unbind(sessionId: string): void {
+    const instance = this.getBindingForSession(sessionId)
+    if (instance) {
+      this.instanceManager.updateSessionBinding(instance.id, null)
+    }
+  }
+
+  /**
+   * インスタンス ID でバインドを解除する
+   */
+  unbindByInstance(instanceId: string): void {
+    this.instanceManager.updateSessionBinding(instanceId, null)
+  }
+
+  /**
+   * セッションにバインドされた DevInstance を取得する
+   */
+  getBindingForSession(sessionId: string): DevInstance | null {
+    const instances = this.instanceManager.getAllInstances()
+    return instances.find(i => i.assignedSessionId === sessionId) ?? null
+  }
+
+  /**
+   * DevInstance にバインドされたセッション ID を取得する
+   */
+  getBoundSessionId(instanceId: string): string | null {
+    const instance = this.instanceManager.getInstanceById(instanceId)
+    return instance?.assignedSessionId ?? null
+  }
+
+  /**
+   * セッションが DevInstance にバインドされているかどうか
+   */
+  isBound(sessionId: string): boolean {
+    return this.getBindingForSession(sessionId) !== null
+  }
+}

--- a/packages/server/src/services/session-lifecycle.ts
+++ b/packages/server/src/services/session-lifecycle.ts
@@ -6,7 +6,7 @@ import type { Session } from '@kurimats/shared'
 import type { SessionStore } from './session-store.js'
 import type { PtyManager } from './pty-manager.js'
 import type { SshManager } from './ssh-manager.js'
-import type { WorktreeService } from './worktree-service.js'
+import { WorktreeService } from './worktree-service.js'
 
 /**
  * シェルの初期化完了を検出してclaude --continueコマンドを送信する
@@ -187,18 +187,27 @@ export async function createAndSpawnSession(
 }
 
 /**
- * セッションのPTY/SSH kill + worktree削除 + DB削除
+ * セッションのPTY/SSH kill + worktree削除 + DB削除（非同期版）
+ *
+ * ステート遷移:
+ * - status → 'cleaning' → worktree 削除試行
+ *   - 成功: DB から完全削除
+ *   - 失敗: status → 'tombstone'（次回起動時に retry）
+ *
  * workspaces.ts / sessions.ts で共通利用
  */
-export function cleanupSession(
+export async function cleanupSession(
   store: SessionStore,
   ptyManager: PtyManager,
   sshManager: SshManager,
   worktreeService: WorktreeService,
   sessionId: string,
-): void {
+): Promise<void> {
   const session = store.getById(sessionId)
   if (!session) return
+
+  // cleaning 状態に遷移
+  store.updateStatus(sessionId, 'cleaning')
 
   // PTY/SSH kill
   if (sshManager.hasSession(sessionId)) {
@@ -207,16 +216,55 @@ export function cleanupSession(
     ptyManager.kill(sessionId)
   }
 
-  // worktree削除
-  if (session.worktreePath && session.repoPath) {
+  // persistent develop worktree はセッション削除時に worktree を残す
+  const isPersistent = session.worktreePath
+    ? WorktreeService.isPersistentDevelop(session.worktreePath)
+    : false
+
+  // worktree削除（persistent 以外）
+  if (session.worktreePath && session.repoPath && !isPersistent) {
     try {
       worktreeService.remove(session.repoPath, session.worktreePath)
       console.log(`🗑️ worktree削除: ${session.worktreePath}`)
     } catch (e) {
-      console.warn(`⚠️ worktree削除エラー (無視): ${e}`)
+      console.warn(`⚠️ worktree削除失敗 → tombstone に遷移: ${e}`)
+      store.updateStatus(sessionId, 'tombstone')
+      return
     }
   }
 
   // DB削除
   store.delete(sessionId)
+}
+
+/**
+ * tombstone セッションの cleanup を再試行する
+ * startup.ts から呼ばれる
+ */
+export function retryTombstoneCleanup(
+  store: SessionStore,
+  worktreeService: WorktreeService,
+): void {
+  const tombstones = store.getAll().filter(s => s.status === 'tombstone')
+  if (tombstones.length === 0) return
+
+  console.log(`🔄 ${tombstones.length}件の tombstone セッションの cleanup を再試行します`)
+  for (const session of tombstones) {
+    const isPersistent = session.worktreePath
+      ? WorktreeService.isPersistentDevelop(session.worktreePath)
+      : false
+
+    if (session.worktreePath && session.repoPath && !isPersistent) {
+      try {
+        worktreeService.remove(session.repoPath, session.worktreePath)
+        console.log(`   🗑️ tombstone worktree 削除成功: ${session.worktreePath}`)
+      } catch (e) {
+        console.warn(`   ⚠️ tombstone worktree 削除再失敗 (残留): ${e}`)
+        continue // 削除失敗は tombstone のまま残す
+      }
+    }
+
+    store.delete(session.id)
+    console.log(`   ✅ tombstone セッション "${session.name}" (${session.id.slice(0, 8)}...) を削除`)
+  }
 }

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -15,6 +15,7 @@ import path from 'path'
 import type { PaneNode } from '@kurimats/shared'
 import type { SessionStore } from './services/session-store.js'
 import { WorktreeService } from './services/worktree-service.js'
+import { retryTombstoneCleanup } from './services/session-lifecycle.js'
 import { collectSessionIds } from './utils/pane-tree.js'
 
 /** StartupGuard の判定結果 */
@@ -134,9 +135,9 @@ function phase0_migratePaneTrees(sessionStore: SessionStore): void {
   }
 }
 
-/** 段階1: PTYが消失したactiveセッションをdisconnectedに変更 */
+/** 段階1: PTYが消失したactive/cleaningセッションをdisconnectedに変更 */
 function phase1_markOrphanedDisconnected(sessionStore: SessionStore): void {
-  const orphanedSessions = sessionStore.getAll().filter(s => s.status === 'active')
+  const orphanedSessions = sessionStore.getAll().filter(s => s.status === 'active' || s.status === 'cleaning')
   if (orphanedSessions.length > 0) {
     console.log(`⚠️  ${orphanedSessions.length}件のorphanedセッションを検出 → disconnectedに変更`)
     for (const s of orphanedSessions) {
@@ -309,6 +310,9 @@ export function runStartupTasks(
 
     // 段階4: git worktree prune + orphaned branch 削除
     phase4_pruneWorktreesAndBranches(sessionStore, worktreeService)
+
+    // 段階4.5: tombstone セッションの cleanup 再試行
+    retryTombstoneCleanup(sessionStore, worktreeService)
   }
 
   // 段階5: ブランチ名修正（非破壊、常時実行）

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,5 @@
 // セッション状態
-export type SessionStatus = 'active' | 'paused' | 'terminated' | 'disconnected'
+export type SessionStatus = 'active' | 'paused' | 'terminated' | 'disconnected' | 'cleaning' | 'tombstone'
 
 // セッション
 export interface Session {


### PR DESCRIPTION
## Summary
- `DevInstanceManager`: DevInstance/Slot ストアと ProcessSupervisor を統合管理（ロールバック対応）
- `SessionDevBindingService`: Session ↔ DevInstance の 1:1 バインディング管理
- `cleanupSession` async 化: cleaning → tombstone 遷移 + startup 時 retry
- route 統合: workspaces.ts / sessions.ts を await 化 + エラーハンドリング強化
- persistent develop: WS 作成時に自動 worktree 確保
- Codex レビュー指摘4件対応済み（error イベント購読、reject ハンドリング、bind/unbind 統合、テスト追加）

## Test plan
- [x] DevInstanceManager: start/stop/getRunning/ロールバック (14テスト)
- [x] SessionDevBindingService: bind/unbind/getBinding (12テスト)
- [x] cleanupSession async: 正常削除 / tombstone 遷移 / retry (11テスト)
- [x] 全292テスト回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)