### PR TITLE
feat: Claude Code 起動時に --dangerously-skip-permissions を付与

### DIFF
--- a/packages/server/src/__tests__/sessions.test.ts
+++ b/packages/server/src/__tests__/sessions.test.ts
@@ -177,7 +177,7 @@ describeServer('セッションAPI', () => {
     expect(updated?.status).toBe('disconnected')
   })
 
-  it('セッション作成時にclaude --continueで起動される', async () => {
+  it('セッション作成時にclaude --dangerously-skip-permissions --continueで起動される', async () => {
     const res = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -185,13 +185,13 @@ describeServer('セッションAPI', () => {
     })
     expect(res.status).toBe(201)
 
-    // child_processモードではclaude --continueが直接spawnされる
+    // child_processモードではclaude --dangerously-skip-permissions --continueが直接spawnされる
     expect(ptyManager.spawn).toHaveBeenCalledWith(
-      expect.any(String), '/tmp', 120, 30, 'claude', ['--continue'],
+      expect.any(String), '/tmp', 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'],
     )
   })
 
-  it('再接続時にclaude --continueで起動される', async () => {
+  it('再接続時にclaude --dangerously-skip-permissions --continueで起動される', async () => {
     const createRes = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -207,7 +207,7 @@ describeServer('セッションAPI', () => {
     await fetch(`${baseUrl}/api/sessions/${session.id}/reconnect`, { method: 'POST' })
 
     expect(ptyManager.spawn).toHaveBeenCalledWith(
-      session.id, '/tmp', 120, 30, 'claude', ['--continue'],
+      session.id, '/tmp', 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'],
     )
   })
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -100,7 +100,7 @@ export function createSessionsRouter(
           await ptyManager.spawn(session.id, cwd, 120, 30, shell, [])
           waitForShellReady(session.id, ptyManager, sshManager, false, true)
         } else {
-          await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--continue'])
+          await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'])
         }
       }
 

--- a/packages/server/src/services/session-lifecycle.ts
+++ b/packages/server/src/services/session-lifecycle.ts
@@ -9,13 +9,14 @@ import type { SshManager } from './ssh-manager.js'
 import { WorktreeService } from './worktree-service.js'
 
 /**
- * シェルの初期化完了を検出してclaude --continueコマンドを送信する
+ * シェルの初期化完了を検出してclaude --dangerously-skip-permissionsコマンドを送信する
  * シェルのプロンプト出力（$ や % や > の末尾文字）を監視し、
- * 表示されたらclaude --continueを実行する。最大5秒のタイムアウト付き。
+ * 表示されたらclaudeを実行する。最大5秒のタイムアウト付き。
+ * --dangerously-skip-permissionsにより権限確認プロンプトをスキップする。
  * --continueにより、前回の会話履歴がある場合は自動復元される。
  */
 /**
- * @param continueSession trueの場合 `claude --continue`、falseの場合 `claude` を実行
+ * @param continueSession trueの場合 `claude --dangerously-skip-permissions --continue`、falseの場合 `claude --dangerously-skip-permissions` を実行
  */
 export function waitForShellReady(
   sessionId: string,
@@ -27,7 +28,7 @@ export function waitForShellReady(
   const manager = isRemote ? sshManager : ptyManager
   let resolved = false
   let timeoutId: ReturnType<typeof setTimeout> | null = null
-  const claudeCmd = continueSession ? 'claude --continue\r' : 'claude\r'
+  const claudeCmd = continueSession ? 'claude --dangerously-skip-permissions --continue\r' : 'claude --dangerously-skip-permissions\r'
 
   const cleanup = () => {
     manager.removeListener('data', onData)
@@ -160,8 +161,8 @@ export async function createAndSpawnSession(
           waitForShellReady(session.id, ptyManager, sshManager, false)
         }
       } else {
-        // child_processモード: claude --continueを直接起動
-        await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--continue'])
+        // child_processモード: claude --dangerously-skip-permissions --continueを直接起動
+        await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'])
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- セッション作成・再接続時の Claude Code 起動コマンドに `--dangerously-skip-permissions` を追加
- 権限確認プロンプトをスキップし、並列ワークフローの中断を防止
- child_process モード・node-pty モード・SSH モードすべてに対応

closes #177

## Test plan
- [x] `sessions.test.ts` 全15テスト合格
- [ ] kurimats-emulator でワークスペース作成 → 権限確認なしで起動確認
- [ ] ペイン分割 → 同様に bypass 付き起動確認
- [ ] セッション再接続 → `--dangerously-skip-permissions --continue` 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)