### PR TITLE
fix(server): startup.test.ts 型エラー修正 (closes #200)

### DIFF
--- a/packages/server/src/__tests__/startup.test.ts
+++ b/packages/server/src/__tests__/startup.test.ts
@@ -456,7 +456,7 @@ describe('runStartupTasks', () => {
         name: 'pane1-session',
         repoPath: '/tmp/repo',
         worktreePath: '/tmp/repo/.kurimats-worktrees/pane1',
-        branch: 'old-branch',
+        baseBranch: 'old-branch',
         isRemote: false,
         workspaceId: null,
         projectId: null,


### PR DESCRIPTION
Closes #200

## Summary
- `startup.test.ts`で`store.create()`に存在しない`branch`プロパティを渡していた型エラーを修正
- 正しい`baseBranch`に変更

## Test plan
- [x] `npx tsc --noEmit -p packages/server` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)