### PR TITLE
release: ペイン分割時セッション即時反映 (closes #197)

### DIFF
--- a/packages/client/src/components/layout/ResourceHud.tsx
+++ b/packages/client/src/components/layout/ResourceHud.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import { useResourceStore } from '../../stores/resource-store'
+
+/** バイトを人間が読みやすい形式に変換 */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
+}
+
+/** 秒を uptime 表記に変換 */
+function formatUptime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h > 0) return `${h}h${m}m`
+  return `${m}m`
+}
+
+/**
+ * ステータスバー内に表示するコンパクトなリソース HUD
+ * WebSocket でリアルタイム更新、初回は API からフェッチ
+ */
+export function ResourceHud() {
+  const snapshot = useResourceStore(s => s.snapshot)
+  const fetchSnapshot = useResourceStore(s => s.fetchSnapshot)
+
+  useEffect(() => {
+    fetchSnapshot()
+  }, [fetchSnapshot])
+
+  if (!snapshot?.server) return null
+
+  const { server, instances, wsConnectionCount } = snapshot
+  const aliveCount = instances.filter(i => i.processStatus === 'alive').length
+
+  return (
+    <div className="flex items-center gap-2 text-[10px] text-text-muted">
+      {/* サーバー CPU */}
+      <span title={`サーバー CPU: ${server.cpuPercent?.toFixed(1) ?? '?'}%`}>
+        CPU {server.cpuPercent?.toFixed(0) ?? '?'}%
+      </span>
+
+      {/* サーバーメモリ */}
+      <span title={`サーバー RSS: ${formatBytes(server.memoryRss)}`}>
+        MEM {formatBytes(server.memoryRss)}
+      </span>
+
+      {/* アクティブインスタンス数 */}
+      {instances.length > 0 && (
+        <span title={`${aliveCount}/${instances.length} インスタンス稼働中`}>
+          {aliveCount}/{instances.length} inst
+        </span>
+      )}
+
+      {/* WS 接続数 */}
+      <span title={`WebSocket 接続: ${wsConnectionCount}`}>
+        WS {wsConnectionCount}
+      </span>
+
+      {/* Uptime */}
+      <span title={`サーバー稼働時間: ${formatUptime(server.uptime)}`}>
+        {formatUptime(server.uptime)}
+      </span>
+    </div>
+  )
+}

--- a/packages/client/src/components/layout/StatusBar.tsx
+++ b/packages/client/src/components/layout/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { useWorkspaceStore } from '../../stores/workspace-store'
 import { countLeaves } from '../../lib/pane-tree-utils'
+import { ResourceHud } from './ResourceHud'
 
 /**
  * 画面下部のステータスバー（cmux v3）
@@ -27,6 +28,11 @@ export function StatusBar() {
       <span>{workspaces.length} ワークスペース</span>
 
       <div className="flex-1" />
+
+      {/* リソース HUD */}
+      <ResourceHud />
+
+      <span className="text-text-muted mx-1">|</span>
 
       {/* キーボードショートカットヒント */}
       <span className="text-text-muted">

--- a/packages/client/src/components/panes/PaneContainer.tsx
+++ b/packages/client/src/components/panes/PaneContainer.tsx
@@ -39,11 +39,11 @@ export function PaneContainer() {
         <div className="flex-1 relative">
           {/* 背景（元のツリーは非表示） */}
           <div className="w-full h-full opacity-10 pointer-events-none">
-            <PaneRenderer node={paneTree} />
+            <PaneRenderer key={activeWorkspace.id} node={paneTree} />
           </div>
           {/* ズームオーバーレイ */}
           <div className="absolute inset-0 z-50 bg-surface-0">
-            <PaneLeafView leaf={zoomedNode as PaneLeaf} />
+            <PaneLeafView key={`${activeWorkspace.id}-zoom`} leaf={zoomedNode as PaneLeaf} />
           </div>
           {/* アンズームボタン */}
           <button
@@ -60,7 +60,7 @@ export function PaneContainer() {
 
   return (
     <div className="flex-1 overflow-hidden">
-      <PaneRenderer node={paneTree} />
+      <PaneRenderer key={activeWorkspace.id} node={paneTree} />
     </div>
   )
 }

--- a/packages/client/src/hooks/useNotificationWs.ts
+++ b/packages/client/src/hooks/useNotificationWs.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { NotificationMessage } from '@kurimats/shared'
 import { useSshStore } from '../stores/ssh-store'
+import { useResourceStore } from '../stores/resource-store'
 
 /** 簡易ユニークID生成 */
 function generateId(): string {
@@ -15,6 +16,7 @@ export function useNotificationWs() {
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const { updateConnectionStatus, addNotification } = useSshStore()
+  const updateSnapshot = useResourceStore(s => s.updateSnapshot)
 
   useEffect(() => {
     let disposed = false
@@ -57,6 +59,9 @@ export function useNotificationWs() {
               read: false,
             })
             break
+          case 'resource_update':
+            updateSnapshot(msg.snapshot)
+            break
         }
       }
 
@@ -82,5 +87,5 @@ export function useNotificationWs() {
       wsRef.current?.close()
       wsRef.current = null
     }
-  }, [updateConnectionStatus, addNotification])
+  }, [updateConnectionStatus, addNotification, updateSnapshot])
 }

--- a/packages/client/src/hooks/useTerminalWs.ts
+++ b/packages/client/src/hooks/useTerminalWs.ts
@@ -62,6 +62,8 @@ export function useTerminalWs(sessionId: string | null, terminal: Terminal | nul
 
     ws.onclose = () => {
       if (disposedRef.current) return
+      // 別の接続が既に確立されている場合は再接続しない（stale closure防止）
+      if (ws !== wsRef.current) return
       // 自動再接続（指数バックオフ）
       reconnectTimerRef.current = setTimeout(() => {
         if (!disposedRef.current && sessionId && terminal) connect()

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Session, CreateSessionParams, FileNode, Project, CreateProjectParams, TabListResponse, TabSyncResponse, TabBookmark, SshHost, SshConnectionStatus, Feedback, CreateFeedbackParams, SshPreset, CreateSshPresetParams, StartupTemplate, CreateStartupTemplateParams, CmuxWorkspace, CreateCmuxWorkspaceParams, PaneNode, SplitPaneRequest, SplitPaneResponse, ClosePaneRequest, ClosePaneResponse, LayoutState, BoardLayoutState } from '@kurimats/shared'
+import type { Session, CreateSessionParams, FileNode, Project, CreateProjectParams, TabListResponse, TabSyncResponse, TabBookmark, SshHost, SshConnectionStatus, Feedback, CreateFeedbackParams, SshPreset, CreateSshPresetParams, StartupTemplate, CreateStartupTemplateParams, CmuxWorkspace, CreateCmuxWorkspaceParams, PaneNode, SplitPaneRequest, SplitPaneResponse, ClosePaneRequest, ClosePaneResponse, LayoutState, BoardLayoutState, ResourceSnapshot, ResourceMetrics } from '@kurimats/shared'
 
 const BASE = '/api'
 
@@ -174,4 +174,11 @@ export const sshApi = {
     delete: (id: string) =>
       request<{ ok: boolean }>(`/ssh/templates/${id}`, { method: 'DELETE' }),
   },
+}
+
+// リソース監視API
+export const resourcesApi = {
+  snapshot: () => request<ResourceSnapshot>('/resources'),
+  instance: (id: string) => request<ResourceMetrics>(`/resources/${id}`),
+  collect: () => request<ResourceSnapshot>('/resources/collect', { method: 'POST' }),
 }

--- a/packages/client/src/stores/pane-store.ts
+++ b/packages/client/src/stores/pane-store.ts
@@ -5,6 +5,7 @@ import {
   findAdjacentPane,
 } from '../lib/pane-tree-utils'
 import { useWorkspaceStore } from './workspace-store'
+import { useSessionStore } from './session-store'
 import { workspacesApi } from '../lib/api'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
@@ -59,6 +60,10 @@ export const usePaneStore = create<PaneState>((set, get) => ({
     try {
       // サーバーAPIで新セッション+worktree+Claude Code起動
       const result = await workspacesApi.splitPane(workspace.id, { paneId, direction, ...opts })
+      // 新セッションをsession storeに即座追加（ツールバー即時描画のため）
+      if (result.newSession) {
+        useSessionStore.getState().addSession(result.newSession)
+      }
       // サーバーが返した新しいペインツリーをストアに反映
       wsStore.updatePaneTree(workspace.id, result.paneTree, result.activePaneId)
     } catch (e) {

--- a/packages/client/src/stores/resource-store.ts
+++ b/packages/client/src/stores/resource-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { ResourceSnapshot } from '@kurimats/shared'
+import { resourcesApi } from '../lib/api'
+
+interface ResourceState {
+  snapshot: ResourceSnapshot | null
+  loading: boolean
+  /** API からスナップショットを取得 */
+  fetchSnapshot: () => Promise<void>
+  /** WebSocket から受信したスナップショットで更新 */
+  updateSnapshot: (snapshot: ResourceSnapshot) => void
+}
+
+export const useResourceStore = create<ResourceState>((set) => ({
+  snapshot: null,
+  loading: false,
+
+  fetchSnapshot: async () => {
+    set({ loading: true })
+    try {
+      const snapshot = await resourcesApi.snapshot()
+      set({ snapshot, loading: false })
+    } catch {
+      set({ loading: false })
+    }
+  },
+
+  updateSnapshot: (snapshot) => {
+    set({ snapshot })
+  },
+}))

--- a/packages/client/src/stores/session-store.ts
+++ b/packages/client/src/stores/session-store.ts
@@ -10,6 +10,8 @@ interface SessionState {
 
   fetchSessions: () => Promise<void>
   createSession: (params: CreateSessionParams) => Promise<Session>
+  /** 外部で作成済みのセッションをストアに追加（ペイン分割時等） */
+  addSession: (session: Session) => void
   deleteSession: (id: string) => Promise<void>
   toggleFavorite: (id: string) => Promise<void>
   assignProject: (sessionId: string, projectId: string | null) => Promise<void>
@@ -42,6 +44,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     const session = await sessionsApi.create(params)
     set({ sessions: [session, ...get().sessions] })
     return session
+  },
+
+  addSession: (session) => {
+    // 重複防止
+    if (get().sessions.some(s => s.id === session.id)) return
+    set({ sessions: [session, ...get().sessions] })
   },
 
   deleteSession: async (id) => {

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -89,6 +89,13 @@ function waitForUrl(url: string, retries: number, intervalMs: number): Promise<v
   })
 }
 
+// Electron single-instance lock: 二重起動を防止
+const gotTheLock = app.requestSingleInstanceLock()
+if (!gotTheLock) {
+  console.log('⚠️ 別の kurimats インスタンスが既に起動中です。終了します。')
+  app.quit()
+}
+
 // 設定ストア
 const store = new Store()
 
@@ -175,6 +182,14 @@ function setupMenu(): void {
   const menu = Menu.buildFromTemplate(template as any)
   Menu.setApplicationMenu(menu)
 }
+
+// 2回目の起動試行時: 既存ウィンドウにフォーカス
+app.on('second-instance', () => {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    mainWindow.focus()
+  }
+})
 
 // アプリケーション起動
 app.whenReady().then(async () => {

--- a/packages/server/src/__tests__/dev-instance-manager.test.ts
+++ b/packages/server/src/__tests__/dev-instance-manager.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('DevInstanceManager', () => {
+  let store: SessionStore
+  let manager: DevInstanceManager
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    manager = new DevInstanceManager(store, {
+      checkIntervalMs: 100,
+      maxRestarts: 1,
+    })
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    store.close()
+  })
+
+  /** ダミーの spawnFn: PID を返し、プロセスが生存しているように振る舞う */
+  function createDummySpawnFn(pid = 99999): SpawnFn {
+    return (_onExit) => pid
+  }
+
+  describe('startInstance', () => {
+    it('スロットにインスタンスを作成して監視を開始する', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      expect(instance).toBeDefined()
+      expect(instance.slotNumber).toBe(0)
+      expect(instance.serverPort).toBe(14000)
+      expect(instance.clientPort).toBe(5180)
+      expect(instance.playwrightPort).toBe(3550)
+      expect(instance.status).toBe('idle')
+    })
+
+    it('slot が既に使用中の場合はエラーになる', () => {
+      manager.startInstance(0, createDummySpawnFn())
+
+      expect(() => {
+        manager.startInstance(0, createDummySpawnFn())
+      }).toThrow()
+    })
+
+    it('異なるスロットは独立して起動できる', () => {
+      const inst1 = manager.startInstance(0, createDummySpawnFn(100))
+      const inst2 = manager.startInstance(1, createDummySpawnFn(101))
+
+      expect(inst1.slotNumber).toBe(0)
+      expect(inst2.slotNumber).toBe(1)
+      expect(manager.getAllInstances()).toHaveLength(2)
+    })
+
+    it('slot 割り当て失敗時に DevInstance がロールバックされる', () => {
+      // スロット0を先に手動で占有
+      const preInstance = store.createDevInstance({
+        slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550,
+      })
+      store.assignSlot(0, preInstance.id)
+
+      // 同じスロット0で startInstance → UNIQUE 制約エラー + DevInstance ロールバック
+      expect(() => {
+        manager.startInstance(0, createDummySpawnFn())
+      }).toThrow()
+
+      // 元の割り当ては残っている
+      expect(store.getSlotAssignment(0)!.instanceId).toBe(preInstance.id)
+    })
+
+    it('spawnFn がエラーを投げた場合はロールバックされる', () => {
+      const failingSpawnFn: SpawnFn = () => {
+        throw new Error('spawn 失敗')
+      }
+
+      // error イベントを受け取る（EventEmitter の unhandled error 防止）
+      manager.on('error', () => { /* テスト用 */ })
+
+      expect(() => {
+        manager.startInstance(0, failingSpawnFn)
+      }).toThrow('インスタンス起動失敗')
+
+      // ロールバック: slot も DevInstance も残っていない
+      expect(store.getSlotAssignment(0)).toBeNull()
+      expect(store.getDevInstance(0)).toBeNull()
+    })
+  })
+
+  describe('stopInstance', () => {
+    it('インスタンスを停止し��リソースを解放する', () => {
+      manager.startInstance(0, createDummySpawnFn())
+
+      manager.stopInstance(0)
+
+      expect(manager.getInstance(0)).toBeNull()
+      expect(store.getSlotAssignment(0)).toBeNull()
+      expect(store.getDevInstance(0)).toBeNull()
+    })
+
+    it('存在しないスロットの停止は安全に無視される', () => {
+      expect(() => manager.stopInstance(999)).not.toThrow()
+    })
+  })
+
+  describe('stopInstanceById', () => {
+    it('インスタンス ID で停止できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.stopInstanceById(instance.id)
+
+      expect(manager.getInstance(0)).toBeNull()
+    })
+  })
+
+  describe('stopAll', () => {
+    it('全インスタンスを停止する', () => {
+      manager.startInstance(0, createDummySpawnFn(100))
+      manager.startInstance(1, createDummySpawnFn(101))
+      manager.startInstance(2, createDummySpawnFn(102))
+
+      manager.stopAll()
+
+      expect(manager.getAllInstances()).toHaveLength(0)
+    })
+  })
+
+  describe('getAllInstances / getRunningInstances', () => {
+    it('全インスタンスを取得できる', () => {
+      manager.startInstance(0, createDummySpawnFn())
+      manager.startInstance(1, createDummySpawnFn())
+
+      expect(manager.getAllInstances()).toHaveLength(2)
+    })
+
+    it('running 状態のインスタンスのみ取得できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      // 初期状態は idle なので running には含まれない
+      expect(manager.getRunningInstances()).toHaveLength(0)
+
+      // 手動で running に変更
+      store.updateDevInstanceStatus(instance.id, 'running')
+      expect(manager.getRunningInstances()).toHaveLength(1)
+    })
+  })
+
+  describe('updateWorktreePath', () => {
+    it('DevInstance の worktreePath を更新できる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.updateWorktreePath(instance.id, '/tmp/worktree')
+
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.worktreePath).toBe('/tmp/worktree')
+    })
+  })
+
+  describe('updateSessionBinding', () => {
+    it('DevInstance にセッションをバインドできる', () => {
+      const instance = manager.startInstance(0, createDummySpawnFn())
+
+      manager.updateSessionBinding(instance.id, 'session-abc')
+
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBe('session-abc')
+    })
+  })
+
+  describe('イベント中継', () => {
+    it('supervisor の stopped イベントを中継する', () => {
+      const handler = vi.fn()
+      manager.on('stopped', handler)
+
+      const instance = manager.startInstance(0, createDummySpawnFn())
+      manager.stopInstance(0)
+
+      expect(handler).toHaveBeenCalledWith(instance.id)
+    })
+  })
+})

--- a/packages/server/src/__tests__/dev-instance.test.ts
+++ b/packages/server/src/__tests__/dev-instance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { SessionStore } from '../services/session-store'
+import { calculatePortsForSlot } from '../utils/ports'
 
 describe('DevInstance / SlotAssignment', () => {
   let store: SessionStore
@@ -163,6 +164,41 @@ describe('DevInstance / SlotAssignment', () => {
       expect(all).toHaveLength(2)
       expect(all[0].slotNumber).toBe(0)
       expect(all[1].slotNumber).toBe(1)
+    })
+
+    it('同一 instanceId を複数スロットに割り当てられない（UNIQUE instance_id）', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      // 同じ instance を別スロットに割り当て → UNIQUE 制約違反
+      expect(() => store.assignSlot(1, instance.id)).toThrow()
+    })
+
+    it('存在しない instanceId での assignSlot は FK 制約で拒否される', () => {
+      expect(() => store.assignSlot(0, 'non-existent-id')).toThrow()
+    })
+  })
+
+  describe('異常系', () => {
+    it('存在しない ID の deleteDevInstance は false を返す', () => {
+      const result = store.deleteDevInstance('non-existent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('calculatePortsForSlot', () => {
+    it('スロット0のポートを正しく算出する', () => {
+      const ports = calculatePortsForSlot(0)
+      expect(ports.serverPort).toBe(14000)
+      expect(ports.clientPort).toBe(5180)
+      expect(ports.playwrightPort).toBe(3550)
+    })
+
+    it('スロット3のポートを正しく算出する', () => {
+      const ports = calculatePortsForSlot(3)
+      expect(ports.serverPort).toBe(14003)
+      expect(ports.clientPort).toBe(5183)
+      expect(ports.playwrightPort).toBe(3553)
     })
   })
 })

--- a/packages/server/src/__tests__/dev-instance.test.ts
+++ b/packages/server/src/__tests__/dev-instance.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SessionStore } from '../services/session-store'
+
+describe('DevInstance / SlotAssignment', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  describe('DevInstance CRUD', () => {
+    it('DevInstance を作成して取得できる', () => {
+      const instance = store.createDevInstance({
+        slotNumber: 0,
+        serverPort: 14000,
+        clientPort: 5180,
+        playwrightPort: 3550,
+      })
+
+      expect(instance.id).toBeDefined()
+      expect(instance.slotNumber).toBe(0)
+      expect(instance.serverPort).toBe(14000)
+      expect(instance.clientPort).toBe(5180)
+      expect(instance.playwrightPort).toBe(3550)
+      expect(instance.status).toBe('idle')
+      expect(instance.pid).toBeNull()
+      expect(instance.worktreePath).toBeNull()
+      expect(instance.assignedSessionId).toBeNull()
+    })
+
+    it('スロット番号で DevInstance を取得できる', () => {
+      store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      const retrieved = store.getDevInstance(1)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.slotNumber).toBe(1)
+    })
+
+    it('存在しないスロット番号は null を返す', () => {
+      expect(store.getDevInstance(999)).toBeNull()
+    })
+
+    it('全 DevInstance を取得できる', () => {
+      store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+      store.createDevInstance({ slotNumber: 2, serverPort: 14002, clientPort: 5182, playwrightPort: 3552 })
+
+      const all = store.getAllDevInstances()
+      expect(all).toHaveLength(3)
+      expect(all[0].slotNumber).toBe(0)
+      expect(all[1].slotNumber).toBe(1)
+      expect(all[2].slotNumber).toBe(2)
+    })
+
+    it('状態を更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceStatus(instance.id, 'running', 12345)
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.status).toBe('running')
+      expect(updated!.pid).toBe(12345)
+    })
+
+    it('worktreePath を更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceWorktreePath(instance.id, '/tmp/repo/.kurimats-worktrees/pane0')
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.worktreePath).toBe('/tmp/repo/.kurimats-worktrees/pane0')
+    })
+
+    it('セッションバインディングを更新できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      store.updateDevInstanceSession(instance.id, 'session-123')
+      const updated = store.getDevInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBe('session-123')
+
+      // null でアンバインド
+      store.updateDevInstanceSession(instance.id, null)
+      const unbound = store.getDevInstanceById(instance.id)
+      expect(unbound!.assignedSessionId).toBeNull()
+    })
+
+    it('DevInstance を削除できる（slot_assignment も連動削除）', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      const deleted = store.deleteDevInstance(instance.id)
+      expect(deleted).toBe(true)
+      expect(store.getDevInstance(0)).toBeNull()
+      expect(store.getSlotAssignment(0)).toBeNull()
+    })
+
+    it('同一スロット番号の二重作成は UNIQUE 制約で拒否される', () => {
+      store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+
+      expect(() => {
+        store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      }).toThrow()
+    })
+  })
+
+  describe('SlotAssignment', () => {
+    it('スロットを割り当てて取得できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const assignment = store.assignSlot(0, instance.id)
+
+      expect(assignment.slotNumber).toBe(0)
+      expect(assignment.instanceId).toBe(instance.id)
+      expect(assignment.assignedAt).toBeGreaterThan(0)
+
+      const retrieved = store.getSlotAssignment(0)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.instanceId).toBe(instance.id)
+    })
+
+    it('同一スロットへの二重割り当てが UNIQUE 制約で拒否される', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      store.assignSlot(0, inst1.id)
+
+      // 同じ slotNumber=0 に別の instance を割り当てようとする → UNIQUE 制約違反
+      expect(() => store.assignSlot(0, inst2.id)).toThrow()
+    })
+
+    it('異なるスロットは独立して割り当て可能', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      const a1 = store.assignSlot(0, inst1.id)
+      const a2 = store.assignSlot(1, inst2.id)
+
+      expect(a1.slotNumber).toBe(0)
+      expect(a2.slotNumber).toBe(1)
+    })
+
+    it('スロットを解放できる', () => {
+      const instance = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      store.assignSlot(0, instance.id)
+
+      store.releaseSlot(0)
+      expect(store.getSlotAssignment(0)).toBeNull()
+
+      // 解放後は再割り当て可能
+      const newAssignment = store.assignSlot(0, instance.id)
+      expect(newAssignment.slotNumber).toBe(0)
+    })
+
+    it('全スロット割り当てを取得できる', () => {
+      const inst1 = store.createDevInstance({ slotNumber: 0, serverPort: 14000, clientPort: 5180, playwrightPort: 3550 })
+      const inst2 = store.createDevInstance({ slotNumber: 1, serverPort: 14001, clientPort: 5181, playwrightPort: 3551 })
+
+      store.assignSlot(0, inst1.id)
+      store.assignSlot(1, inst2.id)
+
+      const all = store.getAllSlotAssignments()
+      expect(all).toHaveLength(2)
+      expect(all[0].slotNumber).toBe(0)
+      expect(all[1].slotNumber).toBe(1)
+    })
+  })
+})

--- a/packages/server/src/__tests__/leader-lock.test.ts
+++ b/packages/server/src/__tests__/leader-lock.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, existsSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs'
 import path from 'path'
 import { tmpdir } from 'os'
-import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath } from '../services/leader-lock'
+import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath, registerLockCleanup } from '../services/leader-lock'
 import type { LockInfo } from '../services/leader-lock'
 
 /** テスト用の一時ディレクトリを作成 */
@@ -168,11 +168,57 @@ describe('LeaderLock', () => {
   })
 
   describe('破損した lockfile の処理', () => {
-    it('不正な JSON の lockfile は新規取得として扱われる', () => {
+    it('不正な JSON の lockfile は stale 扱いで新規取得される', () => {
       writeFileSync(lockfilePath, 'not valid json', 'utf-8')
 
       const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
       expect(result.acquired).toBe(true)
+    })
+  })
+
+  describe('原子的取得（排他的作成）', () => {
+    it('lockfile が存在しない場合は排他的作成で一発取得', () => {
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+
+      // lockfile が正しく書かれている
+      const info = readLock(lockfilePath)
+      expect(info!.pid).toBe(process.pid)
+    })
+
+    it('stale lock を unlink → 再度排他的作成で取得', () => {
+      // stale lock を作成（存在しない PID）
+      const staleLock: LockInfo = {
+        pid: 2147483647,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      // 排他的取得 → stale 検出 → unlink → 再取得
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+      expect(readLock(lockfilePath)!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('registerLockCleanup', () => {
+    it('exit イベントのみ登録し SIGINT/SIGTERM ハンドラは登録しない', () => {
+      // registerLockCleanup が SIGINT/SIGTERM を登録しないことを確認
+      // (index.ts の shutdown() が graceful shutdown を担当するため)
+      const exitListenersBefore = process.listenerCount('exit')
+      const sigintListenersBefore = process.listenerCount('SIGINT')
+      const sigtermListenersBefore = process.listenerCount('SIGTERM')
+
+      // 一時的な lockfile で cleanup を登録
+      const tempLockPath = path.join(tempDir, 'cleanup-test.lock')
+      registerLockCleanup({ paneNumber: 99, lockfilePath: tempLockPath })
+
+      expect(process.listenerCount('exit')).toBe(exitListenersBefore + 1)
+      expect(process.listenerCount('SIGINT')).toBe(sigintListenersBefore) // 増えない
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermListenersBefore) // 増えない
     })
   })
 })

--- a/packages/server/src/__tests__/leader-lock.test.ts
+++ b/packages/server/src/__tests__/leader-lock.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, existsSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { acquireLock, releaseLock, isLocked, readLock, getLockfilePath } from '../services/leader-lock'
+import type { LockInfo } from '../services/leader-lock'
+
+/** テスト用の一時ディレクトリを作成 */
+function createTempDir(): string {
+  const dir = path.join(tmpdir(), `leader-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('LeaderLock', () => {
+  let tempDir: string
+  let lockfilePath: string
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+    lockfilePath = path.join(tempDir, 'test.lock')
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // テスト後のクリーンアップ失敗は無視
+    }
+  })
+
+  describe('acquireLock / releaseLock 基本サイクル', () => {
+    it('lockfile が存在しない場合に取得成功する', () => {
+      const result = acquireLock({
+        port: 14000,
+        paneNumber: 0,
+        type: 'dev',
+        lockfilePath,
+      })
+
+      expect(result.acquired).toBe(true)
+      expect(existsSync(lockfilePath)).toBe(true)
+
+      // lockfile の内容を確認
+      const info = readLock(lockfilePath)
+      expect(info).not.toBeNull()
+      expect(info!.pid).toBe(process.pid)
+      expect(info!.port).toBe(14000)
+      expect(info!.paneNumber).toBe(0)
+      expect(info!.type).toBe('dev')
+    })
+
+    it('releaseLock で lockfile が削除される', () => {
+      acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(true)
+
+      releaseLock({ paneNumber: 0, lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(false)
+    })
+
+    it('releaseLock は自分の PID でない lock を削除しない', () => {
+      // 他プロセスの lock を偽装
+      const fakeLock: LockInfo = {
+        pid: 999999,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: new Date().toISOString(),
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(fakeLock), 'utf-8')
+
+      // 自分の PID と異なるので削除されない
+      releaseLock({ paneNumber: 0, lockfilePath })
+      expect(existsSync(lockfilePath)).toBe(true)
+    })
+  })
+
+  describe('二重取得の拒否', () => {
+    it('有効な lock が存在する場合に取得失敗する', () => {
+      // 自プロセスの PID で lock を取得（自プロセスは当然生きている）
+      const first = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(first.acquired).toBe(true)
+
+      // 同じ lockfile に対して2回目の取得 → 失敗
+      const second = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(second.acquired).toBe(false)
+      expect(second.existingLock).toBeDefined()
+      expect(second.existingLock!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('stale lock の自動回収', () => {
+    it('存在しない PID の lockfile を上書き取得できる', () => {
+      // 存在しない PID で lock を偽装
+      const staleLock: LockInfo = {
+        pid: 2147483647, // 存在しないPID
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      // stale lock を上書きして取得成功
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+
+      // 新しい lock が自分の PID
+      const info = readLock(lockfilePath)
+      expect(info!.pid).toBe(process.pid)
+    })
+  })
+
+  describe('PANE_NUMBER 別の lock 分離', () => {
+    it('異なる paneNumber の lockfile は独立している', () => {
+      const lockPath0 = path.join(tempDir, 'pane0.lock')
+      const lockPath1 = path.join(tempDir, 'pane1.lock')
+
+      const result0 = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath: lockPath0 })
+      const result1 = acquireLock({ port: 14001, paneNumber: 1, type: 'dev', lockfilePath: lockPath1 })
+
+      expect(result0.acquired).toBe(true)
+      expect(result1.acquired).toBe(true)
+    })
+  })
+
+  describe('isLocked', () => {
+    it('有効な lock が存在する場合に LockInfo を返す', () => {
+      acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+
+      const info = isLocked(0, lockfilePath)
+      expect(info).not.toBeNull()
+      expect(info!.pid).toBe(process.pid)
+    })
+
+    it('lock が存在しない場合に null を返す', () => {
+      const info = isLocked(0, lockfilePath)
+      expect(info).toBeNull()
+    })
+
+    it('stale lock は null を返す', () => {
+      const staleLock: LockInfo = {
+        pid: 2147483647,
+        port: 14000,
+        paneNumber: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        type: 'dev',
+      }
+      writeFileSync(lockfilePath, JSON.stringify(staleLock), 'utf-8')
+
+      const info = isLocked(0, lockfilePath)
+      expect(info).toBeNull()
+    })
+  })
+
+  describe('getLockfilePath', () => {
+    it('paneNumber=null → server.lock', () => {
+      expect(getLockfilePath(null)).toMatch(/server\.lock$/)
+    })
+
+    it('paneNumber=0 → server-dev.lock', () => {
+      expect(getLockfilePath(0)).toMatch(/server-dev\.lock$/)
+    })
+
+    it('paneNumber=3 → server-pane3.lock', () => {
+      expect(getLockfilePath(3)).toMatch(/server-pane3\.lock$/)
+    })
+  })
+
+  describe('破損した lockfile の処理', () => {
+    it('不正な JSON の lockfile は新規取得として扱われる', () => {
+      writeFileSync(lockfilePath, 'not valid json', 'utf-8')
+
+      const result = acquireLock({ port: 14000, paneNumber: 0, type: 'dev', lockfilePath })
+      expect(result.acquired).toBe(true)
+    })
+  })
+})

--- a/packages/server/src/__tests__/playwright-runner.test.ts
+++ b/packages/server/src/__tests__/playwright-runner.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { PlaywrightRunner } from '../services/playwright-runner'
+
+describe('PlaywrightRunner', () => {
+  let runner: PlaywrightRunner
+
+  beforeEach(() => {
+    runner = new PlaywrightRunner()
+    // error イベントの unhandled 防止
+    runner.on('runner_error', () => {})
+  })
+
+  afterEach(() => {
+    runner.stopAll()
+    runner.removeAllListeners()
+  })
+
+  describe('run', () => {
+    it('テスト実行を開始して running 状態を返す', () => {
+      // echo で即座に終了するコマンドを使ってテスト
+      const result = runner.run('inst-1', 0, '/tmp', undefined)
+
+      expect(result.instanceId).toBe('inst-1')
+      expect(result.status).toBe('running')
+      expect(result.port).toBe(3550)
+      expect(result.startedAt).toBeGreaterThan(0)
+      expect(result.testPath).toBeNull()
+    })
+
+    it('テストパスを指定して実行できる', () => {
+      const result = runner.run('inst-2', 1, '/tmp', 'e2e/basic.spec.ts')
+
+      expect(result.testPath).toBe('e2e/basic.spec.ts')
+      expect(result.port).toBe(3551)
+    })
+
+    it('同じインスタンスで二重実行はエラーになる', () => {
+      runner.run('inst-3', 0, '/tmp')
+
+      expect(() => {
+        runner.run('inst-3', 0, '/tmp')
+      }).toThrow('既にテスト実行中')
+    })
+
+    it('異なるインスタンスは独立して実行できる', () => {
+      const r1 = runner.run('inst-a', 0, '/tmp')
+      const r2 = runner.run('inst-b', 1, '/tmp')
+
+      expect(r1.port).toBe(3550)
+      expect(r2.port).toBe(3551)
+      expect(r1.instanceId).not.toBe(r2.instanceId)
+    })
+  })
+
+  describe('run + 完了', () => {
+    it('成功したテストは passed 状態になる', async () => {
+      // echo で即座に exit 0 するコマンドを npxPath として使用
+      const fastRunner = new PlaywrightRunner({ npxPath: 'echo' })
+      fastRunner.on('runner_error', () => {})
+
+      const result = fastRunner.run('fast-1', 0, '/tmp')
+
+      // finished イベントを待つ
+      await new Promise<void>((resolve) => {
+        fastRunner.on('finished', () => resolve())
+      })
+
+      expect(result.status).toBe('passed')
+      expect(result.exitCode).toBe(0)
+      expect(result.finishedAt).toBeGreaterThan(0)
+
+      fastRunner.stopAll()
+    })
+
+    it('失敗したテストは failed 状態になる', async () => {
+      // false コマンドで exit 1
+      const failRunner = new PlaywrightRunner({ npxPath: 'false' })
+      failRunner.on('runner_error', () => {})
+
+      const result = failRunner.run('fail-1', 0, '/tmp')
+
+      await new Promise<void>((resolve) => {
+        failRunner.on('finished', () => resolve())
+      })
+
+      expect(result.status).toBe('failed')
+      expect(result.exitCode).not.toBe(0)
+
+      failRunner.stopAll()
+    })
+  })
+
+  describe('stop', () => {
+    it('実行中のテストを中止できる', async () => {
+      // sleep で長時間実行するコマンド
+      const slowRunner = new PlaywrightRunner({ npxPath: 'sleep' })
+      slowRunner.on('runner_error', () => {})
+
+      slowRunner.run('slow-1', 0, '/tmp')
+      slowRunner.stop('slow-1')
+
+      await new Promise<void>((resolve) => {
+        slowRunner.on('finished', () => resolve())
+      })
+
+      const result = slowRunner.getResult('slow-1')
+      expect(result!.status).toBe('cancelled')
+
+      slowRunner.stopAll()
+    })
+
+    it('実行していな��インスタンスの stop は安全に無視される', () => {
+      expect(() => runner.stop('non-existent')).not.toThrow()
+    })
+  })
+
+  describe('getResult / getStatus', () => {
+    it('実行結果を取得できる', () => {
+      runner.run('inst-r', 0, '/tmp')
+
+      const result = runner.getResult('inst-r')
+      expect(result).not.toBeNull()
+      expect(result!.instanceId).toBe('inst-r')
+    })
+
+    it('存在しないインスタンスは null / idle を返す', () => {
+      expect(runner.getResult('no-exist')).toBeNull()
+      expect(runner.getStatus('no-exist')).toBe('idle')
+    })
+  })
+
+  describe('getAllResults', () => {
+    it('全結果を取得できる', () => {
+      runner.run('a', 0, '/tmp')
+      runner.run('b', 1, '/tmp')
+
+      expect(runner.getAllResults()).toHaveLength(2)
+    })
+  })
+
+  describe('clearFinished', () => {
+    it('完了済みの結果をクリアする', async () => {
+      const fastRunner = new PlaywrightRunner({ npxPath: 'echo' })
+      fastRunner.on('runner_error', () => {})
+
+      fastRunner.run('clear-1', 0, '/tmp')
+
+      await new Promise<void>((resolve) => {
+        fastRunner.on('finished', () => resolve())
+      })
+
+      expect(fastRunner.getAllResults()).toHaveLength(1)
+      fastRunner.clearFinished()
+      expect(fastRunner.getAllResults()).toHaveLength(0)
+
+      fastRunner.stopAll()
+    })
+  })
+
+  describe('イベント', () => {
+    it('started イベントが発火する', () => {
+      const handler = vi.fn()
+      runner.on('started', handler)
+
+      runner.run('evt-1', 0, '/tmp')
+
+      expect(handler).toHaveBeenCalledWith('evt-1', expect.objectContaining({ instanceId: 'evt-1' }))
+    })
+
+    it('progress イベントが発火する', () => {
+      const handler = vi.fn()
+      runner.on('progress', handler)
+
+      runner.run('evt-2', 0, '/tmp')
+
+      expect(handler).toHaveBeenCalledWith('evt-2', 'running')
+    })
+  })
+
+  describe('ポート分離', () => {
+    it('スロット番号に応じたポートが設定される', () => {
+      const r0 = runner.run('port-0', 0, '/tmp')
+      const r1 = runner.run('port-1', 1, '/tmp')
+      const r3 = runner.run('port-3', 3, '/tmp')
+
+      expect(r0.port).toBe(3550)
+      expect(r1.port).toBe(3551)
+      expect(r3.port).toBe(3553)
+    })
+  })
+})

--- a/packages/server/src/__tests__/process-supervisor.test.ts
+++ b/packages/server/src/__tests__/process-supervisor.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ProcessSupervisor } from '../services/process-supervisor'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('ProcessSupervisor', () => {
+  let supervisor: ProcessSupervisor
+
+  beforeEach(() => {
+    supervisor = new ProcessSupervisor({
+      checkIntervalMs: 50,  // テスト用に短縮
+      healthyThreshold: 2,
+      maxRestarts: 1,
+    })
+  })
+
+  afterEach(() => {
+    supervisor.stopAll()
+  })
+
+  describe('基本操作', () => {
+    it('プロセスを監視開始できる', () => {
+      const spawnFn: SpawnFn = (_onExit) => process.pid // 自分自身のPIDを返す
+
+      supervisor.supervise('inst-1', spawnFn)
+
+      const status = supervisor.getStatus('inst-1')
+      expect(status).not.toBeNull()
+      expect(status!.instanceId).toBe('inst-1')
+      expect(status!.pid).toBe(process.pid)
+      expect(status!.status).toBe('starting')
+    })
+
+    it('同じIDで二重登録するとエラー', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+
+      expect(() => supervisor.supervise('inst-1', () => process.pid)).toThrow('既に監視中')
+    })
+
+    it('stop で監視を停止できる', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+      supervisor.stop('inst-1')
+
+      expect(supervisor.getStatus('inst-1')).toBeNull()
+    })
+
+    it('getAllStatuses で全状態を取得できる', () => {
+      supervisor.supervise('inst-1', () => process.pid)
+      supervisor.supervise('inst-2', () => process.pid)
+
+      const all = supervisor.getAllStatuses()
+      expect(all).toHaveLength(2)
+    })
+  })
+
+  describe('ヘルスチェック', () => {
+    it('連続成功で healthy に遷移する', async () => {
+      const healthyPromise = new Promise<void>((resolve) => {
+        supervisor.on('healthy', (id) => {
+          if (id === 'inst-1') resolve()
+        })
+      })
+
+      supervisor.supervise('inst-1', () => process.pid)
+
+      // healthyThreshold=2, checkIntervalMs=50 なので ~100ms で healthy
+      await healthyPromise
+      expect(supervisor.getStatus('inst-1')!.status).toBe('healthy')
+    })
+  })
+
+  describe('second shot（再起動）', () => {
+    it('プロセス終了時に 1 回再起動する', async () => {
+      let exitCallback: ((code: number | null) => void) | null = null
+      let spawnCount = 0
+
+      const spawnFn: SpawnFn = (onExit) => {
+        spawnCount++
+        exitCallback = onExit
+        return process.pid
+      }
+
+      const restartingPromise = new Promise<number>((resolve) => {
+        supervisor.on('restarting', (_id, count) => resolve(count))
+      })
+
+      supervisor.supervise('inst-1', spawnFn)
+      expect(spawnCount).toBe(1)
+
+      // プロセス終了をシミュレート
+      exitCallback!(1)
+
+      const restartCount = await restartingPromise
+      expect(restartCount).toBe(1)
+      expect(spawnCount).toBe(2) // 再起動で2回目
+    })
+
+    it('再起動上限到達で error 状態に遷移する', async () => {
+      let exitCallback: ((code: number | null) => void) | null = null
+
+      const spawnFn: SpawnFn = (onExit) => {
+        exitCallback = onExit
+        return process.pid
+      }
+
+      const errorPromise = new Promise<void>((resolve) => {
+        supervisor.on('error', () => resolve())
+      })
+
+      supervisor.supervise('inst-1', spawnFn)
+
+      // 1回目の終了 → 再起動
+      exitCallback!(1)
+
+      // 少し待って2回目の終了 → error
+      await new Promise(r => setTimeout(r, 10))
+      exitCallback!(1)
+
+      await errorPromise
+      expect(supervisor.getStatus('inst-1')!.status).toBe('error')
+    })
+  })
+
+  describe('spawn 失敗', () => {
+    it('spawn 関数が例外を投げると error 状態になる', () => {
+      const errorPromise = new Promise<void>((resolve) => {
+        supervisor.on('error', () => resolve())
+      })
+
+      const spawnFn: SpawnFn = () => {
+        throw new Error('起動失敗')
+      }
+
+      supervisor.supervise('inst-1', spawnFn)
+      expect(supervisor.getStatus('inst-1')!.status).toBe('error')
+    })
+  })
+})

--- a/packages/server/src/__tests__/resource-monitor.test.ts
+++ b/packages/server/src/__tests__/resource-monitor.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import { ResourceMonitorService } from '../services/resource-monitor'
+import type { SpawnFn } from '../services/process-supervisor'
+
+/** PtyManager のモック */
+function createMockPtyManager() {
+  return {
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    kill: vi.fn(),
+    killAll: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    backend: 'node-pty' as const,
+  } as any
+}
+
+describe('ResourceMonitorService', () => {
+  let store: SessionStore
+  let devManager: DevInstanceManager
+  let monitor: ResourceMonitorService
+  let mockPtyManager: ReturnType<typeof createMockPtyManager>
+
+  const dummySpawn: SpawnFn = (_onExit) => process.pid // 自身の PID を返す（テスト用）
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    devManager = new DevInstanceManager(store, { checkIntervalMs: 100 })
+    devManager.on('error', () => {})
+    mockPtyManager = createMockPtyManager()
+    monitor = new ResourceMonitorService(devManager, mockPtyManager, {
+      intervalMs: 60000, // テスト中は手動収集のみ
+      getWsConnectionCount: () => 3,
+    })
+  })
+
+  afterEach(() => {
+    monitor.stop()
+    devManager.stopAll()
+    store.close()
+  })
+
+  describe('collect', () => {
+    it('サーバーメトリクスを収集できる', async () => {
+      const snapshot = await monitor.collect()
+
+      expect(snapshot.server).toBeDefined()
+      expect(snapshot.server.pid).toBe(process.pid)
+      expect(snapshot.server.memoryRss).toBeGreaterThan(0)
+      expect(snapshot.server.uptime).toBeGreaterThanOrEqual(0)
+      expect(snapshot.collectedAt).toBeGreaterThan(0)
+    })
+
+    it('WS 接続数を取得できる', async () => {
+      const snapshot = await monitor.collect()
+      expect(snapshot.wsConnectionCount).toBe(3)
+    })
+
+    it('DevInstance のメトリクスを収集できる', async () => {
+      const instance = devManager.startInstance(0, dummySpawn)
+      // DB に PID を設定（supervisor は非同期で設定するためテストでは手動）
+      store.updateDevInstanceStatus(instance.id, 'running', process.pid)
+
+      const snapshot = await monitor.collect()
+
+      expect(snapshot.instances.length).toBeGreaterThanOrEqual(1)
+      const instanceMetric = snapshot.instances.find(m => m.instanceId !== null)
+      expect(instanceMetric).toBeDefined()
+      expect(instanceMetric!.processStatus).toBe('alive')
+      expect(instanceMetric!.pid).toBe(process.pid)
+    })
+
+    it('DevInstance に紐づかない active セッションも含まれる', async () => {
+      mockPtyManager.getActiveSessionIds.mockReturnValue(['session-orphan'])
+
+      const snapshot = await monitor.collect()
+
+      const orphan = snapshot.instances.find(m => m.sessionId === 'session-orphan')
+      expect(orphan).toBeDefined()
+      expect(orphan!.instanceId).toBeNull()
+      expect(orphan!.processStatus).toBe('unknown')
+    })
+
+    it('snapshot イベントが発火する', async () => {
+      const handler = vi.fn()
+      monitor.on('snapshot', handler)
+
+      await monitor.collect()
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler.mock.calls[0][0].server.pid).toBe(process.pid)
+    })
+  })
+
+  describe('getLastSnapshot / getInstanceMetrics', () => {
+    it('初期状態は null', () => {
+      expect(monitor.getLastSnapshot()).toBeNull()
+    })
+
+    it('collect 後にキャッシュされる', async () => {
+      await monitor.collect()
+      const snapshot = monitor.getLastSnapshot()
+      expect(snapshot).not.toBeNull()
+      expect(snapshot!.server.pid).toBe(process.pid)
+    })
+
+    it('特定インスタンスのメトリクスを取得できる', async () => {
+      const instance = devManager.startInstance(0, dummySpawn)
+      await monitor.collect()
+
+      const metrics = monitor.getInstanceMetrics(instance.id)
+      expect(metrics).not.toBeNull()
+      expect(metrics!.instanceId).toBe(instance.id)
+    })
+
+    it('存在しないインスタンスは null を返す', async () => {
+      await monitor.collect()
+      expect(monitor.getInstanceMetrics('non-existent')).toBeNull()
+    })
+  })
+
+  describe('start / stop', () => {
+    it('start/stop でタイマーが制御される', () => {
+      // start を複数回呼んでも二重起動しない
+      monitor.start()
+      monitor.start()
+      monitor.stop()
+      // 例外なく完了
+    })
+  })
+})

--- a/packages/server/src/__tests__/session-dev-binding-service.test.ts
+++ b/packages/server/src/__tests__/session-dev-binding-service.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { DevInstanceManager } from '../services/dev-instance-manager'
+import { SessionDevBindingService } from '../services/session-dev-binding-service'
+import type { SpawnFn } from '../services/process-supervisor'
+
+describe('SessionDevBindingService', () => {
+  let store: SessionStore
+  let manager: DevInstanceManager
+  let service: SessionDevBindingService
+
+  const dummySpawn: SpawnFn = (_onExit) => 99999
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+    manager = new DevInstanceManager(store, { checkIntervalMs: 100 })
+    service = new SessionDevBindingService(store, manager)
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    store.close()
+  })
+
+  /** テスト用セッションを作成する */
+  function createSession(name = 'test-session') {
+    return store.create({
+      name,
+      repoPath: '/tmp/repo',
+    })
+  }
+
+  describe('bind', () => {
+    it('セッションと DevInstance をバインドできる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+
+      const bound = service.getBindingForSession(session.id)
+      expect(bound).not.toBeNull()
+      expect(bound!.id).toBe(instance.id)
+      expect(bound!.assignedSessionId).toBe(session.id)
+    })
+
+    it('存在しないセッションへのバインドはエラー', () => {
+      const instance = manager.startInstance(0, dummySpawn)
+
+      expect(() => {
+        service.bind('non-existent', instance.id)
+      }).toThrow('セッション non-existent が見つかりません')
+    })
+
+    it('存在しないインスタンスへのバインドはエラー', () => {
+      const session = createSession()
+
+      expect(() => {
+        service.bind(session.id, 'non-existent')
+      }).toThrow('DevInstance non-existent が見つかりません')
+    })
+
+    it('既に別のセッションがバインドされているインスタンスへのバインドはエラー', () => {
+      const session1 = createSession('session-1')
+      const session2 = createSession('session-2')
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session1.id, instance.id)
+
+      expect(() => {
+        service.bind(session2.id, instance.id)
+      }).toThrow('既にセッション')
+    })
+
+    it('同じセッションの再バインドは成功する（冪等）', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      // 同じセッションで再度バインド → エラーにならない
+      expect(() => service.bind(session.id, instance.id)).not.toThrow()
+    })
+  })
+
+  describe('unbind', () => {
+    it('セッションのバインドを解除できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      service.unbind(session.id)
+
+      expect(service.getBindingForSession(session.id)).toBeNull()
+
+      // DevInstance 側もアンバインドされている
+      const updated = manager.getInstanceById(instance.id)
+      expect(updated!.assignedSessionId).toBeNull()
+    })
+
+    it('バインドされていないセッションの unbind は安全に無視される', () => {
+      expect(() => service.unbind('non-existent')).not.toThrow()
+    })
+  })
+
+  describe('unbindByInstance', () => {
+    it('インスタンス ID でバインドを解除できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      service.unbindByInstance(instance.id)
+
+      expect(service.isBound(session.id)).toBe(false)
+    })
+  })
+
+  describe('getBindingForSession', () => {
+    it('バインドされていない場合は null を返す', () => {
+      const session = createSession()
+      expect(service.getBindingForSession(session.id)).toBeNull()
+    })
+  })
+
+  describe('getBoundSessionId', () => {
+    it('バインドされたセッション ID を取得できる', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+
+      expect(service.getBoundSessionId(instance.id)).toBe(session.id)
+    })
+
+    it('バインドされていない場合は null を返す', () => {
+      const instance = manager.startInstance(0, dummySpawn)
+      expect(service.getBoundSessionId(instance.id)).toBeNull()
+    })
+  })
+
+  describe('isBound', () => {
+    it('バインドされている場合は true を返す', () => {
+      const session = createSession()
+      const instance = manager.startInstance(0, dummySpawn)
+
+      service.bind(session.id, instance.id)
+      expect(service.isBound(session.id)).toBe(true)
+    })
+
+    it('バインドされていない場合は false を返す', () => {
+      const session = createSession()
+      expect(service.isBound(session.id)).toBe(false)
+    })
+  })
+})

--- a/packages/server/src/__tests__/session-lifecycle.test.ts
+++ b/packages/server/src/__tests__/session-lifecycle.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SessionStore } from '../services/session-store'
+import { cleanupSession, retryTombstoneCleanup } from '../services/session-lifecycle'
+
+/** PtyManager のモック */
+function createMockPtyManager() {
+  return {
+    kill: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    backend: 'node-pty' as const,
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    killAll: vi.fn(),
+  } as any
+}
+
+/** SshManager のモック */
+function createMockSshManager() {
+  return {
+    kill: vi.fn(),
+    hasSession: vi.fn().mockReturnValue(false),
+    connect: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    getBuffer: vi.fn().mockReturnValue(''),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getActiveSessionIds: vi.fn().mockReturnValue([]),
+    disconnectAll: vi.fn(),
+    getHosts: vi.fn().mockReturnValue([]),
+  } as any
+}
+
+/** WorktreeService のモック */
+function createMockWorktreeService(removeThrows = false) {
+  return {
+    remove: removeThrows
+      ? vi.fn().mockImplementation(() => { throw new Error('worktree 削除失敗') })
+      : vi.fn(),
+    create: vi.fn().mockReturnValue('/tmp/worktree'),
+    getBranch: vi.fn().mockReturnValue('main'),
+    isGitRepo: vi.fn().mockReturnValue(true),
+    list: vi.fn().mockReturnValue([]),
+    prune: vi.fn(),
+    cleanupOrphanedBranches: vi.fn().mockReturnValue([]),
+    ensurePersistentDevelopWorktree: vi.fn().mockReturnValue('/tmp/persistent'),
+  } as any
+}
+
+describe('cleanupSession (async)', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('正常な cleanup: PTY kill → worktree 削除 → DB 削除', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/test',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // PTY が kill されている
+    expect(ptyManager.kill).toHaveBeenCalledWith(session.id)
+    // worktree が削除されている
+    expect(worktreeService.remove).toHaveBeenCalledWith('/tmp/repo', '/tmp/repo/.kurimats-worktrees/test')
+    // DB から削除されている
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('worktree 削除失敗 → tombstone に遷移（DB は残る）', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/test',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService(true) // remove が例外を投げる
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // DB にはまだ残っていて tombstone 状態
+    const remaining = store.getById(session.id)
+    expect(remaining).not.toBeNull()
+    expect(remaining!.status).toBe('tombstone')
+  })
+
+  it('worktree なしのセッションは直接 DB 削除', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      // worktreePath なし
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(store.getById(session.id)).toBeNull()
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+  })
+
+  it('存在しないセッション ID は安全に無視される', async () => {
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await expect(
+      cleanupSession(store, ptyManager, sshManager, worktreeService, 'non-existent'),
+    ).resolves.not.toThrow()
+  })
+
+  it('SSH セッションの場合は sshManager.kill が呼ばれる', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      sshHost: 'remote-host',
+      isRemote: true,
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    sshManager.hasSession.mockReturnValue(true)
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(sshManager.kill).toHaveBeenCalledWith(session.id)
+    expect(ptyManager.kill).not.toHaveBeenCalled()
+  })
+
+  it('persistent develop worktree はセッション削除時に worktree を残す', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+    })
+
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    // worktree は削除されない
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+    // セッションは DB から削除される
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('cleanup 中は cleaning 状態を経由する', async () => {
+    const session = store.create({
+      name: 'test',
+      repoPath: '/tmp/repo',
+    })
+
+    // worktreeService.remove を遅延させて cleaning 状態を確認
+    const ptyManager = createMockPtyManager()
+    const sshManager = createMockSshManager()
+    const worktreeService = createMockWorktreeService()
+
+    // cleanupSession 開始直後に状態を確認するため、pty.kill のモックで状態をキャプチャ
+    let statusDuringKill: string | undefined
+    ptyManager.kill.mockImplementation(() => {
+      statusDuringKill = store.getById(session.id)?.status
+    })
+
+    await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+
+    expect(statusDuringKill).toBe('cleaning')
+  })
+})
+
+describe('retryTombstoneCleanup', () => {
+  let store: SessionStore
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('tombstone セッションの worktree を削除して DB から消す', () => {
+    const session = store.create({
+      name: 'tombstone-test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/tombstone',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    expect(worktreeService.remove).toHaveBeenCalled()
+    expect(store.getById(session.id)).toBeNull()
+  })
+
+  it('tombstone retry でも worktree 削除失敗の場合は残留する', () => {
+    const session = store.create({
+      name: 'tombstone-test',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/stuck',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService(true) // remove が例外
+    retryTombstoneCleanup(store, worktreeService)
+
+    // DB に残留
+    const remaining = store.getById(session.id)
+    expect(remaining).not.toBeNull()
+    expect(remaining!.status).toBe('tombstone')
+  })
+
+  it('tombstone がない場合は何もしない', () => {
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+  })
+
+  it('persistent develop の tombstone は worktree を削除せず DB から消す', () => {
+    const session = store.create({
+      name: 'persistent-tombstone',
+      repoPath: '/tmp/repo',
+      worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+    })
+    store.updateStatus(session.id, 'tombstone')
+
+    const worktreeService = createMockWorktreeService()
+    retryTombstoneCleanup(store, worktreeService)
+
+    // worktree は削除されない
+    expect(worktreeService.remove).not.toHaveBeenCalled()
+    // DB からは削除される
+    expect(store.getById(session.id)).toBeNull()
+  })
+})

--- a/packages/server/src/__tests__/sessions.test.ts
+++ b/packages/server/src/__tests__/sessions.test.ts
@@ -177,7 +177,7 @@ describeServer('セッションAPI', () => {
     expect(updated?.status).toBe('disconnected')
   })
 
-  it('セッション作成時にclaude --continueで起動される', async () => {
+  it('セッション作成時にclaude --dangerously-skip-permissions --continueで起動される', async () => {
     const res = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -185,13 +185,13 @@ describeServer('セッションAPI', () => {
     })
     expect(res.status).toBe(201)
 
-    // child_processモードではclaude --continueが直接spawnされる
+    // child_processモードではclaude --dangerously-skip-permissions --continueが直接spawnされる
     expect(ptyManager.spawn).toHaveBeenCalledWith(
-      expect.any(String), '/tmp', 120, 30, 'claude', ['--continue'],
+      expect.any(String), '/tmp', 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'],
     )
   })
 
-  it('再接続時にclaude --continueで起動される', async () => {
+  it('再接続時にclaude --dangerously-skip-permissions --continueで起動される', async () => {
     const createRes = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -207,7 +207,7 @@ describeServer('セッションAPI', () => {
     await fetch(`${baseUrl}/api/sessions/${session.id}/reconnect`, { method: 'POST' })
 
     expect(ptyManager.spawn).toHaveBeenCalledWith(
-      session.id, '/tmp', 120, 30, 'claude', ['--continue'],
+      session.id, '/tmp', 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'],
     )
   })
 

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -479,4 +479,49 @@ describe('runStartupTasks', () => {
       expect(worktreeService.getBranch).toHaveBeenCalledWith('/tmp/repo/.kurimats-worktrees/pane1')
     })
   })
+
+  describe('persistent develop worktree の保護', () => {
+    it('段階2で persistent develop worktree が削除されない', () => {
+      const session = store.create({
+        name: 'persistent-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane0',
+        baseBranch: 'kurimats/persistent-develop-pane0',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+      store.updateStatus(session.id, 'disconnected')
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
+
+      // persistent develop worktree は削除されない
+      const updated = store.getById(session.id)
+      expect(updated?.worktreePath).toBe('/tmp/repo/.kurimats-worktrees/persistent-develop-pane0')
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+    })
+
+    it('段階3で persistent develop worktree を持つ孤立セッションが保護される', () => {
+      const ws = store.createCmuxWorkspace(
+        { name: 'test-ws', repoPath: '/tmp/repo' },
+        { kind: 'leaf', id: 'pane-a', sessionId: 'some-other-session', ratio: 1 },
+      )
+      const orphan = store.create({
+        name: 'persistent-orphan',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+        isRemote: false,
+        workspaceId: ws.id,
+        projectId: null,
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
+
+      // persistent develop worktree は worktreeService.remove されない
+      expect(worktreeService.remove).not.toHaveBeenCalledWith(
+        '/tmp/repo',
+        '/tmp/repo/.kurimats-worktrees/persistent-develop-pane1',
+      )
+    })
+  })
 })

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { SessionStore } from '../services/session-store'
-import { runStartupTasks } from '../startup'
+import { runStartupTasks, resolveSelfWorktreeVerdict } from '../startup'
 import type { WorktreeService } from '../services/worktree-service'
 
 /** WorktreeServiceのモック */
@@ -15,6 +15,9 @@ function createMockWorktreeService(): WorktreeService {
     cleanupOrphanedBranches: vi.fn().mockReturnValue([]),
   } as unknown as WorktreeService
 }
+
+/** 既存テストを verdict='outside' で実行するための cwd オプション */
+const OUTSIDE_CWD = { cwd: '/tmp/definitely-not-a-worktree' }
 
 describe('runStartupTasks', () => {
   let store: SessionStore
@@ -39,7 +42,7 @@ describe('runStartupTasks', () => {
         projectId: null,
       })
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       const updated = store.getById(session.id)
       expect(updated?.status).toBe('disconnected')
@@ -59,7 +62,7 @@ describe('runStartupTasks', () => {
     // disconnectedに設定
     store.updateStatus(session.id, 'disconnected')
 
-    runStartupTasks(store, worktreeService as unknown as WorktreeService)
+    runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
     const updated = store.getById(session.id)
     expect(updated?.worktreePath).toBeNull()
@@ -84,7 +87,7 @@ describe('runStartupTasks', () => {
       projectId: null,
     })
 
-    runStartupTasks(store, worktreeService as unknown as WorktreeService)
+    runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
     const found = store.getById(orphan.id)
     expect(found).toBeNull()
@@ -105,7 +108,7 @@ describe('runStartupTasks', () => {
         projectId: null,
       })
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       const updated = store.getById(session.id)
       expect(updated?.status).toBe('disconnected')
@@ -124,7 +127,7 @@ describe('runStartupTasks', () => {
       })
       store.updateStatus(session.id, 'disconnected')
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       const updated = store.getById(session.id)
       // セッション自体は残る
@@ -149,7 +152,7 @@ describe('runStartupTasks', () => {
         projectId: null,
       })
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       expect(store.getById(orphan.id)).toBeNull()
       // SSHはworktreeを持たないのでremoveは呼ばれない
@@ -184,7 +187,7 @@ describe('runStartupTasks', () => {
         projectId: null,
       })
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       // 両方とも削除される
       expect(store.getById(localOrphan.id)).toBeNull()
@@ -222,7 +225,7 @@ describe('runStartupTasks', () => {
       })
       store.updateStatus(sshSession.id, 'disconnected')
 
-      runStartupTasks(store, worktreeService as unknown as WorktreeService)
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
 
       // ローカル: worktreePathがnullに更新
       const localUpdated = store.getById(localSession.id)
@@ -261,9 +264,159 @@ describe('runStartupTasks', () => {
     })
 
     // エラーが投げられないことを確認
-    expect(() => runStartupTasks(store, worktreeService as unknown as WorktreeService)).not.toThrow()
+    expect(() => runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)).not.toThrow()
 
     // セッションは削除されている
     expect(store.getById(orphan.id)).toBeNull()
+  })
+
+  // ── StartupGuard テスト ──────────────────────────────
+
+  describe('StartupGuard (resolveSelfWorktreeVerdict)', () => {
+    it("verdict='inside': cwd が worktreePath 配下 → 段階1-4 未実行", () => {
+      // worktree を持つ disconnected セッションを作成
+      const session = store.create({
+        name: 'pane1-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+      // active のまま → 通常なら段階1で disconnected に変更される
+
+      // cwd を worktree 内に設定
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, {
+        cwd: '/tmp/repo/.kurimats-worktrees/pane1/packages/server',
+      })
+
+      // 段階1 がスキップされたので active のまま
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('active')
+
+      // 段階2-4 もスキップ: worktree 削除は呼ばれない
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+      expect(worktreeService.prune).not.toHaveBeenCalled()
+    })
+
+    it("verdict='unknown': sessionStore.getAll() 例外 → 段階1-4 未実行 (fail-safe)", () => {
+      const session = store.create({
+        name: 'test-session',
+        repoPath: '/tmp/repo',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      // sessionStore.getAll を一時的にモックして例外を投げさせる
+      // → resolveSelfWorktreeVerdict が 'unknown' を返す
+      const originalGetAll = store.getAll.bind(store)
+      let callCount = 0
+      vi.spyOn(store, 'getAll').mockImplementation(() => {
+        callCount++
+        // 最初の呼び出し（verdict判定）で例外を投げる
+        if (callCount === 1) {
+          throw new Error('DB接続エラー')
+        }
+        return originalGetAll()
+      })
+
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, OUTSIDE_CWD)
+
+      // 段階1 がスキップされたので active のまま
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('active')
+
+      // 段階2-4 もスキップ
+      expect(worktreeService.remove).not.toHaveBeenCalled()
+      expect(worktreeService.prune).not.toHaveBeenCalled()
+    })
+
+    it("verdict='outside': 従来通り全段階実行", () => {
+      const session = store.create({
+        name: 'test-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/test-session',
+        baseBranch: 'kurimats/test-session',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      // まず active → disconnected にするため runStartupTasks を実行
+      // cwd は worktree の外
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, {
+        cwd: '/tmp/completely-outside',
+      })
+
+      // 段階1 が実行: active → disconnected
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('disconnected')
+
+      // 段階2 が実行: worktree 削除
+      expect(worktreeService.remove).toHaveBeenCalledWith(
+        '/tmp/repo',
+        '/tmp/repo/.kurimats-worktrees/test-session',
+      )
+      expect(updated?.worktreePath).toBeNull()
+    })
+  })
+
+  describe('resolveSelfWorktreeVerdict 単体', () => {
+    it('cwd が worktreePath のサブディレクトリなら inside を返す', () => {
+      store.create({
+        name: 'pane1',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/repo/.kurimats-worktrees/pane1/packages/server',
+      })
+      expect(verdict).toBe('inside')
+    })
+
+    it('cwd が worktreePath と一致する場合も inside を返す', () => {
+      store.create({
+        name: 'pane1',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/repo/.kurimats-worktrees/pane1',
+      })
+      expect(verdict).toBe('inside')
+    })
+
+    it('cwd が worktree 外なら outside を返す', () => {
+      store.create({
+        name: 'pane1',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/completely-outside',
+      })
+      expect(verdict).toBe('outside')
+    })
+
+    it('フォールバック: .kurimats-worktrees セグメントを含む cwd は inside', () => {
+      // DB にセッションがない状態でもパスベースのフォールバックが効く
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/repo/.kurimats-worktrees/kurimats-emulator-pane1/packages/server',
+      })
+      expect(verdict).toBe('inside')
+    })
   })
 })

--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -418,5 +418,65 @@ describe('runStartupTasks', () => {
       })
       expect(verdict).toBe('inside')
     })
+
+    it('prefix隣接: pane1 と pane10 を誤判定しない', () => {
+      store.create({
+        name: 'pane1',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      // pane10 は pane1 の prefix を含むが別ディレクトリ → outside
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/repo/.kurimats-worktrees/pane10/packages/server',
+      })
+      // pane10 は pane1 配下ではないが、.kurimats-worktrees セグメントのフォールバックで inside
+      expect(verdict).toBe('inside')
+    })
+
+    it('sessionStore.getAll() 例外時は unknown を返す', () => {
+      vi.spyOn(store, 'getAll').mockImplementation(() => {
+        throw new Error('DB接続エラー')
+      })
+
+      const verdict = resolveSelfWorktreeVerdict(store, {
+        cwd: '/tmp/completely-outside',
+      })
+      expect(verdict).toBe('unknown')
+    })
+  })
+
+  describe('StartupGuard: inside/unknown 時も段階0・5は実行される', () => {
+    it("verdict='inside' でも段階5（ブランチ名修正）が実行される", () => {
+      // worktree を持つセッションを作成（ブランチ名が古い状態）
+      const session = store.create({
+        name: 'pane1-session',
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
+        branch: 'old-branch',
+        isRemote: false,
+        workspaceId: null,
+        projectId: null,
+      })
+
+      // getBranch が新しいブランチ名を返す
+      vi.mocked(worktreeService.getBranch).mockReturnValue('new-branch')
+
+      // cwd を worktree 内に設定 → verdict='inside'
+      runStartupTasks(store, worktreeService as unknown as WorktreeService, {
+        cwd: '/tmp/repo/.kurimats-worktrees/pane1/packages/server',
+      })
+
+      // 段階1 がスキップされたので active のまま
+      const updated = store.getById(session.id)
+      expect(updated?.status).toBe('active')
+
+      // 段階5 は実行: ブランチ名が修正される
+      expect(updated?.branch).toBe('new-branch')
+      expect(worktreeService.getBranch).toHaveBeenCalledWith('/tmp/repo/.kurimats-worktrees/pane1')
+    })
   })
 })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,7 @@ import { createWorkspacesRouter } from './routes/workspaces.js'
 import { CanvasStore } from './services/canvas-store.js'
 import { SERVER_PORT_BASE, calculatePort } from './utils/ports.js'
 import { runStartupTasks } from './startup.js'
+import { acquireLock, registerLockCleanup } from './services/leader-lock.js'
 
 // PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
 // 設定時は既存PORT環境変数より優先。未設定時のみPORTにフォールバック
@@ -33,6 +34,20 @@ const HOST = process.env.HOST || 'localhost'
 
 // トークン認証（リモートアクセス用、オプション）
 const AUTH_TOKEN = process.env.AUTH_TOKEN || ''
+
+// LeaderLock: 重複サーバー起動を防止
+const lockResult = acquireLock({
+  port: PORT,
+  paneNumber: PANE_NUMBER,
+  type: PANE_NUMBER != null ? 'dev' : 'electron',
+})
+if (!lockResult.acquired) {
+  const info = lockResult.existingLock!
+  console.error(`❌ LeaderLock: サーバーは既に起動中です (PID=${info.pid}, port=${info.port}, 起動=${info.startedAt})`)
+  process.exit(1)
+}
+registerLockCleanup({ paneNumber: PANE_NUMBER })
+console.log(`🔒 LeaderLock: 取得成功 (PID=${process.pid}, port=${PORT})`)
 
 // サービス初期化
 const ptyManager = new PtyManager()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,8 @@ import { WorktreeService } from './services/worktree-service.js'
 import { SessionStore } from './services/session-store.js'
 import { DevInstanceManager } from './services/dev-instance-manager.js'
 import { SessionDevBindingService } from './services/session-dev-binding-service.js'
+import { PlaywrightRunner } from './services/playwright-runner.js'
+import { createPlaywrightRouter } from './routes/playwright.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -62,6 +64,10 @@ devInstanceManager.on('error', (instanceId: string, err: unknown) => {
   console.error(`❌ DevInstance ${instanceId} エラー:`, err)
 })
 const bindingService = new SessionDevBindingService(sessionStore, devInstanceManager)
+const playwrightRunner = new PlaywrightRunner()
+playwrightRunner.on('runner_error', (instanceId: string, err: unknown) => {
+  console.error(`❌ Playwright Runner ${instanceId} エラー:`, err)
+})
 
 const markDisconnected = (sessionId: string) => {
   const session = sessionStore.getById(sessionId)
@@ -108,6 +114,7 @@ app.use('/api/tab', createTabRouter(sessionStore, ptyManager, sshManager, worktr
 app.use('/api/ssh', createSshRouter(sshManager, sessionStore))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
 app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService, devInstanceManager, bindingService))
+app.use('/api/playwright', createPlaywrightRouter(playwrightRunner, devInstanceManager))
 
 // 本番時: 静的ファイル配信（Electronビルド or スタンドアロン）
 const STATIC_DIR = process.env.STATIC_DIR
@@ -143,7 +150,7 @@ setupTerminalWs(terminalWss, ptyManager, sshManager)
 
 // WebSocketサーバー（通知用）
 const notificationWss = new WebSocketServer({ noServer: true })
-setupNotificationWs(notificationWss, sshManager)
+setupNotificationWs(notificationWss, sshManager, playwrightRunner)
 
 // WebSocketアップグレード処理
 server.on('upgrade', (request, socket, head) => {
@@ -180,8 +187,9 @@ server.listen(PORT, HOST, () => {
 })
 
 // グレースフルシャットダウン
-function shutdown() {
+async function shutdown() {
   console.log('\nシャットダウン中...')
+  await playwrightRunner.stopAllAndWait()
   devInstanceManager.shutdown()
   ptyManager.killAll()
   sshManager.disconnectAll()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,8 @@ import { PtyManager } from './services/pty-manager.js'
 import { SshManager } from './services/ssh-manager.js'
 import { WorktreeService } from './services/worktree-service.js'
 import { SessionStore } from './services/session-store.js'
+import { DevInstanceManager } from './services/dev-instance-manager.js'
+import { SessionDevBindingService } from './services/session-dev-binding-service.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -55,6 +57,11 @@ const sshManager = new SshManager()
 const worktreeService = new WorktreeService()
 const sessionStore = new SessionStore()
 const canvasStore = new CanvasStore()
+const devInstanceManager = new DevInstanceManager(sessionStore)
+devInstanceManager.on('error', (instanceId: string, err: unknown) => {
+  console.error(`❌ DevInstance ${instanceId} エラー:`, err)
+})
+const bindingService = new SessionDevBindingService(sessionStore, devInstanceManager)
 
 const markDisconnected = (sessionId: string) => {
   const session = sessionStore.getById(sessionId)
@@ -100,7 +107,7 @@ app.use('/api/layout', createLayoutRouter(sessionStore, canvasStore))
 app.use('/api/tab', createTabRouter(sessionStore, ptyManager, sshManager, worktreeService))
 app.use('/api/ssh', createSshRouter(sshManager, sessionStore))
 app.use('/api/feedback', createFeedbackRouter(sessionStore))
-app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService))
+app.use('/api/workspaces', createWorkspacesRouter(sessionStore, ptyManager, sshManager, worktreeService, devInstanceManager, bindingService))
 
 // 本番時: 静的ファイル配信（Electronビルド or スタンドアロン）
 const STATIC_DIR = process.env.STATIC_DIR
@@ -175,6 +182,7 @@ server.listen(PORT, HOST, () => {
 // グレースフルシャットダウン
 function shutdown() {
   console.log('\nシャットダウン中...')
+  devInstanceManager.shutdown()
   ptyManager.killAll()
   sshManager.disconnectAll()
   sessionStore.close()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,9 @@ import { SessionStore } from './services/session-store.js'
 import { DevInstanceManager } from './services/dev-instance-manager.js'
 import { SessionDevBindingService } from './services/session-dev-binding-service.js'
 import { PlaywrightRunner } from './services/playwright-runner.js'
+import { ResourceMonitorService } from './services/resource-monitor.js'
 import { createPlaywrightRouter } from './routes/playwright.js'
+import { createResourcesRouter } from './routes/resources.js'
 import { setupTerminalWs } from './ws/terminal-handler.js'
 import { setupNotificationWs } from './ws/notification-handler.js'
 import { createSessionsRouter } from './routes/sessions.js'
@@ -150,7 +152,18 @@ setupTerminalWs(terminalWss, ptyManager, sshManager)
 
 // WebSocketサーバー（通知用）
 const notificationWss = new WebSocketServer({ noServer: true })
-setupNotificationWs(notificationWss, sshManager, playwrightRunner)
+
+// ResourceMonitor: WS 接続数を通知 WSS から取得
+const resourceMonitor = new ResourceMonitorService(devInstanceManager, ptyManager, {
+  getWsConnectionCount: () => terminalWss.clients.size + notificationWss.clients.size,
+})
+resourceMonitor.start()
+
+// 通知 WS セットアップ（ResourceMonitor 初期化後）
+const cleanupNotificationWs = setupNotificationWs(notificationWss, sshManager, playwrightRunner, resourceMonitor)
+
+// Resource API（モニター初期化後に登録）
+app.use('/api/resources', createResourcesRouter(resourceMonitor))
 
 // WebSocketアップグレード処理
 server.on('upgrade', (request, socket, head) => {
@@ -189,6 +202,8 @@ server.listen(PORT, HOST, () => {
 // グレースフルシャットダウン
 async function shutdown() {
   console.log('\nシャットダウン中...')
+  cleanupNotificationWs()
+  resourceMonitor.stop()
   await playwrightRunner.stopAllAndWait()
   devInstanceManager.shutdown()
   ptyManager.killAll()

--- a/packages/server/src/routes/playwright.ts
+++ b/packages/server/src/routes/playwright.ts
@@ -1,0 +1,92 @@
+/**
+ * Playwright Runner REST API ルート
+ *
+ * POST   /api/playwright/run            — テスト実行指示
+ * GET    /api/playwright/status/:id     — 実行状態取得
+ * DELETE /api/playwright/run/:id        — 実行中止
+ * GET    /api/playwright/results        — 全結果取得
+ * POST   /api/playwright/clear          — 完了済み結果クリア
+ */
+import { Router } from 'express'
+import type { PlaywrightRunner } from '../services/playwright-runner.js'
+import type { DevInstanceManager } from '../services/dev-instance-manager.js'
+
+export function createPlaywrightRouter(
+  runner: PlaywrightRunner,
+  devInstanceManager: DevInstanceManager,
+): Router {
+  const router = Router()
+
+  // テスト実行指示
+  router.post('/run', (req, res) => {
+    const { instanceId, testPath, cwd } = req.body as {
+      instanceId?: string
+      testPath?: string
+      cwd?: string
+    }
+
+    if (!instanceId || typeof instanceId !== 'string') {
+      res.status(400).json({ error: 'instanceId は文字列で必須です' })
+      return
+    }
+    if (testPath !== undefined && typeof testPath !== 'string') {
+      res.status(400).json({ error: 'testPath は文字列で指定してください' })
+      return
+    }
+    if (cwd !== undefined && typeof cwd !== 'string') {
+      res.status(400).json({ error: 'cwd は文字列で指定してください' })
+      return
+    }
+
+    const instance = devInstanceManager.getInstanceById(instanceId)
+    if (!instance) {
+      res.status(404).json({ error: `DevInstance ${instanceId} が見つかりません` })
+      return
+    }
+
+    // cwd が指定されていなければ DevInstance の worktreePath または process.cwd() を使用
+    const effectiveCwd = cwd || instance.worktreePath || process.cwd()
+
+    try {
+      const result = runner.run(instanceId, instance.slotNumber, effectiveCwd, testPath)
+      res.status(201).json(result)
+    } catch (e) {
+      res.status(409).json({ error: `${e}` })
+    }
+  })
+
+  // 実行状態取得
+  router.get('/status/:id', (req, res) => {
+    const result = runner.getResult(req.params.id)
+    if (!result) {
+      res.json({ instanceId: req.params.id, status: 'idle' })
+      return
+    }
+    res.json(result)
+  })
+
+  // 実行中止
+  router.delete('/run/:id', (req, res) => {
+    const result = runner.getResult(req.params.id)
+    if (!result || result.status !== 'running') {
+      res.status(400).json({ error: '実行中のテストがありません' })
+      return
+    }
+
+    runner.stop(req.params.id)
+    res.json({ ok: true, instanceId: req.params.id })
+  })
+
+  // 全結果取得
+  router.get('/results', (_req, res) => {
+    res.json(runner.getAllResults())
+  })
+
+  // 完了済み結果クリア
+  router.post('/clear', (_req, res) => {
+    runner.clearFinished()
+    res.json({ ok: true })
+  })
+
+  return router
+}

--- a/packages/server/src/routes/resources.ts
+++ b/packages/server/src/routes/resources.ts
@@ -1,0 +1,47 @@
+/**
+ * Resource HUD REST API ルート
+ *
+ * GET /api/resources              — 全体スナップショット
+ * GET /api/resources/:instanceId  — 特定インスタンスのメトリクス
+ * POST /api/resources/collect     — 即座に収集を実行
+ */
+import { Router } from 'express'
+import type { ResourceMonitorService } from '../services/resource-monitor.js'
+
+export function createResourcesRouter(
+  monitor: ResourceMonitorService,
+): Router {
+  const router = Router()
+
+  // 全体スナップショット
+  router.get('/', (_req, res) => {
+    const snapshot = monitor.getLastSnapshot()
+    if (!snapshot) {
+      res.json({ server: null, instances: [], wsConnectionCount: 0, collectedAt: null })
+      return
+    }
+    res.json(snapshot)
+  })
+
+  // 特定インスタンスのメトリクス
+  router.get('/:instanceId', (req, res) => {
+    const metrics = monitor.getInstanceMetrics(req.params.instanceId)
+    if (!metrics) {
+      res.status(404).json({ error: 'メトリクスが見つかりません' })
+      return
+    }
+    res.json(metrics)
+  })
+
+  // 即座に収集を実行
+  router.post('/collect', async (_req, res) => {
+    try {
+      const snapshot = await monitor.collect()
+      res.json(snapshot)
+    } catch (e) {
+      res.status(500).json({ error: `メトリクス収集に失敗: ${e}` })
+    }
+  })
+
+  return router
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -100,7 +100,7 @@ export function createSessionsRouter(
           await ptyManager.spawn(session.id, cwd, 120, 30, shell, [])
           waitForShellReady(session.id, ptyManager, sshManager, false, true)
         } else {
-          await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--continue'])
+          await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'])
         }
       }
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -58,15 +58,20 @@ export function createSessionsRouter(
   })
 
   // セッション終了
-  router.delete('/:id', (req, res) => {
+  router.delete('/:id', async (req, res) => {
     const session = store.getById(req.params.id)
     if (!session) {
       res.status(404).json({ error: 'セッションが見つかりません' })
       return
     }
 
-    cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
-    res.json({ ok: true })
+    try {
+      await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+      res.json({ ok: true })
+    } catch (e) {
+      console.error(`セッション終了エラー "${session.name}":`, e)
+      res.status(500).json({ error: `セッション終了に失敗: ${e}` })
+    }
   })
 
   // セッション再接続（PTY再spawn）

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -2,7 +2,9 @@ import { Router } from 'express'
 import type { SessionStore } from '../services/session-store.js'
 import type { PtyManager } from '../services/pty-manager.js'
 import type { SshManager } from '../services/ssh-manager.js'
-import type { WorktreeService } from '../services/worktree-service.js'
+import { WorktreeService } from '../services/worktree-service.js'
+import type { DevInstanceManager } from '../services/dev-instance-manager.js'
+import type { SessionDevBindingService } from '../services/session-dev-binding-service.js'
 import type { PaneNode, PaneLeaf, SplitDirection, Session } from '@kurimats/shared'
 import { createAndSpawnSession, cleanupSession } from '../services/session-lifecycle.js'
 import {
@@ -49,11 +51,39 @@ async function createWorkspaceSession(
   return { session, paneId }
 }
 
+/**
+ * ローカルリポジトリの場合、pane のスロット番号に対応する
+ * persistent develop worktree を確保して DevInstance に記録する
+ */
+function ensurePersistentDevelop(
+  worktreeService: WorktreeService,
+  devInstanceManager: DevInstanceManager | undefined,
+  repoPath: string,
+  sshHost: string | null | undefined,
+  slotNumber: number,
+): void {
+  if (!devInstanceManager) return
+  if (sshHost) return // リモートの場合はスキップ
+  if (!worktreeService.isGitRepo(repoPath)) return
+
+  try {
+    const worktreePath = worktreeService.ensurePersistentDevelopWorktree(repoPath, slotNumber)
+    const instance = devInstanceManager.getInstance(slotNumber)
+    if (instance) {
+      devInstanceManager.updateWorktreePath(instance.id, worktreePath)
+    }
+  } catch (e) {
+    console.warn(`⚠️ persistent develop worktree 確保失敗 (スロット${slotNumber}): ${e}`)
+  }
+}
+
 export function createWorkspacesRouter(
   store: SessionStore,
   ptyManager: PtyManager,
   sshManager: SshManager,
   worktreeService: WorktreeService,
+  devInstanceManager?: DevInstanceManager,
+  bindingService?: SessionDevBindingService,
 ): Router {
   const router = Router()
 
@@ -122,6 +152,22 @@ export function createWorkspacesRouter(
         paneTree,
         workspaceId,
       )
+
+      // persistent develop worktree を確保（ローカルリポジトリのみ）
+      const paneNumber = process.env.PANE_NUMBER != null
+        ? parseInt(process.env.PANE_NUMBER, 10)
+        : null
+      if (paneNumber != null) {
+        ensurePersistentDevelop(worktreeService, devInstanceManager, repoPath, sshHost, paneNumber)
+
+        // セッションと DevInstance をバインド
+        if (bindingService && devInstanceManager) {
+          const instance = devInstanceManager.getInstance(paneNumber)
+          if (instance) {
+            try { bindingService.bind(session.id, instance.id) } catch { /* バインド失敗は非致命的 */ }
+          }
+        }
+      }
 
       res.status(201).json(workspace)
     } catch (e) {
@@ -194,7 +240,7 @@ export function createWorkspacesRouter(
 
       const splitTree = splitLeafInTree(workspace.paneTree, paneId, direction, newLeaf)
       if (!splitTree) {
-        cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
         res.status(400).json({ error: '指定されたペインが見つかりません' })
         return
       }
@@ -212,7 +258,7 @@ export function createWorkspacesRouter(
       })
     } catch (e) {
       if (session) {
-        cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, session.id)
       }
       console.error('ペイン分割エラー:', e)
       res.status(500).json({ error: `ペイン分割に失敗: ${e}` })
@@ -220,7 +266,7 @@ export function createWorkspacesRouter(
   })
 
   // ペイン閉じ（セッション/PTY/worktreeも連動削除）
-  router.post('/:id/close-pane', (req, res) => {
+  router.post('/:id/close-pane', async (req, res) => {
     const { paneId } = req.body as { paneId: string }
     if (!paneId) {
       res.status(400).json({ error: 'paneId は必須です' })
@@ -263,9 +309,14 @@ export function createWorkspacesRouter(
     // DB更新
     store.updateCmuxPaneTree(workspace.id, rebalanced, newActivePaneId)
 
-    // セッション/PTY/worktreeをクリーンアップ
+    // セッション/PTY/worktreeをクリーンアップ（失敗してもペインツリーは更新済み）
     if (sessionId) {
-      cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      if (bindingService) bindingService.unbind(sessionId)
+      try {
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      } catch (e) {
+        console.error(`ペイン閉じ時のセッション cleanup エラー (${sessionId}):`, e)
+      }
     }
 
     res.json({
@@ -312,17 +363,22 @@ export function createWorkspacesRouter(
   })
 
   // ワークスペース削除（全セッション/PTY/worktreeも連動クリーンアップ）
-  router.delete('/:id', (req, res) => {
+  router.delete('/:id', async (req, res) => {
     const workspace = store.getCmuxWorkspace(req.params.id)
     if (!workspace) {
       res.status(404).json({ error: 'ワークスペースが見つかりません' })
       return
     }
 
-    // ペインツリー内の全セッションをクリーンアップ
+    // ペインツリー内の全セッションをクリーンアップ（個別失敗は続行）
     const sessionIds = collectSessionIds(workspace.paneTree)
     for (const sessionId of sessionIds) {
-      cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      if (bindingService) bindingService.unbind(sessionId)
+      try {
+        await cleanupSession(store, ptyManager, sshManager, worktreeService, sessionId)
+      } catch (e) {
+        console.error(`ワークスペース削除時のセッション cleanup エラー (${sessionId}):`, e)
+      }
     }
 
     const deleted = store.deleteCmuxWorkspace(req.params.id)

--- a/packages/server/src/services/dev-instance-manager.ts
+++ b/packages/server/src/services/dev-instance-manager.ts
@@ -1,0 +1,197 @@
+/**
+ * DevInstanceManager — DevInstance/Slot ストアと ProcessSupervisor の統合管理
+ *
+ * 責務:
+ * - スロット割り当て + DevInstance 作成 + プロセス監視の一括管理
+ * - インスタンス停止時のリソース解放（supervisor 停止 + slot 解放 + DB 削除）
+ * - 起動中インスタンスの一覧取得
+ */
+import { EventEmitter } from 'events'
+import type { DevInstance } from '@kurimats/shared'
+import type { SessionStore } from './session-store.js'
+import { ProcessSupervisor, type SpawnFn } from './process-supervisor.js'
+import { calculatePortsForSlot } from '../utils/ports.js'
+
+export interface DevInstanceManagerOptions {
+  /** ProcessSupervisor のヘルスチェック間隔（ms） */
+  checkIntervalMs?: number
+  /** 最大再起動回数 */
+  maxRestarts?: number
+}
+
+export class DevInstanceManager extends EventEmitter {
+  private store: SessionStore
+  private supervisor: ProcessSupervisor
+
+  constructor(store: SessionStore, options?: DevInstanceManagerOptions) {
+    super()
+    this.store = store
+    this.supervisor = new ProcessSupervisor({
+      checkIntervalMs: options?.checkIntervalMs,
+      maxRestarts: options?.maxRestarts,
+    })
+
+    // supervisor イベントを中継
+    this.supervisor.on('healthy', (instanceId: string) => {
+      this.store.updateDevInstanceStatus(instanceId, 'running')
+      this.emit('healthy', instanceId)
+    })
+    this.supervisor.on('error', (instanceId: string, err: unknown) => {
+      this.store.updateDevInstanceStatus(instanceId, 'error')
+      this.emit('error', instanceId, err)
+    })
+    this.supervisor.on('stopped', (instanceId: string) => {
+      this.emit('stopped', instanceId)
+    })
+  }
+
+  /**
+   * スロットにインスタンスを作成して監視を開始する
+   *
+   * 1. ポート計算
+   * 2. slot_assignments に排他的に割り当て
+   * 3. dev_instances に DB レコード作成
+   * 4. spawnFn でプロセス起動 → supervisor 監視開始
+   *
+   * @param slotNumber スロット番号（PANE_NUMBER に対応）
+   * @param spawnFn プロセス起動関数
+   * @returns 作成された DevInstance
+   * @throws スロットが既に使用中の場合は UNIQUE constraint エラー
+   */
+  startInstance(slotNumber: number, spawnFn: SpawnFn): DevInstance {
+    // ポート算出
+    const ports = calculatePortsForSlot(slotNumber)
+
+    // スロット排他割り当て（UNIQUE 制約で競合検出）
+    // DevInstance を先に作成してから slot を割り当てる
+    const instance = this.store.createDevInstance({
+      slotNumber,
+      ...ports,
+    })
+
+    try {
+      this.store.assignSlot(slotNumber, instance.id)
+    } catch (e) {
+      // slot 割り当て失敗 → DevInstance ロールバック
+      this.store.deleteDevInstance(instance.id)
+      throw e
+    }
+
+    // supervisor で監視開始
+    try {
+      this.supervisor.supervise(instance.id, spawnFn)
+    } catch (e) {
+      // supervisor 開始失敗 → slot + DevInstance ロールバック
+      this.store.releaseSlot(slotNumber)
+      this.store.deleteDevInstance(instance.id)
+      throw e
+    }
+
+    // spawnFn が即座にエラーを起こした場合（supervisor が catch → emit）
+    const status = this.supervisor.getStatus(instance.id)
+    if (status?.status === 'error') {
+      this.supervisor.stop(instance.id)
+      this.store.releaseSlot(slotNumber)
+      this.store.deleteDevInstance(instance.id)
+      throw new Error(`インスタンス起動失敗 (スロット${slotNumber}): spawnFn がエラーを返しました`)
+    }
+
+    return instance
+  }
+
+  /**
+   * インスタンスを停止してリソースを解放する
+   *
+   * 1. supervisor 停止
+   * 2. slot 解放
+   * 3. DB レコード削除
+   */
+  stopInstance(slotNumber: number): void {
+    const instance = this.store.getDevInstance(slotNumber)
+    if (!instance) return
+
+    // supervisor 停止（プロセス kill も含む）
+    this.supervisor.stop(instance.id)
+
+    // slot 解放
+    this.store.releaseSlot(slotNumber)
+
+    // DB レコード削除
+    this.store.deleteDevInstance(instance.id)
+  }
+
+  /**
+   * インスタンス ID で停止する
+   */
+  stopInstanceById(instanceId: string): void {
+    const instance = this.store.getDevInstanceById(instanceId)
+    if (!instance) return
+    this.stopInstance(instance.slotNumber)
+  }
+
+  /**
+   * 全インスタンスを停止する
+   */
+  stopAll(): void {
+    const instances = this.store.getAllDevInstances()
+    for (const instance of instances) {
+      this.stopInstance(instance.slotNumber)
+    }
+  }
+
+  /**
+   * 指定スロットの DevInstance を取得する
+   */
+  getInstance(slotNumber: number): DevInstance | null {
+    return this.store.getDevInstance(slotNumber)
+  }
+
+  /**
+   * ID で DevInstance を取得する
+   */
+  getInstanceById(instanceId: string): DevInstance | null {
+    return this.store.getDevInstanceById(instanceId)
+  }
+
+  /**
+   * 全 DevInstance を取得する
+   */
+  getAllInstances(): DevInstance[] {
+    return this.store.getAllDevInstances()
+  }
+
+  /**
+   * 実行中（running）の DevInstance を取得する
+   */
+  getRunningInstances(): DevInstance[] {
+    return this.store.getAllDevInstances().filter(i => i.status === 'running')
+  }
+
+  /**
+   * supervisor の状態を取得する
+   */
+  getSupervisorStatus(instanceId: string) {
+    return this.supervisor.getStatus(instanceId)
+  }
+
+  /**
+   * DevInstance の worktreePath を更新する
+   */
+  updateWorktreePath(instanceId: string, worktreePath: string | null): void {
+    this.store.updateDevInstanceWorktreePath(instanceId, worktreePath)
+  }
+
+  /**
+   * DevInstance のセッションバインディングを更新する
+   */
+  updateSessionBinding(instanceId: string, sessionId: string | null): void {
+    this.store.updateDevInstanceSession(instanceId, sessionId)
+  }
+
+  /**
+   * シャットダウン: 全 supervisor を停止（DB レコードは残す）
+   */
+  shutdown(): void {
+    this.supervisor.stopAll()
+  }
+}

--- a/packages/server/src/services/leader-lock.ts
+++ b/packages/server/src/services/leader-lock.ts
@@ -3,8 +3,11 @@
  *
  * lockfile にはPID・ポート・pane番号・起動時刻を記録し、
  * stale lock の自動回収もサポートする。
+ *
+ * 原子性: openSync('wx') で排他的作成を行い、2プロセス同時起動時の race を防止。
+ * シグナル: 'exit' イベントのみで cleanup。SIGINT/SIGTERM は index.ts の shutdown() に委譲。
  */
-import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, openSync, closeSync, constants } from 'fs'
 import path from 'path'
 import { homedir } from 'os'
 
@@ -35,7 +38,7 @@ export interface LockResult {
 
 /**
  * PANE_NUMBER に応じた lockfile パスを算出
- * DB ファイルと同じディレクトリ（~/.kurimats/）に配���
+ * DB ファイルと同じディレクトリ（~/.kurimats/）に配置
  */
 export function getLockfilePath(paneNumber: number | null): string {
   const baseDir = path.join(homedir(), '.kurimats')
@@ -45,7 +48,7 @@ export function getLockfilePath(paneNumber: number | null): string {
 }
 
 /**
- * PID が生存し��いるかを確認する
+ * PID が生存しているかを確認する
  */
 function isPidAlive(pid: number): boolean {
   try {
@@ -70,11 +73,30 @@ export function readLock(lockfilePath: string): LockInfo | null {
 }
 
 /**
+ * lockfile を排他的に書き込む（openSync 'wx' で原子的作成）
+ * @returns true: 書き込み成功、false: ファイルが既に存在（EEXIST）
+ */
+function writeExclusive(lockfilePath: string, lockInfo: LockInfo): boolean {
+  try {
+    const fd = openSync(lockfilePath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL)
+    const content = JSON.stringify(lockInfo, null, 2)
+    writeFileSync(fd, content, 'utf-8')
+    closeSync(fd)
+    return true
+  } catch (e: any) {
+    if (e.code === 'EEXIST') return false
+    throw e
+  }
+}
+
+/**
  * lock を取得する
  *
- * 1. lockfile が存在しない → 新規作成して取得成功
- * 2. lockfile が存在 + PID が生存 → 取得失敗（既に別インスタンスが稼働中）
- * 3. lockfile が存在 + PID が死亡 → stale lock として上書き取得
+ * 原子性を確保するフロー:
+ * 1. openSync('wx') で排他的作成を試みる → 成功なら取得完了
+ * 2. EEXIST → 既存 lock を読み取り PID 生存チェック
+ * 3. PID 生存 → 取得失敗
+ * 4. PID 死亡（stale） → unlink して再度 openSync('wx') を試みる
  */
 export function acquireLock(options: LockOptions): LockResult {
   const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
@@ -85,18 +107,6 @@ export function acquireLock(options: LockOptions): LockResult {
     mkdirSync(dir, { recursive: true })
   }
 
-  // 既存 lock を確認
-  const existing = readLock(lockfilePath)
-  if (existing) {
-    if (isPidAlive(existing.pid)) {
-      // 有効な lock が存在 → 取得失敗
-      return { acquired: false, existingLock: existing }
-    }
-    // stale lock → 上書き
-    console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing.pid})。上書きします。`)
-  }
-
-  // lockfile を書き込み
   const lockInfo: LockInfo = {
     pid: process.pid,
     port: options.port,
@@ -105,8 +115,34 @@ export function acquireLock(options: LockOptions): LockResult {
     type: options.type,
   }
 
-  writeFileSync(lockfilePath, JSON.stringify(lockInfo, null, 2), 'utf-8')
-  return { acquired: true }
+  // 1回目: 排他的作成を試みる
+  if (writeExclusive(lockfilePath, lockInfo)) {
+    return { acquired: true }
+  }
+
+  // lockfile が既に存在 → 読み取り
+  const existing = readLock(lockfilePath)
+  if (existing && isPidAlive(existing.pid)) {
+    // 有効な lock が存在 → 取得失敗
+    return { acquired: false, existingLock: existing }
+  }
+
+  // stale lock または破損ファイル → 削除して再試行
+  console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing?.pid ?? '不明'})。上書きします。`)
+  try {
+    unlinkSync(lockfilePath)
+  } catch {
+    // 別プロセスが先に消した場合は無視
+  }
+
+  // 2回目: 排他的作成を再試行
+  if (writeExclusive(lockfilePath, lockInfo)) {
+    return { acquired: true }
+  }
+
+  // 2回目も失敗 → 別プロセスが先に取得した
+  const winner = readLock(lockfilePath)
+  return { acquired: false, existingLock: winner ?? undefined }
 }
 
 /**
@@ -139,10 +175,11 @@ export function isLocked(paneNumber: number | null, lockfilePath?: string): Lock
 
 /**
  * process exit 時に lockfile を自動解放するハンドラを登録する
+ *
+ * 注意: SIGINT/SIGTERM ハンドラは登録しない。
+ * index.ts の shutdown() が ptyManager.killAll() 等のグレースフル処理を行った後に
+ * process.exit(0) を呼び、それが 'exit' イベントをトリガーして lock を解放する。
  */
 export function registerLockCleanup(options: { paneNumber: number | null; lockfilePath?: string }): void {
-  const cleanup = () => releaseLock(options)
-  process.on('exit', cleanup)
-  process.on('SIGINT', () => { cleanup(); process.exit(0) })
-  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
+  process.on('exit', () => releaseLock(options))
 }

--- a/packages/server/src/services/leader-lock.ts
+++ b/packages/server/src/services/leader-lock.ts
@@ -1,0 +1,148 @@
+/**
+ * LeaderLock — サーバーインスタンスの重複起動を防止する lockfile 機構
+ *
+ * lockfile にはPID・ポート・pane番号・起動時刻を記録し、
+ * stale lock の自動回収もサポートする。
+ */
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs'
+import path from 'path'
+import { homedir } from 'os'
+
+/** lockfile に記録する情報 */
+export interface LockInfo {
+  pid: number
+  port: number
+  paneNumber: number | null
+  startedAt: string
+  type: 'electron' | 'dev'
+}
+
+/** lock 取得オプション */
+export interface LockOptions {
+  port: number
+  paneNumber: number | null
+  type: 'electron' | 'dev'
+  /** lockfile パスを直接指定（テスト用） */
+  lockfilePath?: string
+}
+
+/** lock 取得結果 */
+export interface LockResult {
+  acquired: boolean
+  /** 取得失敗時: 既存 lock の情報 */
+  existingLock?: LockInfo
+}
+
+/**
+ * PANE_NUMBER に応じた lockfile パスを算出
+ * DB ファイルと同じディレクトリ（~/.kurimats/）に配���
+ */
+export function getLockfilePath(paneNumber: number | null): string {
+  const baseDir = path.join(homedir(), '.kurimats')
+  if (paneNumber === null) return path.join(baseDir, 'server.lock')
+  if (paneNumber === 0) return path.join(baseDir, 'server-dev.lock')
+  return path.join(baseDir, `server-pane${paneNumber}.lock`)
+}
+
+/**
+ * PID が生存し��いるかを確認する
+ */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 既存の lockfile を読み取る
+ * @returns LockInfo または null（ファイルなし・パースエラー時）
+ */
+export function readLock(lockfilePath: string): LockInfo | null {
+  try {
+    const content = readFileSync(lockfilePath, 'utf-8')
+    return JSON.parse(content) as LockInfo
+  } catch {
+    return null
+  }
+}
+
+/**
+ * lock を取得する
+ *
+ * 1. lockfile が存在しない → 新規作成して取得成功
+ * 2. lockfile が存在 + PID が生存 → 取得失敗（既に別インスタンスが稼働中）
+ * 3. lockfile が存在 + PID が死亡 → stale lock として上書き取得
+ */
+export function acquireLock(options: LockOptions): LockResult {
+  const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
+  const dir = path.dirname(lockfilePath)
+
+  // ディレクトリがなければ作成
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  // 既存 lock を確認
+  const existing = readLock(lockfilePath)
+  if (existing) {
+    if (isPidAlive(existing.pid)) {
+      // 有効な lock が存在 → 取得失敗
+      return { acquired: false, existingLock: existing }
+    }
+    // stale lock → 上書き
+    console.warn(`⚠️ LeaderLock: stale lock を検出 (PID=${existing.pid})。上書きします。`)
+  }
+
+  // lockfile を書き込み
+  const lockInfo: LockInfo = {
+    pid: process.pid,
+    port: options.port,
+    paneNumber: options.paneNumber,
+    startedAt: new Date().toISOString(),
+    type: options.type,
+  }
+
+  writeFileSync(lockfilePath, JSON.stringify(lockInfo, null, 2), 'utf-8')
+  return { acquired: true }
+}
+
+/**
+ * lock を解放する（lockfile を削除）
+ */
+export function releaseLock(options: { paneNumber: number | null; lockfilePath?: string }): void {
+  const lockfilePath = options.lockfilePath ?? getLockfilePath(options.paneNumber)
+  try {
+    // 自分の PID が書かれた lock のみ削除（他プロセスの lock を誤削除しない）
+    const existing = readLock(lockfilePath)
+    if (existing && existing.pid === process.pid) {
+      unlinkSync(lockfilePath)
+    }
+  } catch {
+    // ファイルが既に存在しない場合は無視
+  }
+}
+
+/**
+ * 現在の lock 状態を取得する
+ */
+export function isLocked(paneNumber: number | null, lockfilePath?: string): LockInfo | null {
+  const filePath = lockfilePath ?? getLockfilePath(paneNumber)
+  const info = readLock(filePath)
+  if (!info) return null
+  // PID が死んでいれば stale → null 扱い
+  if (!isPidAlive(info.pid)) return null
+  return info
+}
+
+/**
+ * process exit 時に lockfile を自動解放するハンドラを登録する
+ */
+export function registerLockCleanup(options: { paneNumber: number | null; lockfilePath?: string }): void {
+  const cleanup = () => releaseLock(options)
+  process.on('exit', cleanup)
+  process.on('SIGINT', () => { cleanup(); process.exit(0) })
+  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
+}

--- a/packages/server/src/services/playwright-runner.ts
+++ b/packages/server/src/services/playwright-runner.ts
@@ -1,0 +1,239 @@
+/**
+ * PlaywrightRunner — pane 単位の Playwright テスト実行管理
+ *
+ * 責務:
+ * - slot/instance ベースのポート固定化でテスト実行
+ * - テスト進捗・結果のイベント発火（WebSocket 通知用）
+ * - 多重実行の防止（instance 単位で1プロセスのみ）
+ */
+import { EventEmitter } from 'events'
+import { spawn, type ChildProcess } from 'child_process'
+import type { PlaywrightRunResult, PlaywrightRunStatus } from '@kurimats/shared'
+import { calculatePort, PLAYWRIGHT_PORT_BASE } from '../utils/ports.js'
+
+export interface PlaywrightRunnerOptions {
+  /** npx コマンドパス（テスト時に差し替え可能） */
+  npxPath?: string
+  /** 出力バッファの最大長（バイト） */
+  maxOutputLength?: number
+}
+
+const DEFAULT_OPTIONS: Required<PlaywrightRunnerOptions> = {
+  npxPath: 'npx',
+  maxOutputLength: 512 * 1024, // 512KB
+}
+
+export class PlaywrightRunner extends EventEmitter {
+  private runs = new Map<string, PlaywrightRunResult>()
+  private processes = new Map<string, ChildProcess>()
+  private killTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private options: Required<PlaywrightRunnerOptions>
+
+  constructor(options?: PlaywrightRunnerOptions) {
+    super()
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * テストを実行する
+   *
+   * @param instanceId DevInstance ID（実行の識別子として使用）
+   * @param slotNumber スロット番号（ポート算出用）
+   * @param testPath テストファイルパス（省略時は全テスト）
+   * @param cwd テスト実行ディレクトリ
+   * @returns 実行結果オブジェクト（ステータスは running で返る）
+   * @throws 既に実行中の場合
+   */
+  run(instanceId: string, slotNumber: number, cwd: string, testPath?: string): PlaywrightRunResult {
+    const existing = this.runs.get(instanceId)
+    if (existing?.status === 'running') {
+      throw new Error(`インスタンス ${instanceId} は既にテスト実行中です`)
+    }
+
+    const port = calculatePort(PLAYWRIGHT_PORT_BASE, slotNumber)
+    const now = Date.now()
+
+    const result: PlaywrightRunResult = {
+      instanceId,
+      status: 'running',
+      testPath: testPath ?? null,
+      pid: null,
+      startedAt: now,
+      finishedAt: null,
+      exitCode: null,
+      output: '',
+      port,
+    }
+    this.runs.set(instanceId, result)
+
+    // Playwright テスト実行
+    const args = ['playwright', 'test']
+    if (testPath) args.push(testPath)
+    args.push('--reporter=line')
+
+    const child = spawn(this.options.npxPath, args, {
+      cwd,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_MCP_PORT: String(port),
+        // CI モードでヘッドレス実行
+        CI: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    result.pid = child.pid ?? null
+    this.processes.set(instanceId, child)
+
+    this.emit('started', instanceId, result)
+    this.emit('progress', instanceId, 'running' as PlaywrightRunStatus)
+
+    // stdout/stderr を収集
+    const appendOutput = (data: Buffer) => {
+      const line = data.toString()
+      const remaining = this.options.maxOutputLength - result.output.length
+      if (remaining > 0) {
+        result.output += remaining >= line.length ? line : line.slice(0, remaining)
+      }
+      this.emit('output', instanceId, line)
+      this.emit('progress', instanceId, 'running' as PlaywrightRunStatus, line)
+    }
+
+    child.stdout?.on('data', appendOutput)
+    child.stderr?.on('data', appendOutput)
+
+    child.on('close', (code) => {
+      result.finishedAt = Date.now()
+      result.exitCode = code
+
+      // SIGKILL フォールバックのタイマーをクリア
+      const killTimer = this.killTimers.get(instanceId)
+      if (killTimer) {
+        clearTimeout(killTimer)
+        this.killTimers.delete(instanceId)
+      }
+
+      if (result.status === 'cancelled') {
+        // stop() で既にキャンセル済み
+      } else if (code === 0) {
+        result.status = 'passed'
+      } else {
+        result.status = 'failed'
+      }
+
+      this.processes.delete(instanceId)
+      this.emit('finished', instanceId, result)
+      this.emit('progress', instanceId, result.status)
+    })
+
+    child.on('error', (err) => {
+      result.status = 'error'
+      result.finishedAt = Date.now()
+      result.output += `\nプロセスエラー: ${err.message}`
+      this.processes.delete(instanceId)
+
+      const killTimer = this.killTimers.get(instanceId)
+      if (killTimer) {
+        clearTimeout(killTimer)
+        this.killTimers.delete(instanceId)
+      }
+
+      this.emit('runner_error', instanceId, err)
+      this.emit('progress', instanceId, 'error' as PlaywrightRunStatus)
+    })
+
+    return result
+  }
+
+  /**
+   * 実行中のテストを中止する
+   */
+  stop(instanceId: string): void {
+    const result = this.runs.get(instanceId)
+    const child = this.processes.get(instanceId)
+
+    if (result && result.status === 'running') {
+      result.status = 'cancelled'
+    }
+
+    if (child) {
+      child.kill('SIGTERM')
+      // 3秒後にまだ生きていれば SIGKILL（close で clearTimeout するため誤送信なし）
+      const timer = setTimeout(() => {
+        if (this.processes.has(instanceId)) {
+          child.kill('SIGKILL')
+        }
+        this.killTimers.delete(instanceId)
+      }, 3000)
+      this.killTimers.set(instanceId, timer)
+    }
+  }
+
+  /**
+   * 全実行を中止する
+   */
+  stopAll(): void {
+    for (const id of [...this.processes.keys()]) {
+      this.stop(id)
+    }
+  }
+
+  /**
+   * 全実行を中止し、子プロセスの終了を待つ（シャットダウン用）
+   * @param timeoutMs 最大待機時間（デフォルト5秒）
+   */
+  async stopAllAndWait(timeoutMs = 5000): Promise<void> {
+    this.stopAll()
+    if (this.processes.size === 0) return
+
+    await Promise.race([
+      Promise.all(
+        [...this.processes.keys()].map(id =>
+          new Promise<void>(resolve => {
+            const check = () => {
+              if (!this.processes.has(id)) return resolve()
+              this.once('finished', (_finishedId) => {
+                if (_finishedId === id) resolve()
+                else check()
+              })
+            }
+            check()
+          }),
+        ),
+      ),
+      new Promise<void>(resolve => setTimeout(resolve, timeoutMs)),
+    ])
+  }
+
+  /**
+   * 実行結果を取得する
+   */
+  getResult(instanceId: string): PlaywrightRunResult | null {
+    return this.runs.get(instanceId) ?? null
+  }
+
+  /**
+   * 実行ステータスを取得する
+   */
+  getStatus(instanceId: string): PlaywrightRunStatus {
+    return this.runs.get(instanceId)?.status ?? 'idle'
+  }
+
+  /**
+   * 全実行結果を取得する
+   */
+  getAllResults(): PlaywrightRunResult[] {
+    return [...this.runs.values()]
+  }
+
+  /**
+   * 完了済みの結果をクリアする
+   */
+  clearFinished(): void {
+    for (const [id, result] of this.runs) {
+      if (result.status !== 'running') {
+        this.runs.delete(id)
+      }
+    }
+  }
+}

--- a/packages/server/src/services/process-supervisor.ts
+++ b/packages/server/src/services/process-supervisor.ts
@@ -1,0 +1,211 @@
+/**
+ * ProcessSupervisor — プロセスの生存監視と自動再起動
+ *
+ * 3-snapshot ヘルスチェック:
+ * - 3回連続でプロセス生存を確認 → 健全
+ * - 異常検出 → second shot（1回再起動）
+ * - second shot 後も異常 → error 状態に遷移
+ */
+import { EventEmitter } from 'events'
+
+/** 監視対象プロセスの状態 */
+export type SupervisedStatus = 'starting' | 'healthy' | 'restarting' | 'error' | 'stopped'
+
+/** 監視対象の情報 */
+export interface SupervisedProcess {
+  instanceId: string
+  status: SupervisedStatus
+  pid: number | null
+  restartCount: number
+  lastCheckedAt: number | null
+  consecutiveOk: number
+}
+
+/** Supervisor の設定 */
+export interface SupervisorOptions {
+  /** ヘルスチェック間隔（ms） */
+  checkIntervalMs?: number
+  /** 健全判定に必要な連続成功回数 */
+  healthyThreshold?: number
+  /** 最大再起動回数 */
+  maxRestarts?: number
+}
+
+const DEFAULT_OPTIONS: Required<SupervisorOptions> = {
+  checkIntervalMs: 5000,
+  healthyThreshold: 3,
+  maxRestarts: 1,
+}
+
+/**
+ * spawn 関数の型: プロセスを起動して PID を返す
+ * プロセス終了時に onExit コールバックを呼ぶ
+ */
+export type SpawnFn = (onExit: (code: number | null) => void) => number
+
+export class ProcessSupervisor extends EventEmitter {
+  private processes = new Map<string, SupervisedProcess>()
+  private timers = new Map<string, ReturnType<typeof setInterval>>()
+  private spawnFns = new Map<string, SpawnFn>()
+  private options: Required<SupervisorOptions>
+
+  constructor(options?: SupervisorOptions) {
+    super()
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * プロセスの監視を開始する
+   * @param instanceId 管理対象のインスタンスID
+   * @param spawnFn プロセス起動関数
+   */
+  supervise(instanceId: string, spawnFn: SpawnFn): void {
+    if (this.processes.has(instanceId)) {
+      throw new Error(`インスタンス ${instanceId} は既に監視中です`)
+    }
+
+    this.spawnFns.set(instanceId, spawnFn)
+
+    const proc: SupervisedProcess = {
+      instanceId,
+      status: 'starting',
+      pid: null,
+      restartCount: 0,
+      lastCheckedAt: null,
+      consecutiveOk: 0,
+    }
+    this.processes.set(instanceId, proc)
+
+    this.startProcess(instanceId)
+  }
+
+  /**
+   * 監視を停止する
+   */
+  stop(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc) return
+
+    // タイマー停止
+    const timer = this.timers.get(instanceId)
+    if (timer) {
+      clearInterval(timer)
+      this.timers.delete(instanceId)
+    }
+
+    proc.status = 'stopped'
+    this.processes.delete(instanceId)
+    this.spawnFns.delete(instanceId)
+    this.emit('stopped', instanceId)
+  }
+
+  /**
+   * 全監視を停止する
+   */
+  stopAll(): void {
+    for (const id of [...this.processes.keys()]) {
+      this.stop(id)
+    }
+  }
+
+  /**
+   * 監視中プロセスの状態を取得する
+   */
+  getStatus(instanceId: string): SupervisedProcess | null {
+    return this.processes.get(instanceId) ?? null
+  }
+
+  /**
+   * 全監視中プロセスの状態を取得する
+   */
+  getAllStatuses(): SupervisedProcess[] {
+    return [...this.processes.values()]
+  }
+
+  /** プロセスを起動して監視を開始する */
+  private startProcess(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    const spawnFn = this.spawnFns.get(instanceId)
+    if (!proc || !spawnFn) return
+
+    try {
+      const pid = spawnFn((code) => {
+        this.handleExit(instanceId, code)
+      })
+      proc.pid = pid
+      proc.status = 'starting'
+      proc.consecutiveOk = 0
+
+      // ヘルスチェックタイマーを開始
+      this.startHealthCheck(instanceId)
+      this.emit('started', instanceId, pid)
+    } catch (e) {
+      proc.status = 'error'
+      proc.pid = null
+      this.emit('error', instanceId, e)
+    }
+  }
+
+  /** プロセス終了時のハンドラ */
+  private handleExit(instanceId: string, code: number | null): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc || proc.status === 'stopped') return
+
+    // ヘルスチェック停止
+    const timer = this.timers.get(instanceId)
+    if (timer) {
+      clearInterval(timer)
+      this.timers.delete(instanceId)
+    }
+
+    proc.pid = null
+    this.emit('exit', instanceId, code)
+
+    // second shot: 再起動可能か判定
+    if (proc.restartCount < this.options.maxRestarts) {
+      proc.status = 'restarting'
+      proc.restartCount++
+      console.warn(`⚠️ ProcessSupervisor: ${instanceId} が終了 (code=${code})。再起動します (${proc.restartCount}/${this.options.maxRestarts})`)
+      this.emit('restarting', instanceId, proc.restartCount)
+      this.startProcess(instanceId)
+    } else {
+      proc.status = 'error'
+      console.error(`❌ ProcessSupervisor: ${instanceId} が再起動上限に到達。error 状態に遷移します。`)
+      this.emit('error', instanceId, new Error(`再起動上限 (${this.options.maxRestarts}) に到達`))
+    }
+  }
+
+  /** ヘルスチェックタイマーを開始する */
+  private startHealthCheck(instanceId: string): void {
+    // 既存のタイマーがあれば停止
+    const existing = this.timers.get(instanceId)
+    if (existing) clearInterval(existing)
+
+    const timer = setInterval(() => {
+      this.checkHealth(instanceId)
+    }, this.options.checkIntervalMs)
+
+    this.timers.set(instanceId, timer)
+  }
+
+  /** ヘルスチェック: PID が生存しているか確認 */
+  private checkHealth(instanceId: string): void {
+    const proc = this.processes.get(instanceId)
+    if (!proc || !proc.pid) return
+
+    proc.lastCheckedAt = Date.now()
+
+    try {
+      process.kill(proc.pid, 0) // signal 0 で生存確認
+      proc.consecutiveOk++
+
+      if (proc.consecutiveOk >= this.options.healthyThreshold && proc.status !== 'healthy') {
+        proc.status = 'healthy'
+        this.emit('healthy', instanceId)
+      }
+    } catch {
+      // PID が死んでいる → handleExit が呼ばれるはずだが、念のため
+      proc.consecutiveOk = 0
+    }
+  }
+}

--- a/packages/server/src/services/resource-monitor.ts
+++ b/packages/server/src/services/resource-monitor.ts
@@ -1,0 +1,259 @@
+/**
+ * ResourceMonitorService — リソースメトリクスの定期収集
+ *
+ * 責務:
+ * - PID ベースの CPU/メモリ取得（ps コマンド経由）
+ * - worktree ディスク使用量取得（du コマンド経由）
+ * - サーバープロセス自身のメトリクス
+ * - 定期収集とイベント発火（WebSocket 通知用）
+ */
+import { EventEmitter } from 'events'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import type { ResourceMetrics, ResourceSnapshot, ProcessAliveness } from '@kurimats/shared'
+import type { DevInstanceManager } from './dev-instance-manager.js'
+import type { PtyManager } from './pty-manager.js'
+
+const execFileAsync = promisify(execFile)
+
+export interface ResourceMonitorOptions {
+  /** 収集間隔（ms）。デフォルト 5000ms */
+  intervalMs?: number
+  /** WebSocket 接続数取得関数（外部注入） */
+  getWsConnectionCount?: () => number
+}
+
+const DEFAULT_OPTIONS: Required<ResourceMonitorOptions> = {
+  intervalMs: 5000,
+  getWsConnectionCount: () => 0,
+}
+
+export class ResourceMonitorService extends EventEmitter {
+  private options: Required<ResourceMonitorOptions>
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private collecting = false
+  private devInstanceManager: DevInstanceManager
+  private ptyManager: PtyManager
+  private lastSnapshot: ResourceSnapshot | null = null
+  private startTime = Date.now()
+  /** du キャッシュ（低頻度更新） */
+  private diskCache = new Map<string, { bytes: number; updatedAt: number }>()
+  /** du を更新する間隔（ms） */
+  private diskCacheIntervalMs = 30000
+
+  constructor(
+    devInstanceManager: DevInstanceManager,
+    ptyManager: PtyManager,
+    options?: ResourceMonitorOptions,
+  ) {
+    super()
+    this.devInstanceManager = devInstanceManager
+    this.ptyManager = ptyManager
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  /**
+   * 定期収集を開始する（再帰 setTimeout で前回完了を待ってから次回を予約）
+   */
+  start(): void {
+    if (this.timer) return
+    const schedule = () => {
+      this.timer = setTimeout(async () => {
+        try {
+          await this.collect()
+        } catch (err) {
+          console.warn('⚠️ リソースメトリクス収集エラー:', err)
+        }
+        if (this.timer !== null) schedule()
+      }, this.options.intervalMs)
+    }
+
+    // 初回は即座に収集してからスケジュール開始
+    this.collect().catch(() => {}).then(() => schedule())
+  }
+
+  /**
+   * 定期収集を停止する
+   */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  /**
+   * メトリクスを即座に収集する
+   */
+  async collect(): Promise<ResourceSnapshot> {
+    if (this.collecting) return this.lastSnapshot ?? this.emptySnapshot()
+    this.collecting = true
+
+    try {
+      return await this.doCollect()
+    } finally {
+      this.collecting = false
+    }
+  }
+
+  private emptySnapshot(): ResourceSnapshot {
+    return {
+      server: { pid: process.pid, cpuPercent: null, memoryRss: 0, uptime: 0 },
+      instances: [],
+      wsConnectionCount: 0,
+      collectedAt: Date.now(),
+    }
+  }
+
+  private async doCollect(): Promise<ResourceSnapshot> {
+    const now = Date.now()
+
+    // サーバープロセス自身のメトリクス
+    const serverMemory = process.memoryUsage()
+    const serverCpu = await this.getCpuPercent(process.pid)
+
+    // DevInstance のメトリクス収集（並列実行）
+    const instances = this.devInstanceManager.getAllInstances()
+    const metrics = await Promise.all(
+      instances.map(instance =>
+        this.collectInstanceMetrics(instance.id, instance.pid, instance.assignedSessionId, instance.worktreePath),
+      ),
+    )
+
+    // DevInstance に紐づかない active セッションのメトリクス
+    const activePtyIds = this.ptyManager.getActiveSessionIds()
+    const boundSessionIds = new Set(instances.map(i => i.assignedSessionId).filter(Boolean))
+    for (const sessionId of activePtyIds) {
+      if (!boundSessionIds.has(sessionId)) {
+        metrics.push({
+          instanceId: null,
+          sessionId,
+          pid: null,
+          cpuPercent: null,
+          memoryRss: null,
+          processStatus: 'unknown',
+          worktreeDiskUsage: null,
+          collectedAt: now,
+        })
+      }
+    }
+
+    const snapshot: ResourceSnapshot = {
+      server: {
+        pid: process.pid,
+        cpuPercent: serverCpu,
+        memoryRss: serverMemory.rss,
+        uptime: (now - this.startTime) / 1000,
+      },
+      instances: metrics,
+      wsConnectionCount: this.options.getWsConnectionCount(),
+      collectedAt: now,
+    }
+
+    this.lastSnapshot = snapshot
+    this.emit('snapshot', snapshot)
+    return snapshot
+  }
+
+  /**
+   * 最新のスナップショットを取得する（キャッシュ）
+   */
+  getLastSnapshot(): ResourceSnapshot | null {
+    return this.lastSnapshot
+  }
+
+  /**
+   * 特定インスタンスのメトリクスを取得する
+   */
+  getInstanceMetrics(instanceId: string): ResourceMetrics | null {
+    return this.lastSnapshot?.instances.find(m => m.instanceId === instanceId) ?? null
+  }
+
+  /** PID ベースで CPU 使用率を取得する */
+  private async getCpuPercent(pid: number): Promise<number | null> {
+    try {
+      const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', '%cpu='], {
+        timeout: 3000,
+      })
+      const value = parseFloat(stdout.trim())
+      return isNaN(value) ? null : value
+    } catch {
+      return null
+    }
+  }
+
+  /** PID ベースで RSS メモリを取得する（バイト） */
+  private async getMemoryRss(pid: number): Promise<number | null> {
+    try {
+      // ps の rss はキロバイト単位
+      const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'rss='], {
+        timeout: 3000,
+      })
+      const kb = parseInt(stdout.trim(), 10)
+      return isNaN(kb) ? null : kb * 1024
+    } catch {
+      return null
+    }
+  }
+
+  /** PID の生存確認 */
+  private checkAliveness(pid: number | null): ProcessAliveness {
+    if (pid === null) return 'unknown'
+    try {
+      process.kill(pid, 0)
+      return 'alive'
+    } catch {
+      return 'exited'
+    }
+  }
+
+  /** worktree のディスク使用量を取得する（キャッシュ付き、低頻度更新） */
+  private async getWorktreeDiskUsage(worktreePath: string): Promise<number | null> {
+    const cached = this.diskCache.get(worktreePath)
+    const now = Date.now()
+    if (cached && (now - cached.updatedAt) < this.diskCacheIntervalMs) {
+      return cached.bytes
+    }
+
+    try {
+      // du -sk: キロバイト単位。タイムアウトは収集間隔未満に設定
+      const { stdout } = await execFileAsync('du', ['-sk', worktreePath], {
+        timeout: 4000,
+      })
+      const kb = parseInt(stdout.trim().split('\t')[0], 10)
+      if (isNaN(kb)) return cached?.bytes ?? null
+      const bytes = kb * 1024
+      this.diskCache.set(worktreePath, { bytes, updatedAt: now })
+      return bytes
+    } catch {
+      return cached?.bytes ?? null
+    }
+  }
+
+  /** 単一インスタンスのメトリクスを収集する */
+  private async collectInstanceMetrics(
+    instanceId: string,
+    pid: number | null,
+    sessionId: string | null,
+    worktreePath: string | null,
+  ): Promise<ResourceMetrics> {
+    const now = Date.now()
+
+    const [cpuPercent, memoryRss, worktreeDiskUsage] = await Promise.all([
+      pid ? this.getCpuPercent(pid) : Promise.resolve(null),
+      pid ? this.getMemoryRss(pid) : Promise.resolve(null),
+      worktreePath ? this.getWorktreeDiskUsage(worktreePath) : Promise.resolve(null),
+    ])
+
+    return {
+      instanceId,
+      sessionId,
+      pid,
+      cpuPercent,
+      memoryRss,
+      processStatus: this.checkAliveness(pid),
+      worktreeDiskUsage,
+      collectedAt: now,
+    }
+  }
+}

--- a/packages/server/src/services/session-dev-binding-service.ts
+++ b/packages/server/src/services/session-dev-binding-service.ts
@@ -1,0 +1,93 @@
+/**
+ * SessionDevBindingService — Session ↔ DevInstance のバインディング管理
+ *
+ * 責務:
+ * - セッションと DevInstance の 1:1 紐付け
+ * - バインド/アンバインドの整合性保証（双方向更新）
+ * - バインディング情報の参照
+ */
+import type { DevInstance } from '@kurimats/shared'
+import type { SessionStore } from './session-store.js'
+import type { DevInstanceManager } from './dev-instance-manager.js'
+
+export class SessionDevBindingService {
+  private store: SessionStore
+  private instanceManager: DevInstanceManager
+
+  constructor(store: SessionStore, instanceManager: DevInstanceManager) {
+    this.store = store
+    this.instanceManager = instanceManager
+  }
+
+  /**
+   * セッションと DevInstance をバインドする
+   *
+   * 双方向に紐付けを設定:
+   * - DevInstance.assignedSessionId = sessionId
+   * - （Session 側は workspaceId 等で間接参照）
+   *
+   * @throws セッションまたはインスタンスが存在しない場合
+   */
+  bind(sessionId: string, instanceId: string): void {
+    const session = this.store.getById(sessionId)
+    if (!session) {
+      throw new Error(`セッション ${sessionId} が見つかりません`)
+    }
+
+    const instance = this.instanceManager.getInstanceById(instanceId)
+    if (!instance) {
+      throw new Error(`DevInstance ${instanceId} が見つかりません`)
+    }
+
+    // 既に他のセッションがバインドされている場合はエラー
+    if (instance.assignedSessionId && instance.assignedSessionId !== sessionId) {
+      throw new Error(
+        `DevInstance ${instanceId} は既にセッション ${instance.assignedSessionId} にバインドされています`,
+      )
+    }
+
+    this.instanceManager.updateSessionBinding(instanceId, sessionId)
+  }
+
+  /**
+   * セッションのバインドを解除する
+   *
+   * セッション ID からバインドされた DevInstance を探してアンバインドする
+   */
+  unbind(sessionId: string): void {
+    const instance = this.getBindingForSession(sessionId)
+    if (instance) {
+      this.instanceManager.updateSessionBinding(instance.id, null)
+    }
+  }
+
+  /**
+   * インスタンス ID でバインドを解除する
+   */
+  unbindByInstance(instanceId: string): void {
+    this.instanceManager.updateSessionBinding(instanceId, null)
+  }
+
+  /**
+   * セッションにバインドされた DevInstance を取得する
+   */
+  getBindingForSession(sessionId: string): DevInstance | null {
+    const instances = this.instanceManager.getAllInstances()
+    return instances.find(i => i.assignedSessionId === sessionId) ?? null
+  }
+
+  /**
+   * DevInstance にバインドされたセッション ID を取得する
+   */
+  getBoundSessionId(instanceId: string): string | null {
+    const instance = this.instanceManager.getInstanceById(instanceId)
+    return instance?.assignedSessionId ?? null
+  }
+
+  /**
+   * セッションが DevInstance にバインドされているかどうか
+   */
+  isBound(sessionId: string): boolean {
+    return this.getBindingForSession(sessionId) !== null
+  }
+}

--- a/packages/server/src/services/session-lifecycle.ts
+++ b/packages/server/src/services/session-lifecycle.ts
@@ -6,7 +6,7 @@ import type { Session } from '@kurimats/shared'
 import type { SessionStore } from './session-store.js'
 import type { PtyManager } from './pty-manager.js'
 import type { SshManager } from './ssh-manager.js'
-import type { WorktreeService } from './worktree-service.js'
+import { WorktreeService } from './worktree-service.js'
 
 /**
  * シェルの初期化完了を検出してclaude --continueコマンドを送信する
@@ -187,18 +187,27 @@ export async function createAndSpawnSession(
 }
 
 /**
- * セッションのPTY/SSH kill + worktree削除 + DB削除
+ * セッションのPTY/SSH kill + worktree削除 + DB削除（非同期版）
+ *
+ * ステート遷移:
+ * - status → 'cleaning' → worktree 削除試行
+ *   - 成功: DB から完全削除
+ *   - 失敗: status → 'tombstone'（次回起動時に retry）
+ *
  * workspaces.ts / sessions.ts で共通利用
  */
-export function cleanupSession(
+export async function cleanupSession(
   store: SessionStore,
   ptyManager: PtyManager,
   sshManager: SshManager,
   worktreeService: WorktreeService,
   sessionId: string,
-): void {
+): Promise<void> {
   const session = store.getById(sessionId)
   if (!session) return
+
+  // cleaning 状態に遷移
+  store.updateStatus(sessionId, 'cleaning')
 
   // PTY/SSH kill
   if (sshManager.hasSession(sessionId)) {
@@ -207,16 +216,55 @@ export function cleanupSession(
     ptyManager.kill(sessionId)
   }
 
-  // worktree削除
-  if (session.worktreePath && session.repoPath) {
+  // persistent develop worktree はセッション削除時に worktree を残す
+  const isPersistent = session.worktreePath
+    ? WorktreeService.isPersistentDevelop(session.worktreePath)
+    : false
+
+  // worktree削除（persistent 以外）
+  if (session.worktreePath && session.repoPath && !isPersistent) {
     try {
       worktreeService.remove(session.repoPath, session.worktreePath)
       console.log(`🗑️ worktree削除: ${session.worktreePath}`)
     } catch (e) {
-      console.warn(`⚠️ worktree削除エラー (無視): ${e}`)
+      console.warn(`⚠️ worktree削除失敗 → tombstone に遷移: ${e}`)
+      store.updateStatus(sessionId, 'tombstone')
+      return
     }
   }
 
   // DB削除
   store.delete(sessionId)
+}
+
+/**
+ * tombstone セッションの cleanup を再試行する
+ * startup.ts から呼ばれる
+ */
+export function retryTombstoneCleanup(
+  store: SessionStore,
+  worktreeService: WorktreeService,
+): void {
+  const tombstones = store.getAll().filter(s => s.status === 'tombstone')
+  if (tombstones.length === 0) return
+
+  console.log(`🔄 ${tombstones.length}件の tombstone セッションの cleanup を再試行します`)
+  for (const session of tombstones) {
+    const isPersistent = session.worktreePath
+      ? WorktreeService.isPersistentDevelop(session.worktreePath)
+      : false
+
+    if (session.worktreePath && session.repoPath && !isPersistent) {
+      try {
+        worktreeService.remove(session.repoPath, session.worktreePath)
+        console.log(`   🗑️ tombstone worktree 削除成功: ${session.worktreePath}`)
+      } catch (e) {
+        console.warn(`   ⚠️ tombstone worktree 削除再失敗 (残留): ${e}`)
+        continue // 削除失敗は tombstone のまま残す
+      }
+    }
+
+    store.delete(session.id)
+    console.log(`   ✅ tombstone セッション "${session.name}" (${session.id.slice(0, 8)}...) を削除`)
+  }
 }

--- a/packages/server/src/services/session-lifecycle.ts
+++ b/packages/server/src/services/session-lifecycle.ts
@@ -9,13 +9,14 @@ import type { SshManager } from './ssh-manager.js'
 import { WorktreeService } from './worktree-service.js'
 
 /**
- * シェルの初期化完了を検出してclaude --continueコマンドを送信する
+ * シェルの初期化完了を検出してclaude --dangerously-skip-permissionsコマンドを送信する
  * シェルのプロンプト出力（$ や % や > の末尾文字）を監視し、
- * 表示されたらclaude --continueを実行する。最大5秒のタイムアウト付き。
+ * 表示されたらclaudeを実行する。最大5秒のタイムアウト付き。
+ * --dangerously-skip-permissionsにより権限確認プロンプトをスキップする。
  * --continueにより、前回の会話履歴がある場合は自動復元される。
  */
 /**
- * @param continueSession trueの場合 `claude --continue`、falseの場合 `claude` を実行
+ * @param continueSession trueの場合 `claude --dangerously-skip-permissions --continue`、falseの場合 `claude --dangerously-skip-permissions` を実行
  */
 export function waitForShellReady(
   sessionId: string,
@@ -27,7 +28,7 @@ export function waitForShellReady(
   const manager = isRemote ? sshManager : ptyManager
   let resolved = false
   let timeoutId: ReturnType<typeof setTimeout> | null = null
-  const claudeCmd = continueSession ? 'claude --continue\r' : 'claude\r'
+  const claudeCmd = continueSession ? 'claude --dangerously-skip-permissions --continue\r' : 'claude --dangerously-skip-permissions\r'
 
   const cleanup = () => {
     manager.removeListener('data', onData)
@@ -160,8 +161,8 @@ export async function createAndSpawnSession(
           waitForShellReady(session.id, ptyManager, sshManager, false)
         }
       } else {
-        // child_processモード: claude --continueを直接起動
-        await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--continue'])
+        // child_processモード: claude --dangerously-skip-permissions --continueを直接起動
+        await ptyManager.spawn(session.id, cwd, 120, 30, 'claude', ['--dangerously-skip-permissions', '--continue'])
       }
     }
   } catch (e) {

--- a/packages/server/src/services/session-store-migrations.ts
+++ b/packages/server/src/services/session-store-migrations.ts
@@ -134,4 +134,37 @@ export function runSessionStoreMigrations(db: Database.Database): void {
   try { db.exec('ALTER TABLE cmux_workspaces ADD COLUMN repo_path TEXT NOT NULL DEFAULT \'\'') } catch { /* カラム既存 */ }
   try { db.exec('ALTER TABLE cmux_workspaces ADD COLUMN ssh_host TEXT') } catch { /* カラム既存 */ }
   try { db.exec('ALTER TABLE sessions ADD COLUMN workspace_id TEXT') } catch { /* カラム既存 */ }
+
+  // Phase B: 開発インスタンス / スロット管理テーブル
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS dev_instances (
+      id TEXT PRIMARY KEY,
+      slot_number INTEGER NOT NULL,
+      server_port INTEGER NOT NULL,
+      client_port INTEGER NOT NULL,
+      playwright_port INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'idle',
+      pid INTEGER,
+      worktree_path TEXT,
+      assigned_session_id TEXT,
+      created_at INTEGER NOT NULL,
+      last_active_at INTEGER NOT NULL
+    );
+  `)
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slot_assignments (
+      slot_number INTEGER PRIMARY KEY,
+      instance_id TEXT NOT NULL,
+      assigned_at INTEGER NOT NULL,
+      FOREIGN KEY (instance_id) REFERENCES dev_instances(id)
+    );
+  `)
+
+  // slot_number の一意性を dev_instances テーブル側にも適用
+  // （slot_assignments の PRIMARY KEY で排他、dev_instances 側は重複チェック用インデックス）
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_dev_instances_slot
+    ON dev_instances(slot_number);
+  `)
 }

--- a/packages/server/src/services/session-store-migrations.ts
+++ b/packages/server/src/services/session-store-migrations.ts
@@ -155,9 +155,9 @@ export function runSessionStoreMigrations(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS slot_assignments (
       slot_number INTEGER PRIMARY KEY,
-      instance_id TEXT NOT NULL,
+      instance_id TEXT NOT NULL UNIQUE,
       assigned_at INTEGER NOT NULL,
-      FOREIGN KEY (instance_id) REFERENCES dev_instances(id)
+      FOREIGN KEY (instance_id) REFERENCES dev_instances(id) ON DELETE CASCADE
     );
   `)
 

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3'
 import path from 'path'
 import { mkdirSync } from 'fs'
 import { homedir } from 'os'
-import type { BoardLayoutState, CreateFeedbackParams, CreateProjectParams, CreateSessionParams, CreateSshPresetParams, CreateStartupTemplateParams, CreateCmuxWorkspaceParams, Feedback, LayoutState, PaneNode, Project, Session, SshPreset, StartupTemplate, CmuxWorkspace } from '@kurimats/shared'
+import type { BoardLayoutState, CreateFeedbackParams, CreateProjectParams, CreateSessionParams, CreateSshPresetParams, CreateStartupTemplateParams, CreateCmuxWorkspaceParams, DevInstance, Feedback, LayoutState, PaneNode, Project, Session, SlotAssignment, SshPreset, StartupTemplate, CmuxWorkspace } from '@kurimats/shared'
 import { v4 as uuidv4 } from 'uuid'
 import { loadBoardLayoutState, loadLegacyLayout, saveBoardLayoutState, saveLegacyLayout } from './session-store-layout.js'
 import { mapCmuxWorkspaceRow, mapFeedbackRow, mapProjectRow, mapSessionRow, mapSshPresetRow, mapStartupTemplateRow } from './session-store-mappers.js'
@@ -487,7 +487,119 @@ export class SessionStore {
     return tx(id)
   }
 
+  // ========== DevInstance / SlotAssignment ==========
+
+  /** DevInstance を作成 */
+  createDevInstance(params: {
+    slotNumber: number
+    serverPort: number
+    clientPort: number
+    playwrightPort: number
+  }): DevInstance {
+    const id = uuidv4()
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO dev_instances (id, slot_number, server_port, client_port, playwright_port, status, created_at, last_active_at)
+      VALUES (?, ?, ?, ?, ?, 'idle', ?, ?)
+    `).run(id, params.slotNumber, params.serverPort, params.clientPort, params.playwrightPort, now, now)
+    return this.getDevInstance(params.slotNumber)!
+  }
+
+  /** スロット番号で DevInstance を取得 */
+  getDevInstance(slotNumber: number): DevInstance | null {
+    const row = this.db.prepare('SELECT * FROM dev_instances WHERE slot_number = ?').get(slotNumber) as any
+    return row ? mapDevInstanceRow(row) : null
+  }
+
+  /** ID で DevInstance を取得 */
+  getDevInstanceById(id: string): DevInstance | null {
+    const row = this.db.prepare('SELECT * FROM dev_instances WHERE id = ?').get(id) as any
+    return row ? mapDevInstanceRow(row) : null
+  }
+
+  /** 全 DevInstance を取得 */
+  getAllDevInstances(): DevInstance[] {
+    const rows = this.db.prepare('SELECT * FROM dev_instances ORDER BY slot_number').all() as any[]
+    return rows.map(mapDevInstanceRow)
+  }
+
+  /** DevInstance の状態を更新 */
+  updateDevInstanceStatus(id: string, status: string, pid?: number | null): void {
+    const now = Date.now()
+    if (pid !== undefined) {
+      this.db.prepare('UPDATE dev_instances SET status = ?, pid = ?, last_active_at = ? WHERE id = ?').run(status, pid, now, id)
+    } else {
+      this.db.prepare('UPDATE dev_instances SET status = ?, last_active_at = ? WHERE id = ?').run(status, now, id)
+    }
+  }
+
+  /** DevInstance の worktreePath を更新 */
+  updateDevInstanceWorktreePath(id: string, worktreePath: string | null): void {
+    this.db.prepare('UPDATE dev_instances SET worktree_path = ? WHERE id = ?').run(worktreePath, id)
+  }
+
+  /** DevInstance のセッションバインディングを更新 */
+  updateDevInstanceSession(id: string, sessionId: string | null): void {
+    this.db.prepare('UPDATE dev_instances SET assigned_session_id = ? WHERE id = ?').run(sessionId, id)
+  }
+
+  /** DevInstance を削除 */
+  deleteDevInstance(id: string): boolean {
+    const tx = this.db.transaction((instanceId: string) => {
+      this.db.prepare('DELETE FROM slot_assignments WHERE instance_id = ?').run(instanceId)
+      return this.db.prepare('DELETE FROM dev_instances WHERE id = ?').run(instanceId).changes > 0
+    })
+    return tx(id)
+  }
+
+  /**
+   * スロットを割り当て（UNIQUE 制約で排他制御）
+   * @throws slot_number が既に使用中の場合は UNIQUE constraint エラー
+   */
+  assignSlot(slotNumber: number, instanceId: string): SlotAssignment {
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO slot_assignments (slot_number, instance_id, assigned_at)
+      VALUES (?, ?, ?)
+    `).run(slotNumber, instanceId, now)
+    return { slotNumber, instanceId, assignedAt: now }
+  }
+
+  /** スロットを解放 */
+  releaseSlot(slotNumber: number): void {
+    this.db.prepare('DELETE FROM slot_assignments WHERE slot_number = ?').run(slotNumber)
+  }
+
+  /** スロット割り当てを取得 */
+  getSlotAssignment(slotNumber: number): SlotAssignment | null {
+    const row = this.db.prepare('SELECT * FROM slot_assignments WHERE slot_number = ?').get(slotNumber) as any
+    return row ? { slotNumber: row.slot_number, instanceId: row.instance_id, assignedAt: row.assigned_at } : null
+  }
+
+  /** 全スロット割り当てを取得 */
+  getAllSlotAssignments(): SlotAssignment[] {
+    const rows = this.db.prepare('SELECT * FROM slot_assignments ORDER BY slot_number').all() as any[]
+    return rows.map(row => ({ slotNumber: row.slot_number, instanceId: row.instance_id, assignedAt: row.assigned_at }))
+  }
+
   close(): void {
     this.db.close()
+  }
+}
+
+/** DB行を DevInstance にマップ */
+function mapDevInstanceRow(row: any): DevInstance {
+  return {
+    id: row.id,
+    slotNumber: row.slot_number,
+    serverPort: row.server_port,
+    clientPort: row.client_port,
+    playwrightPort: row.playwright_port,
+    status: row.status,
+    pid: row.pid ?? null,
+    worktreePath: row.worktree_path ?? null,
+    assignedSessionId: row.assigned_session_id ?? null,
+    createdAt: row.created_at,
+    lastActiveAt: row.last_active_at,
   }
 }

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -44,6 +44,7 @@ export class SessionStore {
 
     this.db = new Database(resolvedPath)
     this.db.pragma('journal_mode = WAL')
+    this.db.pragma('foreign_keys = ON')
     this.migrate()
   }
 

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -224,9 +224,11 @@ export class WorktreeService {
 
   /**
    * パスが persistent develop worktree かどうか判定する
+   * パスセグメント境界で判定し、部分一致の誤判定を防ぐ
    */
   static isPersistentDevelop(worktreePath: string): boolean {
-    return worktreePath.includes('persistent-develop-pane')
+    const segments = worktreePath.split(path.sep)
+    return segments.some(seg => seg.startsWith('persistent-develop-pane'))
   }
 
   /**

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -165,10 +165,10 @@ export class WorktreeService {
       return []
     }
 
-    // 使用中でないブランチを削除
+    // 使用中でないブランチを削除（persistent develop ブランチは除外）
     const deleted: string[] = []
     for (const branch of allBranches) {
-      if (!activeBranches.has(branch)) {
+      if (!activeBranches.has(branch) && !WorktreeService.isPersistentDevelopBranch(branch)) {
         try {
           execFileSync('git', ['branch', '-D', branch], {
             cwd: repoPath,
@@ -182,6 +182,58 @@ export class WorktreeService {
       }
     }
     return deleted
+  }
+
+  /**
+   * persistent develop worktree を確保する（冪等）
+   * 存在すればそのまま返し、なければ作成する。
+   * 命名規則: .kurimats-worktrees/persistent-develop-paneN/
+   * ブランチ: kurimats/persistent-develop-paneN
+   */
+  ensurePersistentDevelopWorktree(repoPath: string, slotNumber: number, baseBranch = 'develop'): string {
+    const name = `persistent-develop-pane${slotNumber}`
+    const worktreeBase = path.join(repoPath, WORKTREE_DIR)
+    const worktreePath = path.join(worktreeBase, name)
+
+    if (existsSync(worktreePath)) {
+      return worktreePath
+    }
+
+    // worktree ディレクトリがなければ作成
+    mkdirSync(worktreeBase, { recursive: true })
+
+    const branchName = `kurimats/${name}`
+    try {
+      execFileSync('git', ['worktree', 'add', worktreePath, '-b', branchName, baseBranch], {
+        cwd: repoPath, encoding: 'utf-8', stdio: 'pipe',
+      })
+    } catch {
+      // ブランチが既に存在する場合、ブランチなしで追加
+      try {
+        execFileSync('git', ['worktree', 'add', worktreePath, branchName], {
+          cwd: repoPath, encoding: 'utf-8', stdio: 'pipe',
+        })
+      } catch (e) {
+        throw new Error(`persistent develop worktree の作成に失敗: ${e}`)
+      }
+    }
+
+    console.log(`🌿 persistent develop worktree 作成: ${worktreePath}`)
+    return worktreePath
+  }
+
+  /**
+   * パスが persistent develop worktree かどうか判定する
+   */
+  static isPersistentDevelop(worktreePath: string): boolean {
+    return worktreePath.includes('persistent-develop-pane')
+  }
+
+  /**
+   * ブランチ名が persistent develop のものかどうか判定する
+   */
+  static isPersistentDevelopBranch(branchName: string): boolean {
+    return branchName.startsWith('kurimats/persistent-develop-pane')
   }
 
   /**

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -15,6 +15,7 @@ import path from 'path'
 import type { PaneNode } from '@kurimats/shared'
 import type { SessionStore } from './services/session-store.js'
 import { WorktreeService } from './services/worktree-service.js'
+import { retryTombstoneCleanup } from './services/session-lifecycle.js'
 import { collectSessionIds } from './utils/pane-tree.js'
 
 /** StartupGuard の判定結果 */
@@ -134,9 +135,9 @@ function phase0_migratePaneTrees(sessionStore: SessionStore): void {
   }
 }
 
-/** 段階1: PTYが消失したactiveセッションをdisconnectedに変更 */
+/** 段階1: PTYが消失したactive/cleaningセッションをdisconnectedに変更 */
 function phase1_markOrphanedDisconnected(sessionStore: SessionStore): void {
-  const orphanedSessions = sessionStore.getAll().filter(s => s.status === 'active')
+  const orphanedSessions = sessionStore.getAll().filter(s => s.status === 'active' || s.status === 'cleaning')
   if (orphanedSessions.length > 0) {
     console.log(`⚠️  ${orphanedSessions.length}件のorphanedセッションを検出 → disconnectedに変更`)
     for (const s of orphanedSessions) {
@@ -309,6 +310,9 @@ export function runStartupTasks(
 
     // 段階4: git worktree prune + orphaned branch 削除
     phase4_pruneWorktreesAndBranches(sessionStore, worktreeService)
+
+    // 段階4.5: tombstone セッションの cleanup 再試行
+    retryTombstoneCleanup(sessionStore, worktreeService)
   }
 
   // 段階5: ブランチ名修正（非破壊、常時実行）

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -14,7 +14,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import type { PaneNode } from '@kurimats/shared'
 import type { SessionStore } from './services/session-store.js'
-import type { WorktreeService } from './services/worktree-service.js'
+import { WorktreeService } from './services/worktree-service.js'
 import { collectSessionIds } from './utils/pane-tree.js'
 
 /** StartupGuard の判定結果 */
@@ -157,6 +157,11 @@ function phase2_cleanupDisconnectedWorktrees(sessionStore: SessionStore, worktre
       console.log(`🧹 ${disconnectedSessions.length}件のdisconnectedセッションのworktreeを解放`)
       for (const s of disconnectedSessions) {
         if (s.worktreePath && s.repoPath) {
+          // persistent develop worktree は削除しない
+          if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
+            console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
+            continue
+          }
           try {
             worktreeService.remove(s.repoPath, s.worktreePath)
             console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)
@@ -190,6 +195,11 @@ function phase3_deleteOrphanedSessions(sessionStore: SessionStore, worktreeServi
       console.log(`🧹 ${orphanedCleanup.length}件の孤立セッションを削除します`)
       for (const s of orphanedCleanup) {
         if (s.worktreePath && s.repoPath) {
+          // persistent develop worktree は削除しない
+          if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
+            console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
+            continue
+          }
           try {
             worktreeService.remove(s.repoPath, s.worktreePath)
             console.log(`   🗑️ worktree+ブランチ削除: ${s.worktreePath}`)

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -195,7 +195,8 @@ function phase3_deleteOrphanedSessions(sessionStore: SessionStore, worktreeServi
       console.log(`🧹 ${orphanedCleanup.length}件の孤立セッションを削除します`)
       for (const s of orphanedCleanup) {
         if (s.worktreePath && s.repoPath) {
-          // persistent develop worktree は削除しない
+          // persistent develop worktree は worktree もセッションも削除しない
+          // （DevInstanceManager が管理するため、孤立判定の対象外）
           if (WorktreeService.isPersistentDevelop(s.worktreePath)) {
             console.log(`   🛡️ persistent develop worktree をスキップ: ${s.worktreePath}`)
             continue

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -28,9 +28,12 @@ export interface StartupOptions {
 /**
  * 現在の cwd が自身の管理する worktree 内かどうかを判定する
  *
- * - 'inside': cwd が既知の worktreePath 配下にある → 破壊的操作をスキップ
+ * - 'inside': cwd が既知の worktreePath 配下、またはパスに .kurimats-worktrees を含む → 破壊的操作をスキップ
  * - 'outside': cwd はどの worktree にも含まれない → 通常通り全段階実行
- * - 'unknown': 判定不能（realpathSync 例外、DB例外等） → fail-safe でスキップ
+ * - 'unknown': 判定不能（sessionStore.getAll() 例外等） → fail-safe でスキップ
+ *
+ * cwd/worktreePath の正規化は realpathSync を優先し、失敗時は path.resolve にフォールバック。
+ * これにより存在しないパスでも正規化して比較できる。
  */
 export function resolveSelfWorktreeVerdict(
   sessionStore: SessionStore,

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -1,17 +1,81 @@
 /**
  * サーバー起動時の初期化タスク
- * - orphanedセッション(active)をdisconnectedに変更
- * - disconnectedセッションのworktree+ブランチを削除してDB更新
- * - ペインツリーに含まれない孤立セッションを削除
- * - git worktree pruneで物理的な孤立worktreeを除去
- * - 孤立したkurimats/ブランチを一括削除
- * - worktreeセッションのブランチ名を最新化
+ * - 段階0: ペインツリーマイグレーション（非破壊、常時実行）
+ * - 段階1: orphanedセッション(active)をdisconnectedに変更
+ * - 段階2: disconnectedセッションのworktree+ブランチを削除してDB更新
+ * - 段階3: ペインツリーに含まれない孤立セッションを削除
+ * - 段階4: git worktree prune + 孤立kurimats/ブランチの一括削除
+ * - 段階5: worktreeセッションのブランチ名を最新化（非破壊、常時実行）
+ *
+ * StartupGuard: cwdがworktree内の場合は段階1-4をスキップし自爆を防止
  */
+import { realpathSync } from 'fs'
 import { existsSync } from 'fs'
+import path from 'path'
 import type { PaneNode } from '@kurimats/shared'
 import type { SessionStore } from './services/session-store.js'
 import type { WorktreeService } from './services/worktree-service.js'
 import { collectSessionIds } from './utils/pane-tree.js'
+
+/** StartupGuard の判定結果 */
+export type StartupGuardVerdict = 'inside' | 'outside' | 'unknown'
+
+/** StartupOptions: テスト容易性のために cwd を注入可能 */
+export interface StartupOptions {
+  cwd?: string
+}
+
+/**
+ * 現在の cwd が自身の管理する worktree 内かどうかを判定する
+ *
+ * - 'inside': cwd が既知の worktreePath 配下にある → 破壊的操作をスキップ
+ * - 'outside': cwd はどの worktree にも含まれない → 通常通り全段階実行
+ * - 'unknown': 判定不能（realpathSync 例外、DB例外等） → fail-safe でスキップ
+ */
+export function resolveSelfWorktreeVerdict(
+  sessionStore: SessionStore,
+  options?: StartupOptions,
+): StartupGuardVerdict {
+  // cwd を正規化（realpathSync でシンボリックリンクを解決、失敗時は path.resolve にフォールバック）
+  const rawCwd = options?.cwd ?? process.cwd()
+  let cwdReal: string
+  try {
+    cwdReal = realpathSync(rawCwd)
+  } catch {
+    cwdReal = path.resolve(rawCwd)
+  }
+
+  let sessions: ReturnType<SessionStore['getAll']>
+  try {
+    sessions = sessionStore.getAll()
+  } catch {
+    return 'unknown'
+  }
+
+  // 各セッションの worktreePath を正規化して cwd が配下か判定
+  for (const session of sessions) {
+    if (!session.worktreePath) continue
+    let wtReal: string
+    try {
+      wtReal = realpathSync(session.worktreePath)
+    } catch {
+      wtReal = path.resolve(session.worktreePath)
+    }
+    const rel = path.relative(wtReal, cwdReal)
+    // rel が '..' で始まらず、絶対パスでもなければ cwd は worktree 配下
+    if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return 'inside'
+    }
+  }
+
+  // フォールバック: cwd パスセグメントに .kurimats-worktrees を含むか
+  const segments = cwdReal.split(path.sep)
+  if (segments.includes('.kurimats-worktrees')) {
+    return 'inside'
+  }
+
+  return 'outside'
+}
 
 /**
  * 旧surfaces形式のペインツリーをsessionId形式にマイグレーションする
@@ -43,14 +107,15 @@ function migratePaneTree(node: any): PaneNode {
   return node
 }
 
-export function runStartupTasks(sessionStore: SessionStore, worktreeService: WorktreeService): void {
-  // 0. ペインツリーの旧形式(surfaces[])から新形式(sessionId)へマイグレーション
+// ── 段階関数 ──────────────────────────────────────────
+
+/** 段階0: ペインツリーの旧形式(surfaces[])から新形式(sessionId)へマイグレーション（非破壊） */
+function phase0_migratePaneTrees(sessionStore: SessionStore): void {
   try {
     const workspaces = sessionStore.getAllCmuxWorkspaces()
     let migratedCount = 0
     for (const ws of workspaces) {
       const tree = ws.paneTree as any
-      // 旧形式の判定: リーフノードに surfaces プロパティがある
       const needsMigration = JSON.stringify(tree).includes('"surfaces"')
       if (needsMigration) {
         const migrated = migratePaneTree(tree)
@@ -64,8 +129,10 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } catch (e) {
     console.error('⚠️ ペインツリーマイグレーション中にエラー（サーバー起動は続行）:', e)
   }
+}
 
-  // 1. PTYが消失したactiveセッションをdisconnectedに変更
+/** 段階1: PTYが消失したactiveセッションをdisconnectedに変更 */
+function phase1_markOrphanedDisconnected(sessionStore: SessionStore): void {
   const orphanedSessions = sessionStore.getAll().filter(s => s.status === 'active')
   if (orphanedSessions.length > 0) {
     console.log(`⚠️  ${orphanedSessions.length}件のorphanedセッションを検出 → disconnectedに変更`)
@@ -77,9 +144,10 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } else {
     console.log('✅ orphanedセッションなし')
   }
+}
 
-  // 2. disconnectedセッションのworktreeをクリーンアップ
-  //    アプリ再起動後のdisconnectedは実質再接続不可能なのでworktreeを解放する
+/** 段階2: disconnectedセッションのworktreeをクリーンアップ */
+function phase2_cleanupDisconnectedWorktrees(sessionStore: SessionStore, worktreeService: WorktreeService): void {
   try {
     const disconnectedSessions = sessionStore.getAll().filter(s => s.status === 'disconnected' && s.worktreePath)
     if (disconnectedSessions.length > 0) {
@@ -92,7 +160,6 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
           } catch {
             // 既に削除済みの場合は無視
           }
-          // worktreePathをnullに更新（セッション自体は再接続可能なまま保持）
           sessionStore.updateWorktreePath(s.id, null)
         }
       }
@@ -101,8 +168,10 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } catch (e) {
     console.error('⚠️ disconnectedセッションworktree解放中にエラー（サーバー起動は続行）:', e)
   }
+}
 
-  // 3. ペインツリーに含まれない孤立セッションを削除
+/** 段階3: ペインツリーに含まれない孤立セッションを削除 */
+function phase3_deleteOrphanedSessions(sessionStore: SessionStore, worktreeService: WorktreeService): void {
   try {
     const workspaces = sessionStore.getAllCmuxWorkspaces()
     const referencedIds = new Set<string>()
@@ -112,7 +181,6 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
       }
     }
 
-    // workspace_id が NULL のセッション（単体セッション）は孤立とみなさない
     const allSessions = sessionStore.getAll()
     const orphanedCleanup = allSessions.filter(s => s.workspaceId && !referencedIds.has(s.id))
     if (orphanedCleanup.length > 0) {
@@ -136,8 +204,10 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } catch (e) {
     console.error('⚠️ 孤立セッション削除中にエラー（サーバー起動は続行）:', e)
   }
+}
 
-  // 4. git worktree prune + 孤立kurimats/ブランチの一括削除
+/** 段階4: git worktree prune + 孤立kurimats/ブランチの一括削除 */
+function phase4_pruneWorktreesAndBranches(sessionStore: SessionStore, worktreeService: WorktreeService): void {
   try {
     const allSessions = sessionStore.getAll()
     const repoPathsWithWorktrees = new Set(
@@ -145,8 +215,6 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
         .filter(s => s.repoPath && s.worktreePath)
         .map(s => s.repoPath),
     )
-    // 過去にworktreeが存在した可能性があるリポジトリも対象に含める
-    // （全セッションのrepoPathのうち .kurimats-worktrees ディレクトリが存在するもの）
     for (const s of allSessions) {
       if (s.repoPath && existsSync(`${s.repoPath}/.kurimats-worktrees`)) {
         repoPathsWithWorktrees.add(s.repoPath)
@@ -170,8 +238,10 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } catch (e) {
     console.error('⚠️ orphanedブランチ削除中にエラー（サーバー起動は続行）:', e)
   }
+}
 
-  // 5. worktreeセッションのブランチ名を最新化
+/** 段階5: worktreeセッションのブランチ名を最新化（非破壊） */
+function phase5_syncBranchNames(sessionStore: SessionStore, worktreeService: WorktreeService): void {
   try {
     const allSessionsForBranch = sessionStore.getAll()
     let branchFixCount = 0
@@ -191,4 +261,42 @@ export function runStartupTasks(sessionStore: SessionStore, worktreeService: Wor
   } catch (e) {
     console.error('⚠️ ブランチ修正中にエラー（サーバー起動は続行）:', e)
   }
+}
+
+// ── メインエントリポイント ────────────────────────────
+
+export function runStartupTasks(
+  sessionStore: SessionStore,
+  worktreeService: WorktreeService,
+  options?: StartupOptions,
+): void {
+  // StartupGuard: cwd が worktree 内かどうかを判定
+  const verdict = resolveSelfWorktreeVerdict(sessionStore, options)
+  const skipDestructive = verdict === 'inside' || verdict === 'unknown'
+
+  if (skipDestructive) {
+    console.warn(
+      `⚠️ StartupGuard verdict=${verdict}: 破壊的段階1-4をスキップします (fail-safe)`,
+    )
+  }
+
+  // 段階0: ペインツリーマイグレーション（非破壊、常時実行）
+  phase0_migratePaneTrees(sessionStore)
+
+  if (!skipDestructive) {
+    // 段階1: orphaned active → disconnected
+    phase1_markOrphanedDisconnected(sessionStore)
+
+    // 段階2: disconnected worktree 削除
+    phase2_cleanupDisconnectedWorktrees(sessionStore, worktreeService)
+
+    // 段階3: ペインツリー外セッション削除
+    phase3_deleteOrphanedSessions(sessionStore, worktreeService)
+
+    // 段階4: git worktree prune + orphaned branch 削除
+    phase4_pruneWorktreesAndBranches(sessionStore, worktreeService)
+  }
+
+  // 段階5: ブランチ名修正（非破壊、常時実行）
+  phase5_syncBranchNames(sessionStore, worktreeService)
 }

--- a/packages/server/src/utils/ports.ts
+++ b/packages/server/src/utils/ports.ts
@@ -14,9 +14,27 @@ export const SERVER_PORT_BASE = 14000
 /** Playwright MCPポートベース値 */
 export const PLAYWRIGHT_PORT_BASE = 3550
 
+/** クライアントポートベース値 */
+export const CLIENT_PORT_BASE = 5180
+
 /**
  * ペイン番号からサービスポートを算出
  */
 export function calculatePort(base: number, paneNumber: number): number {
   return base + paneNumber
+}
+
+/**
+ * スロット番号から全ポートを一括算出
+ */
+export function calculatePortsForSlot(slotNumber: number): {
+  serverPort: number
+  clientPort: number
+  playwrightPort: number
+} {
+  return {
+    serverPort: calculatePort(SERVER_PORT_BASE, slotNumber),
+    clientPort: calculatePort(CLIENT_PORT_BASE, slotNumber),
+    playwrightPort: calculatePort(PLAYWRIGHT_PORT_BASE, slotNumber),
+  }
 }

--- a/packages/server/src/ws/notification-handler.ts
+++ b/packages/server/src/ws/notification-handler.ts
@@ -1,17 +1,21 @@
 import { WebSocket, WebSocketServer } from 'ws'
 import type { SshManager } from '../services/ssh-manager.js'
 import type { PlaywrightRunner } from '../services/playwright-runner.js'
-import type { NotificationMessage, PlaywrightRunStatus } from '@kurimats/shared'
+import type { ResourceMonitorService } from '../services/resource-monitor.js'
+import type { NotificationMessage, PlaywrightRunStatus, ResourceSnapshot } from '@kurimats/shared'
 
 /**
  * 通知WebSocketハンドラー
- * SSH接続状態の変更、リモートClaude通知、Playwright進捗をクライアントに中継する
+ * SSH接続状態の変更、リモートClaude通知、Playwright進捗、リソースメトリクスをクライアントに中継する
+ *
+ * @returns cleanup 関数（シャットダウン時にリスナーを解除する）
  */
 export function setupNotificationWs(
   wss: WebSocketServer,
   sshManager: SshManager,
   playwrightRunner?: PlaywrightRunner,
-): void {
+  resourceMonitor?: ResourceMonitorService,
+): () => void {
   const clients = new Set<WebSocket>()
 
   /**
@@ -34,14 +38,13 @@ export function setupNotificationWs(
   }
 
   // SSH接続状態の変更を監視
-  sshManager.on('connection_status', (host: string, status: 'online' | 'offline' | 'reconnecting') => {
+  const onConnectionStatus = (host: string, status: 'online' | 'offline' | 'reconnecting') => {
     broadcast({ type: 'connection_status', host, status })
-  })
+  }
+  sshManager.on('connection_status', onConnectionStatus)
 
   // リモートセッションのデータを監視してClaude通知を検出
-  sshManager.on('data', (sessionId: string, data: string) => {
-    // Claude Code の通知パターンを検出
-    // 例: 「Claude has a question」「Waiting for input」「Task completed」などのパターン
+  const onSshData = (sessionId: string, data: string) => {
     const notificationPatterns = [
       /🔔\s*(.+)/,
       /\[notification\]\s*(.+)/i,
@@ -60,19 +63,29 @@ export function setupNotificationWs(
         break
       }
     }
-  })
+  }
+  sshManager.on('data', onSshData)
 
   // Playwrightテスト進捗を監視
-  if (playwrightRunner) {
-    playwrightRunner.on('progress', (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
-      broadcast({
-        type: 'playwright_progress',
-        instanceId,
-        status,
-        line,
-        timestamp: Date.now(),
-      })
+  const onPlaywrightProgress = (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
+    broadcast({
+      type: 'playwright_progress',
+      instanceId,
+      status,
+      line,
+      timestamp: Date.now(),
     })
+  }
+  if (playwrightRunner) {
+    playwrightRunner.on('progress', onPlaywrightProgress)
+  }
+
+  // リソースメトリクス変化を配信
+  const onSnapshot = (snapshot: ResourceSnapshot) => {
+    broadcast({ type: 'resource_update', snapshot })
+  }
+  if (resourceMonitor) {
+    resourceMonitor.on('snapshot', onSnapshot)
   }
 
   // WebSocket接続処理
@@ -98,4 +111,20 @@ export function setupNotificationWs(
       clients.delete(ws)
     })
   })
+
+  // cleanup 関数: シャットダウン時にリスナーを解除
+  return () => {
+    sshManager.off('connection_status', onConnectionStatus)
+    sshManager.off('data', onSshData)
+    if (playwrightRunner) {
+      playwrightRunner.off('progress', onPlaywrightProgress)
+    }
+    if (resourceMonitor) {
+      resourceMonitor.off('snapshot', onSnapshot)
+    }
+    for (const ws of clients) {
+      ws.close()
+    }
+    clients.clear()
+  }
 }

--- a/packages/server/src/ws/notification-handler.ts
+++ b/packages/server/src/ws/notification-handler.ts
@@ -1,12 +1,17 @@
 import { WebSocket, WebSocketServer } from 'ws'
 import type { SshManager } from '../services/ssh-manager.js'
-import type { NotificationMessage } from '@kurimats/shared'
+import type { PlaywrightRunner } from '../services/playwright-runner.js'
+import type { NotificationMessage, PlaywrightRunStatus } from '@kurimats/shared'
 
 /**
  * 通知WebSocketハンドラー
- * SSH接続状態の変更やリモートClaude通知をクライアントに中継する
+ * SSH接続状態の変更、リモートClaude通知、Playwright進捗をクライアントに中継する
  */
-export function setupNotificationWs(wss: WebSocketServer, sshManager: SshManager): void {
+export function setupNotificationWs(
+  wss: WebSocketServer,
+  sshManager: SshManager,
+  playwrightRunner?: PlaywrightRunner,
+): void {
   const clients = new Set<WebSocket>()
 
   /**
@@ -56,6 +61,19 @@ export function setupNotificationWs(wss: WebSocketServer, sshManager: SshManager
       }
     }
   })
+
+  // Playwrightテスト進捗を監視
+  if (playwrightRunner) {
+    playwrightRunner.on('progress', (instanceId: string, status: PlaywrightRunStatus, line?: string) => {
+      broadcast({
+        type: 'playwright_progress',
+        instanceId,
+        status,
+        line,
+        timestamp: Date.now(),
+      })
+    })
+  }
 
   // WebSocket接続処理
   wss.on('connection', (ws: WebSocket) => {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -18,3 +18,4 @@ export type NotificationMessage =
   | { type: 'connection_status'; host: string; status: 'online' | 'offline' | 'reconnecting' }
   | { type: 'attention_ring'; sessionId: string; active: boolean }
   | { type: 'port_detected'; sessionId: string; port: number; url: string }
+  | { type: 'playwright_progress'; instanceId: string; status: import('./types').PlaywrightRunStatus; line?: string; timestamp: number }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -19,3 +19,4 @@ export type NotificationMessage =
   | { type: 'attention_ring'; sessionId: string; active: boolean }
   | { type: 'port_detected'; sessionId: string; port: number; url: string }
   | { type: 'playwright_progress'; instanceId: string; status: import('./types').PlaywrightRunStatus; line?: string; timestamp: number }
+  | { type: 'resource_update'; snapshot: import('./types').ResourceSnapshot }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -485,6 +485,48 @@ export interface PlaywrightRunResult {
   port: number
 }
 
+// ========== Resource HUD ==========
+
+/** プロセスの生存状態 */
+export type ProcessAliveness = 'alive' | 'exited' | 'error' | 'unknown'
+
+/** 単一インスタンス/セッションのリソースメトリクス */
+export interface ResourceMetrics {
+  /** 対象の DevInstance ID（セッション単体の場合は null） */
+  instanceId: string | null
+  /** 対象のセッション ID */
+  sessionId: string | null
+  /** PID（プロセスが存在する場合） */
+  pid: number | null
+  /** CPU 使用率（%、0-100+）。取得不可の場合は null */
+  cpuPercent: number | null
+  /** メモリ使用量 RSS（バイト）。取得不可の場合は null */
+  memoryRss: number | null
+  /** プロセスの生存状態 */
+  processStatus: ProcessAliveness
+  /** worktree ディスク使用量（バイト）。worktree がない場合は null */
+  worktreeDiskUsage: number | null
+  /** 収集時刻 */
+  collectedAt: number
+}
+
+/** 全体のリソーススナップショット */
+export interface ResourceSnapshot {
+  /** サーバープロセス自身の CPU/メモリ */
+  server: {
+    pid: number
+    cpuPercent: number | null
+    memoryRss: number
+    uptime: number
+  }
+  /** 各インスタンス/セッションのメトリクス */
+  instances: ResourceMetrics[]
+  /** アクティブ WebSocket 接続数 */
+  wsConnectionCount: number
+  /** 収集時刻 */
+  collectedAt: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -459,6 +459,32 @@ export interface SlotAssignment {
   assignedAt: number
 }
 
+// ========== Playwright Runner ==========
+
+/** Playwright テスト実行の状態 */
+export type PlaywrightRunStatus = 'idle' | 'running' | 'passed' | 'failed' | 'cancelled' | 'error'
+
+/** Playwright テスト実行結果 */
+export interface PlaywrightRunResult {
+  /** 実行 ID（instanceId と同一） */
+  instanceId: string
+  status: PlaywrightRunStatus
+  /** 実行対象のテストパス */
+  testPath: string | null
+  /** プロセス PID */
+  pid: number | null
+  /** 開始時刻 */
+  startedAt: number | null
+  /** 終了時刻 */
+  finishedAt: number | null
+  /** exit code（完了時のみ） */
+  exitCode: number | null
+  /** テスト出力（stdout + stderr） */
+  output: string
+  /** Playwright ポート */
+  port: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,5 @@
 // セッション状態
-export type SessionStatus = 'active' | 'paused' | 'terminated' | 'disconnected'
+export type SessionStatus = 'active' | 'paused' | 'terminated' | 'disconnected' | 'cleaning' | 'tombstone'
 
 // セッション
 export interface Session {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -426,6 +426,39 @@ export const FEEDBACK_PRIORITY_LABELS: Record<FeedbackPriority, string> = {
   low: '低',
 } as const
 
+// ========== 開発インスタンス / スロット管理 ==========
+
+/** 開発インスタンスの状態 */
+export type DevInstanceStatus = 'idle' | 'running' | 'error'
+
+/** 開発インスタンス（pane 単位の開発環境） */
+export interface DevInstance {
+  id: string
+  /** スロット番号（PANE_NUMBER に対応） */
+  slotNumber: number
+  /** サーバーポート */
+  serverPort: number
+  /** クライアントポート */
+  clientPort: number
+  /** Playwright ポート */
+  playwrightPort: number
+  status: DevInstanceStatus
+  pid: number | null
+  /** persistent develop worktree パス */
+  worktreePath: string | null
+  /** バインドされたセッションID */
+  assignedSessionId: string | null
+  createdAt: number
+  lastActiveAt: number
+}
+
+/** スロット割り当て（UNIQUE 制約で排他制御） */
+export interface SlotAssignment {
+  slotNumber: number
+  instanceId: string
+  assignedAt: number
+}
+
 // ========== bookmarks ==========
 
 // bookmarks.toml のブックマーク情報


### PR DESCRIPTION
Closes #197

## Summary
- ペイン分割後の新セッションをsession-storeに即時追加する修正

## Changes
- session-storeにaddSessionメソッド追加（重複防止付き）
- pane-storeのsplitPane完了時にaddSessionを呼び出し