### PR TITLE
feat(server): PlaywrightRunner (Phase E, closes #187)

### DIFF
--- a/packages/server/src/__tests__/playwright-runner.test.ts
+++ b/packages/server/src/__tests__/playwright-runner.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { PlaywrightRunner } from '../services/playwright-runner'
+
+describe('PlaywrightRunner', () => {
+  let runner: PlaywrightRunner
+
+  beforeEach(() => {
+    runner = new PlaywrightRunner()
+    // error イベントの unhandled 防止
+    runner.on('runner_error', () => {})
+  })
+
+  afterEach(() => {
+    runner.stopAll()
+    runner.removeAllListeners()
+  })
+
+  describe('run', () => {
+    it('テスト実行を開始して running 状態を返す', () => {
+      // echo で即座に終了するコマンドを使ってテスト
+      const result = runner.run('inst-1', 0, '/tmp', undefined)
+
+      expect(result.instanceId).toBe('inst-1')
+      expect(result.status).toBe('running')
+      expect(result.port).toBe(3550)
+      expect(result.startedAt).toBeGreaterThan(0)
+      expect(result.testPath).toBeNull()
+    })
+
+    it('テストパスを指定して実行できる', () => {
+      const result = runner.run('inst-2', 1, '/tmp', 'e2e/basic.spec.ts')
+
+      expect(result.testPath).toBe('e2e/basic.spec.ts')
+      expect(result.port).toBe(3551)
+    })
+
+    it('同じインスタンスで二重実行はエラーになる', () => {
+      runner.run('inst-3', 0, '/tmp')
+
+      expect(() => {
+        runner.run('inst-3', 0, '/tmp')
+      }).toThrow('既にテスト実行中')
+    })
+
+    it('異なるインスタンスは独立して実行できる', () => {
+      const r1 = runner.run('inst-a', 0, '/tmp')
+      const r2 = runner.run('inst-b', 1, '/tmp')
+
+      expect(r1.port).toBe(3550)
+      expect(r2.port).toBe(3551)
+      expect(r1.instanceId).not.toBe(r2.instanceId)
+    })
+  })
+
+  describe('run + 完了', () => {
+    it('成功したテストは passed 状態になる', async () => {
+      // echo で即座に exit 0 するコマンドを npxPath として使用
+      const fastRunner = new PlaywrightRunner({ npxPath: 'echo' })
+      fastRunner.on('runner_error', () => {})
+
+      const result = fastRunner.run('fast-1', 0, '/tmp')
+
+      // finished イベントを待つ
+      await new Promise<void>((resolve) => {
+        fastRunner.on('finished', () => resolve())
+      })
+
+      expect(result.status).toBe('passed')
+      expect(result.exitCode).toBe(0)
+      expect(result.finishedAt).toBeGreaterThan(0)
+
+      fastRunner.stopAll()
+    })
+
+    it('失敗したテストは failed 状態になる', async () => {
+      // false コマンドで exit 1
+      const failRunner = new PlaywrightRunner({ npxPath: 'false' })
+      failRunner.on('runner_error', () => {})
+
+      const result = failRunner.run('fail-1', 0, '/tmp')
+
+      await new Promise<void>((resolve) => {
+        failRunner.on('finished', () => resolve())
+      })
+
+      expect(result.status).toBe('failed')
+      expect(result.exitCode).not.toBe(0)
+
+      failRunner.stopAll()
+    })
+  })
+
+  describe('stop', () => {
+    it('実行中のテストを中止できる', async () => {
+      // sleep で長時間実行するコマンド
+      const slowRunner = new PlaywrightRunner({ npxPath: 'sleep' })
+      slowRunner.on('runner_error', () => {})
+
+      slowRunner.run('slow-1', 0, '/tmp')
+      slowRunner.stop('slow-1')
+
+      await new Promise<void>((resolve) => {
+        slowRunner.on('finished', () => resolve())
+      })
+
+      const result = slowRunner.getResult('slow-1')
+      expect(result!.status).toBe('cancelled')
+
+      slowRunner.stopAll()
+    })
+
+    it('実行していな��インスタンスの stop は安全に無視される', () => {
+      expect(() => runner.stop('non-existent')).not.toThrow()
+    })
+  })
+
+  describe('getResult / getStatus', () => {
+    it('実行結果を取得できる', () => {
+      runner.run('inst-r', 0, '/tmp')
+
+      const result = runner.getResult('inst-r')
+      expect(result).not.toBeNull()
+      expect(result!.instanceId).toBe('inst-r')
+    })
+
+    it('存在しないインスタンスは null / idle を返す', () => {
+      expect(runner.getResult('no-exist')).toBeNull()
+      expect(runner.getStatus('no-exist')).toBe('idle')
+    })
+  })
+
+  describe('getAllResults', () => {
+    it('全結果を取得できる', () => {
+      runner.run('a', 0, '/tmp')
+      runner.run('b', 1, '/tmp')
+
+      expect(runner.getAllResults()).toHaveLength(2)
+    })
+  })
+
+  describe('clearFinished', () => {
+    it('完了済みの結果をクリアする', async () => {
+      const fastRunner = new PlaywrightRunner({ npxPath: 'echo' })
+      fastRunner.on('runner_error', () => {})
+
+      fastRunner.run('clear-1', 0, '/tmp')
+
+      await new Promise<void>((resolve) => {
+        fastRunner.on('finished', () => resolve())
+      })
+
+      expect(fastRunner.getAllResults()).toHaveLength(1)
+      fastRunner.clearFinished()
+      expect(fastRunner.getAllResults()).toHaveLength(0)
+
+      fastRunner.stopAll()
+    })
+  })
+
+  describe('イベント', () => {
+    it('started イベントが発火する', () => {
+      const handler = vi.fn()
+      runner.on('started', handler)
+
+      runner.run('evt-1', 0, '/tmp')
+
+      expect(handler).toHaveBeenCalledWith('evt-1', expect.objectContaining({ instanceId: 'evt-1' }))
+    })
+
+    it('progress イベントが発火する', () => {
+      const handler = vi.fn()
+      runner.on('progress', handler)
+
+      runner.run('evt-2', 0, '/tmp')
+
+      expect(handler).toHaveBeenCalledWith('evt-2', 'running')
+    })
+  })
+
+  describe('ポート分離', () => {
+    it('スロット番号に応じたポートが設定される', () => {
+      const r0 = runner.run('port-0', 0, '/tmp')
+      const r1 = runner.run('port-1', 1, '/tmp')
+      const r3 = runner.run('port-3', 3, '/tmp')
+
+      expect(r0.port).toBe(3550)
+      expect(r1.port).toBe(3551)
+      expect(r3.port).toBe(3553)
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,8 @@ import { WorktreeService } from './services/worktree-service.js'
 import { SessionStore } from './services/session-store.js'
 import { DevInstanceManager } from './services/dev-instance-manager.js'
 import { SessionDevBindingService } from './services/session-dev-binding-service.js'
+import { PlaywrightRunner } from './services/playwright-runner.js'
+import { createPlaywrightRouter } from './routes/playwright.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -62,6 +64,10 @@ devInstanceManager.on('error', (instanceId: string, err: unknown) => {
   console.error(`❌ DevInstance ${instanceId} エラー:`, err)
 })
 const bindingService = new SessionDevBindingService(sessionStore, devInstanceManager)
+const playwrightRunner = new PlaywrightRunner()
+playwrightRunner.on('runner_error', (instanceId: string, err: unknown) => {
+  console.error(`❌ Playwright Runner ${instanceId} エラー:`, err)
+})
 
 const markDisconnected = (sessionId: string) => {
   const session = sessionStore.getById(sessionId)
@@ -108,6 +114,7 @@ app.use('/api/tab', createTabRouter(sessionStore, ptyManager, sshManager, worktr
 app.use('/api/ssh', createSshRouter(sshManager, sessionStore))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
 app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService, devInstanceManager, bindingService))
+app.use('/api/playwright', createPlaywrightRouter(playwrightRunner, devInstanceManager))
 
 // 本番時: 静的ファイル配信（Electronビルド or スタンドアロン）
 const STATIC_DIR = process.env.STATIC_DIR
@@ -143,7 +150,7 @@ setupTerminalWs(terminalWss, ptyManager, sshManager)
 
 // WebSocketサーバー（通知用）
 const notificationWss = new WebSocketServer({ noServer: true })
-setupNotificationWs(notificationWss, sshManager)
+setupNotificationWs(notificationWss, sshManager, playwrightRunner)
 
 // WebSocketアップグレード処理
 server.on('upgrade', (request, socket, head) => {
@@ -180,8 +187,9 @@ server.listen(PORT, HOST, () => {
 })
 
 // グレースフルシャットダウン
-function shutdown() {
+async function shutdown() {
   console.log('\nシャットダウン中...')
+  await playwrightRunner.stopAllAndWait()
   devInstanceManager.shutdown()
   ptyManager.killAll()
   sshManager.disconnectAll()

--- a/packages/server/src/routes/playwright.ts
+++ b/packages/server/src/routes/playwright.ts
@@ -1,0 +1,92 @@
+/**
+ * Playwright Runner REST API ルート
+ *
+ * POST   /api/playwright/run            — テスト実行指示
+ * GET    /api/playwright/status/:id     — 実行状態取得
+ * DELETE /api/playwright/run/:id        — 実行中止
+ * GET    /api/playwright/results        — 全結果取得
+ * POST   /api/playwright/clear          — 完了済み結果クリア
+ */
+import { Router } from 'express'
+import type { PlaywrightRunner } from '../services/playwright-runner.js'
+import type { DevInstanceManager } from '../services/dev-instance-manager.js'
+
+export function createPlaywrightRouter(
+  runner: PlaywrightRunner,
+  devInstanceManager: DevInstanceManager,
+): Router {
+  const router = Router()
+
+  // テスト実行指示
+  router.post('/run', (req, res) => {
+    const { instanceId, testPath, cwd } = req.body as {
+      instanceId?: string
+      testPath?: string
+      cwd?: string
+    }
+
+    if (!instanceId || typeof instanceId !== 'string') {
+      res.status(400).json({ error: 'instanceId は文字列で必須です' })
+      return
+    }
+    if (testPath !== undefined && typeof testPath !== 'string') {
+      res.status(400).json({ error: 'testPath は文字列で指定してください' })
+      return
+    }
+    if (cwd !== undefined && typeof cwd !== 'string') {
+      res.status(400).json({ error: 'cwd は文字列で指定してください' })
+      return
+    }
+
+    const instance = devInstanceManager.getInstanceById(instanceId)
+    if (!instance) {
+      res.status(404).json({ error: `DevInstance ${instanceId} が見つかりません` })
+      return
+    }
+
+    // cwd が指定されていなければ DevInstance の worktreePath または process.cwd() を使用
+    const effectiveCwd = cwd || instance.worktreePath || process.cwd()
+
+    try {
+      const result = runner.run(instanceId, instance.slotNumber, effectiveCwd, testPath)
+      res.status(201).json(result)
+    } catch (e) {
+      res.status(409).json({ error: `${e}` })
+    }
+  })
+
+  // 実行状態取得
+  router.get('/status/:id', (req, res) => {
+    const result = runner.getResult(req.params.id)
+    if (!result) {
+      res.json({ instanceId: req.params.id, status: 'idle' })
+      return
+    }
+    res.json(result)
+  })
+
+  // 実行中止
+  router.delete('/run/:id', (req, res) => {
+    const result = runner.getResult(req.params.id)
+    if (!result || result.status !== 'running') {
+      res.status(400).json({ error: '実行中のテストがありません' })
+      return
+    }
+
+    runner.stop(req.params.id)
+    res.json({ ok: true, instanceId: req.params.id })
+  })
+
+  // 全結果取得
+  router.get('/results', (_req, res) => {
+    res.json(runner.getAllResults())
+  })
+
+  // 完了済み結果クリア
+  router.post('/clear', (_req, res) => {
+    runner.clearFinished()
+    res.json({ ok: true })
+  })
+
+  return router
+}

--- a/packages/server/src/services/playwright-runner.ts
+++ b/packages/server/src/services/playwright-runner.ts
@@ -1,0 +1,239 @@
+/**
+ * PlaywrightRunner — pane 単位の Playwright テスト実行管理
+ *
+ * 責務:
+ * - slot/instance ベースのポート固定化でテスト実行
+ * - テスト進捗・結果のイベント発火（WebSocket 通知用）
+ * - 多重実行の防止（instance 単位で1プロセスのみ）
+ */
+import { EventEmitter } from 'events'
+import { spawn, type ChildProcess } from 'child_process'
+import type { PlaywrightRunResult, PlaywrightRunStatus } from '@kurimats/shared'
+import { calculatePort, PLAYWRIGHT_PORT_BASE } from '../utils/ports.js'
+
+export interface PlaywrightRunnerOptions {
+  /** npx コマンドパス（テスト時に差し替え可能） */
+  npxPath?: string
+  /** 出力バッファの最大長（バイト） */
+  maxOutputLength?: number
+}
+
+const DEFAULT_OPTIONS: Required<PlaywrightRunnerOptions> = {
+  npxPath: 'npx',
+  maxOutputLength: 512 * 1024, // 512KB
+}
+
+export class PlaywrightRunner extends EventEmitter {
+  private runs = new Map<string, PlaywrightRunResult>()
+  private processes = new Map<string, ChildProcess>()
+  private killTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private options: Required<PlaywrightRunnerOptions>
+
+  constructor(options?: PlaywrightRunnerOptions) {
+    super()
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * テストを実行する
+   *
+   * @param instanceId DevInstance ID（実行の識別子として使用）
+   * @param slotNumber スロット番号（ポート算出用）
+   * @param testPath テストファイルパス（省略時は全テスト）
+   * @param cwd テスト実行ディレクトリ
+   * @returns 実行結果オブジェクト（ステータスは running で返る）
+   * @throws 既に実行中の場合
+   */
+  run(instanceId: string, slotNumber: number, cwd: string, testPath?: string): PlaywrightRunResult {
+    const existing = this.runs.get(instanceId)
+    if (existing?.status === 'running') {
+      throw new Error(`インスタンス ${instanceId} は既にテスト実行中です`)
+    }
+
+    const port = calculatePort(PLAYWRIGHT_PORT_BASE, slotNumber)
+    const now = Date.now()
+
+    const result: PlaywrightRunResult = {
+      instanceId,
+      status: 'running',
+      testPath: testPath ?? null,
+      pid: null,
+      startedAt: now,
+      finishedAt: null,
+      exitCode: null,
+      output: '',
+      port,
+    }
+    this.runs.set(instanceId, result)
+
+    // Playwright テスト実行
+    const args = ['playwright', 'test']
+    if (testPath) args.push(testPath)
+    args.push('--reporter=line')
+
+    const child = spawn(this.options.npxPath, args, {
+      cwd,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_MCP_PORT: String(port),
+        // CI モードでヘッドレス実行
+        CI: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    result.pid = child.pid ?? null
+    this.processes.set(instanceId, child)
+
+    this.emit('started', instanceId, result)
+    this.emit('progress', instanceId, 'running' as PlaywrightRunStatus)
+
+    // stdout/stderr を収集
+    const appendOutput = (data: Buffer) => {
+      const line = data.toString()
+      const remaining = this.options.maxOutputLength - result.output.length
+      if (remaining > 0) {
+        result.output += remaining >= line.length ? line : line.slice(0, remaining)
+      }
+      this.emit('output', instanceId, line)
+      this.emit('progress', instanceId, 'running' as PlaywrightRunStatus, line)
+    }
+
+    child.stdout?.on('data', appendOutput)
+    child.stderr?.on('data', appendOutput)
+
+    child.on('close', (code) => {
+      result.finishedAt = Date.now()
+      result.exitCode = code
+
+      // SIGKILL フォールバックのタイマーをクリア
+      const killTimer = this.killTimers.get(instanceId)
+      if (killTimer) {
+        clearTimeout(killTimer)
+        this.killTimers.delete(instanceId)
+      }
+
+      if (result.status === 'cancelled') {
+        // stop() で既にキャンセル済み
+      } else if (code === 0) {
+        result.status = 'passed'
+      } else {
+        result.status = 'failed'
+      }
+
+      this.processes.delete(instanceId)
+      this.emit('finished', instanceId, result)
+      this.emit('progress', instanceId, result.status)
+    })
+
+    child.on('error', (err) => {
+      result.status = 'error'
+      result.finishedAt = Date.now()
+      result.output += `\nプロセスエラー: ${err.message}`
+      this.processes.delete(instanceId)
+
+      const killTimer = this.killTimers.get(instanceId)
+      if (killTimer) {
+        clearTimeout(killTimer)
+        this.killTimers.delete(instanceId)
+      }
+
+      this.emit('runner_error', instanceId, err)
+      this.emit('progress', instanceId, 'error' as PlaywrightRunStatus)
+    })
+
+    return result
+  }
+
+  /**
+   * 実行中のテストを中止する
+   */
+  stop(instanceId: string): void {
+    const result = this.runs.get(instanceId)
+    const child = this.processes.get(instanceId)
+
+    if (result && result.status === 'running') {
+      result.status = 'cancelled'
+    }
+
+    if (child) {
+      child.kill('SIGTERM')
+      // 3秒後にまだ生きていれば SIGKILL（close で clearTimeout するため誤送信なし）
+      const timer = setTimeout(() => {
+        if (this.processes.has(instanceId)) {
+          child.kill('SIGKILL')
+        }
+        this.killTimers.delete(instanceId)
+      }, 3000)
+      this.killTimers.set(instanceId, timer)
+    }
+  }
+
+  /**
+   * 全実行を中止する
+   */
+  stopAll(): void {
+    for (const id of [...this.processes.keys()]) {
+      this.stop(id)
+    }
+  }
+
+  /**
+   * 全実行を中止し、子プロセスの終了を待つ（シャットダウン用）
+   * @param timeoutMs 最大待機時間（デフォルト5秒）
+   */
+  async stopAllAndWait(timeoutMs = 5000): Promise<void> {
+    this.stopAll()
+    if (this.processes.size === 0) return
+
+    await Promise.race([
+      Promise.all(
+        [...this.processes.keys()].map(id =>
+          new Promise<void>(resolve => {
+            const check = () => {
+              if (!this.processes.has(id)) return resolve()
+              this.once('finished', (_finishedId) => {
+                if (_finishedId === id) resolve()
+                else check()
+              })
+            }
+            check()
+          }),
+        ),
+      ),
+      new Promise<void>(resolve => setTimeout(resolve, timeoutMs)),
+    ])
+  }
+
+  /**
+   * 実行結果を取得する
+   */
+  getResult(instanceId: string): PlaywrightRunResult | null {
+    return this.runs.get(instanceId) ?? null
+  }
+
+  /**
+   * 実行ステータスを取得する
+   */
+  getStatus(instanceId: string): PlaywrightRunStatus {
+    return this.runs.get(instanceId)?.status ?? 'idle'
+  }
+
+  /**
+   * 全実行結果を取得する
+   */
+  getAllResults(): PlaywrightRunResult[] {
+    return [...this.runs.values()]
+  }
+
+  /**
+   * 完了済みの結果をクリアする
+   */
+  clearFinished(): void {
+    for (const [id, result] of this.runs) {
+      if (result.status !== 'running') {
+        this.runs.delete(id)
+      }
+    }
+  }
+}

--- a/packages/server/src/ws/notification-handler.ts
+++ b/packages/server/src/ws/notification-handler.ts
@@ -1,12 +1,17 @@
 import { WebSocket, WebSocketServer } from 'ws'
 import type { SshManager } from '../services/ssh-manager.js'
-import type { NotificationMessage } from '@kurimats/shared'
+import type { PlaywrightRunner } from '../services/playwright-runner.js'
+import type { NotificationMessage, PlaywrightRunStatus } from '@kurimats/shared'
 
 /**
  * 通知WebSocketハンドラー
- * SSH接続状態の変更やリモートClaude通知をクライアントに中継する
+ * SSH接続状態の変更、リモートClaude通知、Playwright進捗をクライアントに中継する
  */
-export function setupNotificationWs(wss: WebSocketServer, sshManager: SshManager): void {
+export function setupNotificationWs(
+  wss: WebSocketServer,
+  sshManager: SshManager,
+  playwrightRunner?: PlaywrightRunner,
+): void {
   const clients = new Set<WebSocket>()
 
   /**
@@ -56,6 +61,19 @@ export function setupNotificationWs(wss: WebSocketServer, sshManager: SshManager
       }
     }
   })
+
+  // Playwrightテスト進捗を監視
+  if (playwrightRunner) {
+    playwrightRunner.on('progress', (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
+      broadcast({
+        type: 'playwright_progress',
+        instanceId,
+        status,
+        line,
+        timestamp: Date.now(),
+      })
+    })
+  }
 
   // WebSocket接続処理
   wss.on('connection', (ws: WebSocket) => {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -18,3 +18,4 @@ export type NotificationMessage =
   | { type: 'connection_status'; host: string; status: 'online' | 'offline' | 'reconnecting' }
   | { type: 'attention_ring'; sessionId: string; active: boolean }
   | { type: 'port_detected'; sessionId: string; port: number; url: string }
+  | { type: 'playwright_progress'; instanceId: string; status: import('./types').PlaywrightRunStatus; line?: string; timestamp: number }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -459,6 +459,32 @@ export interface SlotAssignment {
   assignedAt: number
 }
 
+// ========== Playwright Runner ==========
+
+/** Playwright テスト実行の状態 */
+export type PlaywrightRunStatus = 'idle' | 'running' | 'passed' | 'failed' | 'cancelled' | 'error'
+
+/** Playwright テスト実行結果 */
+export interface PlaywrightRunResult {
+  /** 実行 ID（instanceId と同一） */
+  instanceId: string
+  status: PlaywrightRunStatus
+  /** 実行対象のテストパス */
+  testPath: string | null
+  /** プロセス PID */
+  pid: number | null
+  /** 開始時刻 */
+  startedAt: number | null
+  /** 終了時刻 */
+  finishedAt: number | null
+  /** exit code（完了時のみ） */
+  exitCode: number | null
+  /** テスト出力（stdout + stderr） */
+  output: string
+  /** Playwright ポート */
+  port: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報


### PR DESCRIPTION
## Summary
- `PlaywrightRunner`: slot ベースのポート固定化で Playwright テスト実行管理
- REST API: `POST /run`, `GET /status/:id`, `DELETE /run/:id`, `GET /results`, `POST /clear`
- WebSocket 通知: `playwright_progress` イベントでリアルタイム進捗配信
- Codex レビュー指摘5件対応（SIGKILL 誤送信防止、error イベント名衝突回避、shutdown 非同期化、バッファ切り詰め、入力バリデーション）

## Test plan
- [x] PlaywrightRunner: run/stop/getStatus/ポート分離/イベント (15テスト)
- [x] 全307テスト回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)