### PR TITLE
fix(client): ペイン分割時に新セッションをストアへ即時追加 (closes #197)

### DIFF
--- a/packages/client/src/stores/pane-store.ts
+++ b/packages/client/src/stores/pane-store.ts
@@ -5,6 +5,7 @@ import {
   findAdjacentPane,
 } from '../lib/pane-tree-utils'
 import { useWorkspaceStore } from './workspace-store'
+import { useSessionStore } from './session-store'
 import { workspacesApi } from '../lib/api'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
@@ -59,6 +60,10 @@ export const usePaneStore = create<PaneState>((set, get) => ({
     try {
       // サーバーAPIで新セッション+worktree+Claude Code起動
       const result = await workspacesApi.splitPane(workspace.id, { paneId, direction, ...opts })
+      // 新セッションをsession storeに即座追加（ツールバー即時描画のため）
+      if (result.newSession) {
+        useSessionStore.getState().addSession(result.newSession)
+      }
       // サーバーが返した新しいペインツリーをストアに反映
       wsStore.updatePaneTree(workspace.id, result.paneTree, result.activePaneId)
     } catch (e) {

--- a/packages/client/src/stores/session-store.ts
+++ b/packages/client/src/stores/session-store.ts
@@ -10,6 +10,8 @@ interface SessionState {
 
   fetchSessions: () => Promise<void>
   createSession: (params: CreateSessionParams) => Promise<Session>
+  /** 外部で作成済みのセッションをストアに追加（ペイン分割時等） */
+  addSession: (session: Session) => void
   deleteSession: (id: string) => Promise<void>
   toggleFavorite: (id: string) => Promise<void>
   assignProject: (sessionId: string, projectId: string | null) => Promise<void>
@@ -42,6 +44,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     const session = await sessionsApi.create(params)
     set({ sessions: [session, ...get().sessions] })
     return session
+  },
+
+  addSession: (session) => {
+    // 重複防止
+    if (get().sessions.some(s => s.id === session.id)) return
+    set({ sessions: [session, ...get().sessions] })
   },
 
   deleteSession: async (id) => {


### PR DESCRIPTION
Closes #197

## Summary
- ペイン分割後、新セッションが`session-store`に即座追加されずツールバー描画が遅れる問題を修正
- `session-store`に`addSession`メソッドを追加（重複防止付き）
- `pane-store`の`splitPane`から`addSession`を呼び出し

## Test plan
- [x] devサーバー起動しUI表示が正常であることをPlaywrightで確認
- [ ] ペイン分割（左右・上下）で新セッションがツールバーに即時表示される
- [ ] 重複セッションが追加されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)