### PR TITLE
feat(server/client): Resource HUD (Phase F, closes #188)

### DIFF
--- a/packages/client/src/components/layout/ResourceHud.tsx
+++ b/packages/client/src/components/layout/ResourceHud.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import { useResourceStore } from '../../stores/resource-store'
+
+/** バイトを人間が読みやすい形式に変換 */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
+}
+
+/** 秒を uptime 表記に変換 */
+function formatUptime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h > 0) return `${h}h${m}m`
+  return `${m}m`
+}
+
+/**
+ * ステータスバー内に表示するコンパクトなリソース HUD
+ * WebSocket でリアルタイム更新、初回は API からフェッチ
+ */
+export function ResourceHud() {
+  const snapshot = useResourceStore(s => s.snapshot)
+  const fetchSnapshot = useResourceStore(s => s.fetchSnapshot)
+
+  useEffect(() => {
+    fetchSnapshot()
+  }, [fetchSnapshot])
+
+  if (!snapshot?.server) return null
+
+  const { server, instances, wsConnectionCount } = snapshot
+  const aliveCount = instances.filter(i => i.processStatus === 'alive').length
+
+  return (
+    <div className="flex items-center gap-2 text-[10px] text-text-muted">
+      {/* サーバー CPU */}
+      <span title={`サーバー CPU: ${server.cpuPercent?.toFixed(1) ?? '?'}%`}>
+        CPU {server.cpuPercent?.toFixed(0) ?? '?'}%
+      </span>
+
+      {/* サーバーメモリ */}
+      <span title={`サーバー RSS: ${formatBytes(server.memoryRss)}`}>
+        MEM {formatBytes(server.memoryRss)}
+      </span>
+
+      {/* アクティブインスタンス数 */}
+      {instances.length > 0 && (
+        <span title={`${aliveCount}/${instances.length} インスタンス稼働中`}>
+          {aliveCount}/{instances.length} inst
+        </span>
+      )}
+
+      {/* WS 接続数 */}
+      <span title={`WebSocket 接続: ${wsConnectionCount}`}>
+        WS {wsConnectionCount}
+      </span>
+
+      {/* Uptime */}
+      <span title={`サーバー稼働時間: ${formatUptime(server.uptime)}`}>
+        {formatUptime(server.uptime)}
+      </span>
+    </div>
+  )
+}

--- a/packages/client/src/components/layout/StatusBar.tsx
+++ b/packages/client/src/components/layout/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { useWorkspaceStore } from '../../stores/workspace-store'
 import { countLeaves } from '../../lib/pane-tree-utils'
+import { ResourceHud } from './ResourceHud'
 
 /**
  * 画面下部のステータスバー（cmux v3）
@@ -27,6 +28,11 @@ export function StatusBar() {
       <span>{workspaces.length} ワークスペース</span>
 
       <div className="flex-1" />
+
+      {/* リソース HUD */}
+      <ResourceHud />
+
+      <span className="text-text-muted mx-1">|</span>
 
       {/* キーボードショートカットヒント */}
       <span className="text-text-muted">

--- a/packages/client/src/hooks/useNotificationWs.ts
+++ b/packages/client/src/hooks/useNotificationWs.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { NotificationMessage } from '@kurimats/shared'
 import { useSshStore } from '../stores/ssh-store'
+import { useResourceStore } from '../stores/resource-store'
 
 /** 簡易ユニークID生成 */
 function generateId(): string {
@@ -15,6 +16,7 @@ export function useNotificationWs() {
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const { updateConnectionStatus, addNotification } = useSshStore()
+  const updateSnapshot = useResourceStore(s => s.updateSnapshot)
 
   useEffect(() => {
     let disposed = false
@@ -57,6 +59,9 @@ export function useNotificationWs() {
               read: false,
             })
             break
+          case 'resource_update':
+            updateSnapshot(msg.snapshot)
+            break
         }
       }
 
@@ -82,5 +87,5 @@ export function useNotificationWs() {
       wsRef.current?.close()
       wsRef.current = null
     }
-  }, [updateConnectionStatus, addNotification])
+  }, [updateConnectionStatus, addNotification, updateSnapshot])
 }

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Session, CreateSessionParams, FileNode, Project, CreateProjectParams, TabListResponse, TabSyncResponse, TabBookmark, SshHost, SshConnectionStatus, Feedback, CreateFeedbackParams, SshPreset, CreateSshPresetParams, StartupTemplate, CreateStartupTemplateParams, CmuxWorkspace, CreateCmuxWorkspaceParams, PaneNode, SplitPaneRequest, SplitPaneResponse, ClosePaneRequest, ClosePaneResponse, LayoutState, BoardLayoutState } from '@kurimats/shared'
+import type { Session, CreateSessionParams, FileNode, Project, CreateProjectParams, TabListResponse, TabSyncResponse, TabBookmark, SshHost, SshConnectionStatus, Feedback, CreateFeedbackParams, SshPreset, CreateSshPresetParams, StartupTemplate, CreateStartupTemplateParams, CmuxWorkspace, CreateCmuxWorkspaceParams, PaneNode, SplitPaneRequest, SplitPaneResponse, ClosePaneRequest, ClosePaneResponse, LayoutState, BoardLayoutState, ResourceSnapshot, ResourceMetrics } from '@kurimats/shared'
 
 const BASE = '/api'
 
@@ -174,4 +174,11 @@ export const sshApi = {
     delete: (id: string) =>
       request<{ ok: boolean }>(`/ssh/templates/${id}`, { method: 'DELETE' }),
   },
+}
+
+// リソース監視API
+export const resourcesApi = {
+  snapshot: () => request<ResourceSnapshot>('/resources'),
+  instance: (id: string) => request<ResourceMetrics>(`/resources/${id}`),
+  collect: () => request<ResourceSnapshot>('/resources/collect', { method: 'POST' }),
 }

--- a/packages/client/src/stores/resource-store.ts
+++ b/packages/client/src/stores/resource-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { ResourceSnapshot } from '@kurimats/shared'
+import { resourcesApi } from '../lib/api'
+
+interface ResourceState {
+  snapshot: ResourceSnapshot | null
+  loading: boolean
+  /** API からスナップショットを取得 */
+  fetchSnapshot: () => Promise<void>
+  /** WebSocket から受信したスナップショットで更新 */
+  updateSnapshot: (snapshot: ResourceSnapshot) => void
+}
+
+export const useResourceStore = create<ResourceState>((set) => ({
+  snapshot: null,
+  loading: false,
+
+  fetchSnapshot: async () => {
+    set({ loading: true })
+    try {
+      const snapshot = await resourcesApi.snapshot()
+      set({ snapshot, loading: false })
+    } catch {
+      set({ loading: false })
+    }
+  },
+
+  updateSnapshot: (snapshot) => {
+    set({ snapshot })
+  },
+}))

--- a/packages/server/src/__tests__/resource-monitor.test.ts
+++ b/packages/server/src/__tests__/resource-monitor.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import { ResourceMonitorService } from '../services/resource-monitor'
+import type { SpawnFn } from '../services/process-supervisor'
+
+/** PtyManager のモック */
+function createMockPtyManager() {
+  return {
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    kill: vi.fn(),
+    killAll: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    backend: 'node-pty' as const,
+  } as any
+}
+
+describe('ResourceMonitorService', () => {
+  let store: SessionStore
+  let devManager: DevInstanceManager
+  let monitor: ResourceMonitorService
+  let mockPtyManager: ReturnType<typeof createMockPtyManager>
+
+  const dummySpawn: SpawnFn = (_onExit) => process.pid // 自身の PID を返す（テスト用）
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    devManager = new DevInstanceManager(store, { checkIntervalMs: 100 })
+    devManager.on('error', () => {})
+    mockPtyManager = createMockPtyManager()
+    monitor = new ResourceMonitorService(devManager, mockPtyManager, {
+      intervalMs: 60000, // テスト中は手動収集のみ
+      getWsConnectionCount: () => 3,
+    })
+  })
+
+  afterEach(() => {
+    monitor.stop()
+    devManager.stopAll()
+    store.close()
+  })
+
+  describe('collect', () => {
+    it('サーバーメトリクスを収集できる', async () => {
+      const snapshot = await monitor.collect()
+
+      expect(snapshot.server).toBeDefined()
+      expect(snapshot.server.pid).toBe(process.pid)
+      expect(snapshot.server.memoryRss).toBeGreaterThan(0)
+      expect(snapshot.server.uptime).toBeGreaterThanOrEqual(0)
+      expect(snapshot.collectedAt).toBeGreaterThan(0)
+    })
+
+    it('WS 接続数を取得できる', async () => {
+      const snapshot = await monitor.collect()
+      expect(snapshot.wsConnectionCount).toBe(3)
+    })
+
+    it('DevInstance のメトリクスを収集できる', async () => {
+      const instance = devManager.startInstance(0, dummySpawn)
+      // DB に PID を設定（supervisor は非同期で設定するためテストでは手動）
+      store.updateDevInstanceStatus(instance.id, 'running', process.pid)
+
+      const snapshot = await monitor.collect()
+
+      expect(snapshot.instances.length).toBeGreaterThanOrEqual(1)
+      const instanceMetric = snapshot.instances.find(m => m.instanceId !== null)
+      expect(instanceMetric).toBeDefined()
+      expect(instanceMetric!.processStatus).toBe('alive')
+      expect(instanceMetric!.pid).toBe(process.pid)
+    })
+
+    it('DevInstance に紐づかない active セッションも含まれる', async () => {
+      mockPtyManager.getActiveSessionIds.mockReturnValue(['session-orphan'])
+
+      const snapshot = await monitor.collect()
+
+      const orphan = snapshot.instances.find(m => m.sessionId === 'session-orphan')
+      expect(orphan).toBeDefined()
+      expect(orphan!.instanceId).toBeNull()
+      expect(orphan!.processStatus).toBe('unknown')
+    })
+
+    it('snapshot イベントが発火する', async () => {
+      const handler = vi.fn()
+      monitor.on('snapshot', handler)
+
+      await monitor.collect()
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler.mock.calls[0][0].server.pid).toBe(process.pid)
+    })
+  })
+
+  describe('getLastSnapshot / getInstanceMetrics', () => {
+    it('初期状態は null', () => {
+      expect(monitor.getLastSnapshot()).toBeNull()
+    })
+
+    it('collect 後にキャッシュされる', async () => {
+      await monitor.collect()
+      const snapshot = monitor.getLastSnapshot()
+      expect(snapshot).not.toBeNull()
+      expect(snapshot!.server.pid).toBe(process.pid)
+    })
+
+    it('特定インスタンスのメトリクスを取得できる', async () => {
+      const instance = devManager.startInstance(0, dummySpawn)
+      await monitor.collect()
+
+      const metrics = monitor.getInstanceMetrics(instance.id)
+      expect(metrics).not.toBeNull()
+      expect(metrics!.instanceId).toBe(instance.id)
+    })
+
+    it('存在しないインスタンスは null を返す', async () => {
+      await monitor.collect()
+      expect(monitor.getInstanceMetrics('non-existent')).toBeNull()
+    })
+  })
+
+  describe('start / stop', () => {
+    it('start/stop でタイマーが制御される', () => {
+      // start を複数回呼んでも二重起動しない
+      monitor.start()
+      monitor.start()
+      monitor.stop()
+      // 例外なく完了
+    })
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,9 @@ import { SessionStore } from './services/session-store.js'
 import { DevInstanceManager } from './services/dev-instance-manager.js'
 import { SessionDevBindingService } from './services/session-dev-binding-service.js'
 import { PlaywrightRunner } from './services/playwright-runner.js'
+import { ResourceMonitorService } from './services/resource-monitor.js'
 import { createPlaywrightRouter } from './routes/playwright.js'
+import { createResourcesRouter } from './routes/resources.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -150,7 +152,18 @@ setupTerminalWs(terminalWss, ptyManager, sshManager)
 
 // WebSocketサーバー（通知用）
 const notificationWss = new WebSocketServer({ noServer: true })
-setupNotificationWs(notificationWss, sshManager, playwrightRunner)
+
+// ResourceMonitor: WS 接続数を通知 WSS から取得
+const resourceMonitor = new ResourceMonitorService(devInstanceManager, ptyManager, {
+  getWsConnectionCount: () => terminalWss.clients.size + notificationWss.clients.size,
+})
+resourceMonitor.start()
+
+// 通知 WS セットアップ（ResourceMonitor 初期化後）
+const cleanupNotificationWs = setupNotificationWs(notificationWss, sshManager, playwrightRunner, resourceMonitor)
+
+// Resource API（モニター初期化後に登録）
+app.use('/api/resources', createResourcesRouter(resourceMonitor))
 
 // WebSocketアップグレード処理
 server.on('upgrade', (request, socket, head) => {
@@ -189,6 +202,8 @@ server.listen(PORT, HOST, () => {
 // グレースフルシャットダウン
 async function shutdown() {
   console.log('\nシャットダウン中...')
+  cleanupNotificationWs()
+  resourceMonitor.stop()
   await playwrightRunner.stopAllAndWait()
   devInstanceManager.shutdown()
   ptyManager.killAll()

--- a/packages/server/src/routes/resources.ts
+++ b/packages/server/src/routes/resources.ts
@@ -1,0 +1,47 @@
+/**
+ * Resource HUD REST API ルート
+ *
+ * GET /api/resources              — 全体スナップショット
+ * GET /api/resources/:instanceId  — 特定インスタンスのメトリクス
+ * POST /api/resources/collect     — 即座に収集を実行
+ */
+import { Router } from 'express'
+import type { ResourceMonitorService } from '../services/resource-monitor.js'
+
+export function createResourcesRouter(
+  monitor: ResourceMonitorService,
+): Router {
+  const router = Router()
+
+  // 全体スナップショット
+  router.get('/', (_req, res) => {
+    const snapshot = monitor.getLastSnapshot()
+    if (!snapshot) {
+      res.json({ server: null, instances: [], wsConnectionCount: 0, collectedAt: null })
+      return
+    }
+    res.json(snapshot)
+  })
+
+  // 特定インスタンスのメトリクス
+  router.get('/:instanceId', (req, res) => {
+    const metrics = monitor.getInstanceMetrics(req.params.instanceId)
+    if (!metrics) {
+      res.status(404).json({ error: 'メトリクスが見つかりません' })
+      return
+    }
+    res.json(metrics)
+  })
+
+  // 即座に収集を実行
+  router.post('/collect', async (_req, res) => {
+    try {
+      const snapshot = await monitor.collect()
+      res.json(snapshot)
+    } catch (e) {
+      res.status(500).json({ error: `メトリクス収集に失敗: ${e}` })
+    }
+  })
+
+  return router
+}

--- a/packages/server/src/services/resource-monitor.ts
+++ b/packages/server/src/services/resource-monitor.ts
@@ -1,0 +1,259 @@
+/**
+ * ResourceMonitorService — リソースメトリクスの定期収集
+ *
+ * 責務:
+ * - PID ベースの CPU/メモリ取得（ps コマンド経由）
+ * - worktree ディスク使用量取得（du コマンド経由）
+ * - サーバープロセス自身のメトリクス
+ * - 定期収集とイベント発火（WebSocket 通知用）
+ */
+import { EventEmitter } from 'events'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import type { ResourceMetrics, ResourceSnapshot, ProcessAliveness } from '@kurimats/shared'
+import type { DevInstanceManager } from './dev-instance-manager.js'
+import type { PtyManager } from './pty-manager.js'
+
+const execFileAsync = promisify(execFile)
+
+export interface ResourceMonitorOptions {
+  /** 収集間隔（ms）。デフォルト 5000ms */
+  intervalMs?: number
+  /** WebSocket 接続数取得関数（外部注入） */
+  getWsConnectionCount?: () => number
+}
+
+const DEFAULT_OPTIONS: Required<ResourceMonitorOptions> = {
+  intervalMs: 5000,
+  getWsConnectionCount: () => 0,
+}
+
+export class ResourceMonitorService extends EventEmitter {
+  private options: Required<ResourceMonitorOptions>
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private collecting = false
+  private devInstanceManager: DevInstanceManager
+  private ptyManager: PtyManager
+  private lastSnapshot: ResourceSnapshot | null = null
+  private startTime = Date.now()
+  /** du キャッシュ（低頻度更新） */
+  private diskCache = new Map<string, { bytes: number; updatedAt: number }>()
+  /** du を更新する間隔（ms） */
+  private diskCacheIntervalMs = 30000
+
+  constructor(
+    devInstanceManager: DevInstanceManager,
+    ptyManager: PtyManager,
+    options?: ResourceMonitorOptions,
+  ) {
+    super()
+    this.devInstanceManager = devInstanceManager
+    this.ptyManager = ptyManager
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * 定期収集を開始する（再帰 setTimeout で前回完了を待ってから次回を予約）
+   */
+  start(): void {
+    if (this.timer) return
+    const schedule = () => {
+      this.timer = setTimeout(async () => {
+        try {
+          await this.collect()
+        } catch (err) {
+          console.warn('⚠️ リソースメトリクス収集エラー:', err)
+        }
+        if (this.timer !== null) schedule()
+      }, this.options.intervalMs)
+    }
+
+    // 初回は即座に収集してからスケジュール開始
+    this.collect().catch(() => {}).then(() => schedule())
+  }
+
+  /**
+   * 定期収集を停止する
+   */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  /**
+   * メトリクスを即座に収集する
+   */
+  async collect(): Promise<ResourceSnapshot> {
+    if (this.collecting) return this.lastSnapshot ?? this.emptySnapshot()
+    this.collecting = true
+
+    try {
+      return await this.doCollect()
+    } finally {
+      this.collecting = false
+    }
+  }
+
+  private emptySnapshot(): ResourceSnapshot {
+    return {
+      server: { pid: process.pid, cpuPercent: null, memoryRss: 0, uptime: 0 },
+      instances: [],
+      wsConnectionCount: 0,
+      collectedAt: Date.now(),
+    }
+  }
+
+  private async doCollect(): Promise<ResourceSnapshot> {
+    const now = Date.now()
+
+    // サーバープロセス自身のメトリクス
+    const serverMemory = process.memoryUsage()
+    const serverCpu = await this.getCpuPercent(process.pid)
+
+    // DevInstance のメトリクス収集（並列実行）
+    const instances = this.devInstanceManager.getAllInstances()
+    const metrics = await Promise.all(
+      instances.map(instance =>
+        this.collectInstanceMetrics(instance.id, instance.pid, instance.assignedSessionId, instance.worktreePath),
+      ),
+    )
+
+    // DevInstance に紐づかない active セッションのメトリクス
+    const activePtyIds = this.ptyManager.getActiveSessionIds()
+    const boundSessionIds = new Set(instances.map(i => i.assignedSessionId).filter(Boolean))
+    for (const sessionId of activePtyIds) {
+      if (!boundSessionIds.has(sessionId)) {
+        metrics.push({
+          instanceId: null,
+          sessionId,
+          pid: null,
+          cpuPercent: null,
+          memoryRss: null,
+          processStatus: 'unknown',
+          worktreeDiskUsage: null,
+          collectedAt: now,
+        })
+      }
+    }
+
+    const snapshot: ResourceSnapshot = {
+      server: {
+        pid: process.pid,
+        cpuPercent: serverCpu,
+        memoryRss: serverMemory.rss,
+        uptime: (now - this.startTime) / 1000,
+      },
+      instances: metrics,
+      wsConnectionCount: this.options.getWsConnectionCount(),
+      collectedAt: now,
+    }
+
+    this.lastSnapshot = snapshot
+    this.emit('snapshot', snapshot)
+    return snapshot
+  }
+
+  /**
+   * 最新のスナップショットを取得する（キャッシュ）
+   */
+  getLastSnapshot(): ResourceSnapshot | null {
+    return this.lastSnapshot
+  }
+
+  /**
+   * 特定インスタンスのメトリクスを取得する
+   */
+  getInstanceMetrics(instanceId: string): ResourceMetrics | null {
+    return this.lastSnapshot?.instances.find(m => m.instanceId === instanceId) ?? null
+  }
+
+  /** PID ベースで CPU 使用率を取得する */
+  private async getCpuPercent(pid: number): Promise<number | null> {
+    try {
+      const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', '%cpu='], {
+        timeout: 3000,
+      })
+      const value = parseFloat(stdout.trim())
+      return isNaN(value) ? null : value
+    } catch {
+      return null
+    }
+  }
+
+  /** PID ベースで RSS メモリを取得する（バイト） */
+  private async getMemoryRss(pid: number): Promise<number | null> {
+    try {
+      // ps の rss はキロバイト単位
+      const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'rss='], {
+        timeout: 3000,
+      })
+      const kb = parseInt(stdout.trim(), 10)
+      return isNaN(kb) ? null : kb * 1024
+    } catch {
+      return null
+    }
+  }
+
+  /** PID の生存確認 */
+  private checkAliveness(pid: number | null): ProcessAliveness {
+    if (pid === null) return 'unknown'
+    try {
+      process.kill(pid, 0)
+      return 'alive'
+    } catch {
+      return 'exited'
+    }
+  }
+
+  /** worktree のディスク使用量を取得する（キャッシュ付き、低頻度更新） */
+  private async getWorktreeDiskUsage(worktreePath: string): Promise<number | null> {
+    const cached = this.diskCache.get(worktreePath)
+    const now = Date.now()
+    if (cached && (now - cached.updatedAt) < this.diskCacheIntervalMs) {
+      return cached.bytes
+    }
+
+    try {
+      // du -sk: キロバイト単位。タイムアウトは収集間隔未満に設定
+      const { stdout } = await execFileAsync('du', ['-sk', worktreePath], {
+        timeout: 4000,
+      })
+      const kb = parseInt(stdout.trim().split('\t')[0], 10)
+      if (isNaN(kb)) return cached?.bytes ?? null
+      const bytes = kb * 1024
+      this.diskCache.set(worktreePath, { bytes, updatedAt: now })
+      return bytes
+    } catch {
+      return cached?.bytes ?? null
+    }
+  }
+
+  /** 単一インスタンスのメトリクスを収集する */
+  private async collectInstanceMetrics(
+    instanceId: string,
+    pid: number | null,
+    sessionId: string | null,
+    worktreePath: string | null,
+  ): Promise<ResourceMetrics> {
+    const now = Date.now()
+
+    const [cpuPercent, memoryRss, worktreeDiskUsage] = await Promise.all([
+      pid ? this.getCpuPercent(pid) : Promise.resolve(null),
+      pid ? this.getMemoryRss(pid) : Promise.resolve(null),
+      worktreePath ? this.getWorktreeDiskUsage(worktreePath) : Promise.resolve(null),
+    ])
+
+    return {
+      instanceId,
+      sessionId,
+      pid,
+      cpuPercent,
+      memoryRss,
+      processStatus: this.checkAliveness(pid),
+      worktreeDiskUsage,
+      collectedAt: now,
+    }
+  }
+}

--- a/packages/server/src/ws/notification-handler.ts
+++ b/packages/server/src/ws/notification-handler.ts
@@ -1,17 +1,21 @@
 import { WebSocket, WebSocketServer } from 'ws'
 import type { SshManager } from '../services/ssh-manager.js'
 import type { PlaywrightRunner } from '../services/playwright-runner.js'
-import type { NotificationMessage, PlaywrightRunStatus } from '@kurimats/shared'
+import type { ResourceMonitorService } from '../services/resource-monitor.js'
+import type { NotificationMessage, PlaywrightRunStatus, ResourceSnapshot } from '@kurimats/shared'
 
 /**
  * 通知WebSocketハンドラー
- * SSH接続状態の変更、リモートClaude通知、Playwright進捗をクライアントに中継する
+ * SSH接続状態の変更、リモートClaude通知、Playwright進捗、リソースメトリクスをクライアントに中継する
+ *
+ * @returns cleanup 関数（シャットダウン時にリスナーを解除する）
  */
 export function setupNotificationWs(
   wss: WebSocketServer,
   sshManager: SshManager,
   playwrightRunner?: PlaywrightRunner,
-): void {
+  resourceMonitor?: ResourceMonitorService,
+): () => void {
   const clients = new Set<WebSocket>()
 
   /**
@@ -34,14 +38,13 @@ export function setupNotificationWs(
   }
 
   // SSH接続状態の変更を監視
-  sshManager.on('connection_status', (host: string, status: 'online' | 'offline' | 'reconnecting') => {
+  const onConnectionStatus = (host: string, status: 'online' | 'offline' | 'reconnecting') => {
     broadcast({ type: 'connection_status', host, status })
-  })
+  }
+  sshManager.on('connection_status', onConnectionStatus)
 
   // リモートセッションのデータを監視してClaude通知を検出
-  sshManager.on('data', (sessionId: string, data: string) => {
-    // Claude Code の通知パターンを検出
-    // 例: 「Claude has a question」「Waiting for input」「Task completed」などのパターン
+  const onSshData = (sessionId: string, data: string) => {
     const notificationPatterns = [
       /🔔\s*(.+)/,
       /\[notification\]\s*(.+)/i,
@@ -60,19 +63,29 @@ export function setupNotificationWs(
         break
       }
     }
-  })
+  }
+  sshManager.on('data', onSshData)
 
   // Playwrightテスト進捗を監視
-  if (playwrightRunner) {
-    playwrightRunner.on('progress', (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
-      broadcast({
-        type: 'playwright_progress',
-        instanceId,
-        status,
-        line,
-        timestamp: Date.now(),
-      })
+  const onPlaywrightProgress = (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
+    broadcast({
+      type: 'playwright_progress',
+      instanceId,
+      status,
+      line,
+      timestamp: Date.now(),
     })
+  }
+  if (playwrightRunner) {
+    playwrightRunner.on('progress', onPlaywrightProgress)
+  }
+
+  // リソースメトリクス変化を配信
+  const onSnapshot = (snapshot: ResourceSnapshot) => {
+    broadcast({ type: 'resource_update', snapshot })
+  }
+  if (resourceMonitor) {
+    resourceMonitor.on('snapshot', onSnapshot)
   }
 
   // WebSocket接続処理
@@ -98,4 +111,20 @@ export function setupNotificationWs(
       clients.delete(ws)
     })
   })
+
+  // cleanup 関数: シャットダウン時にリスナーを解除
+  return () => {
+    sshManager.off('connection_status', onConnectionStatus)
+    sshManager.off('data', onSshData)
+    if (playwrightRunner) {
+      playwrightRunner.off('progress', onPlaywrightProgress)
+    }
+    if (resourceMonitor) {
+      resourceMonitor.off('snapshot', onSnapshot)
+    }
+    for (const ws of clients) {
+      ws.close()
+    }
+    clients.clear()
+  }
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -19,3 +19,4 @@ export type NotificationMessage =
   | { type: 'attention_ring'; sessionId: string; active: boolean }
   | { type: 'port_detected'; sessionId: string; port: number; url: string }
   | { type: 'playwright_progress'; instanceId: string; status: import('./types').PlaywrightRunStatus; line?: string; timestamp: number }
+  | { type: 'resource_update'; snapshot: import('./types').ResourceSnapshot }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -485,6 +485,48 @@ export interface PlaywrightRunResult {
   port: number
 }
 
+// ========== Resource HUD ==========
+
+/** プロセスの生存状態 */
+export type ProcessAliveness = 'alive' | 'exited' | 'error' | 'unknown'
+
+/** 単一インスタンス/セッションのリソースメトリクス */
+export interface ResourceMetrics {
+  /** 対象の DevInstance ID（セッション単体の場合は null） */
+  instanceId: string | null
+  /** 対象のセッション ID */
+  sessionId: string | null
+  /** PID（プロセスが存在する場合） */
+  pid: number | null
+  /** CPU 使用率（%、0-100+）。取得不可の場合は null */
+  cpuPercent: number | null
+  /** メモリ使用量 RSS（バイト）。取得不可の場合は null */
+  memoryRss: number | null
+  /** プロセスの生存状態 */
+  processStatus: ProcessAliveness
+  /** worktree ディスク使用量（バイト）。worktree がない場合は null */
+  worktreeDiskUsage: number | null
+  /** 収集時刻 */
+  collectedAt: number
+}
+
+/** 全体のリソーススナップショット */
+export interface ResourceSnapshot {
+  /** サーバープロセス自身の CPU/メモリ */
+  server: {
+    pid: number
+    cpuPercent: number | null
+    memoryRss: number
+    uptime: number
+  }
+  /** 各インスタンス/セッションのメトリクス */
+  instances: ResourceMetrics[]
+  /** アクティブ WebSocket 接続数 */
+  wsConnectionCount: number
+  /** 収集時刻 */
+  collectedAt: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報


### PR DESCRIPTION
## Summary
- `ResourceMonitorService`: PID ベース CPU/メモリ、worktree ディスク使用量（du キャッシュ付き）を定期収集
- REST API: `GET /resources`, `GET /resources/:id`, `POST /resources/collect`
- WebSocket: `resource_update` でリアルタイム配信 + cleanup 関数追加
- クライアント: `ResourceHud` コンポーネントをステータスバーに組み込み
- Codex レビュー指摘対応: 再帰 setTimeout、du キャッシュ、並列収集、リスナー cleanup、selector 最適化

## Test plan
- [x] ResourceMonitorService: collect/getLastSnapshot/start-stop (10テスト)
- [x] 全317テスト回帰なし
- [x] Playwright: ステータスバーに CPU/MEM/WS/uptime が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)