### PR TITLE
feat: worktreeパスからPANE_NUMBERを自動検出

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,12 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { detectPaneNumber } from '@kurimats/shared'
 
-// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
-// 設定時は既存env変数より優先。未設定時のみSERVER_PORT/CLIENT_PORTにフォールバック
-const paneNumber = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+// PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+const paneNumber = detectPaneNumber()
 const serverPort = paneNumber != null
   ? String(14000 + paneNumber)
   : (process.env.SERVER_PORT || '3001')

--- a/packages/server/src/__tests__/pane-detect.test.ts
+++ b/packages/server/src/__tests__/pane-detect.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { extractPaneNumber, detectPaneNumber } from '@kurimats/shared'
+
+describe('extractPaneNumber', () => {
+  it('worktreeパスから pane 番号を抽出する', () => {
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane3')).toBe(3)
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane1')).toBe(1)
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane10')).toBe(10)
+  })
+
+  it('パスの途中に -paneN がある場合も抽出する', () => {
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane2/subdir')).toBe(2)
+  })
+
+  it('-paneN パターンがなければ null を返す', () => {
+    expect(extractPaneNumber('/Users/user/repo')).toBeNull()
+    expect(extractPaneNumber('/Users/user/Documents/kurimats-emulator')).toBeNull()
+  })
+
+  it('"pane" が含まれても -paneN 形式でなければ null を返す', () => {
+    expect(extractPaneNumber('/Users/user/pane3/repo')).toBeNull()
+    expect(extractPaneNumber('/Users/user/repo/panels')).toBeNull()
+  })
+})
+
+describe('detectPaneNumber', () => {
+  it('環境変数 PANE_NUMBER が設定されていれば優先する', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: '2' }, '/some/path')).toBe(2)
+    expect(detectPaneNumber({ PANE_NUMBER: '0' }, '/some/path-pane5')).toBe(0)
+  })
+
+  it('環境変数がなければ CWD パスから検出する', () => {
+    expect(detectPaneNumber({}, '/Users/user/repo/.kurimats-worktrees/repo-pane3')).toBe(3)
+  })
+
+  it('どちらも該当しなければ null を返す', () => {
+    expect(detectPaneNumber({}, '/Users/user/repo')).toBeNull()
+  })
+
+  it('PANE_NUMBER が空文字列の場合は CWD にフォールバックする', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: '' }, '/path/repo-pane1')).toBe(1)
+    expect(detectPaneNumber({ PANE_NUMBER: '' }, '/path/repo')).toBeNull()
+  })
+
+  it('PANE_NUMBER が非数値の場合は CWD にフォールバックする', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: 'abc' }, '/path/repo-pane2')).toBe(2)
+    expect(detectPaneNumber({ PANE_NUMBER: 'abc' }, '/path/repo')).toBeNull()
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,12 +27,10 @@ import { CanvasStore } from './services/canvas-store.js'
 import { SERVER_PORT_BASE, calculatePort } from './utils/ports.js'
 import { runStartupTasks } from './startup.js'
 import { acquireLock, registerLockCleanup } from './services/leader-lock.js'
+import { detectPaneNumber } from '@kurimats/shared'
 
-// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
-// 設定時は既存PORT環境変数より優先。未設定時のみPORTにフォールバック
-const PANE_NUMBER = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+// PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+const PANE_NUMBER = detectPaneNumber()
 const PORT = PANE_NUMBER != null
   ? calculatePort(SERVER_PORT_BASE, PANE_NUMBER)
   : parseInt(process.env.PORT || '3001', 10)

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -5,7 +5,7 @@ import type { SshManager } from '../services/ssh-manager.js'
 import { WorktreeService } from '../services/worktree-service.js'
 import type { DevInstanceManager } from '../services/dev-instance-manager.js'
 import type { SessionDevBindingService } from '../services/session-dev-binding-service.js'
-import type { PaneNode, PaneLeaf, SplitDirection, Session } from '@kurimats/shared'
+import { type PaneNode, type PaneLeaf, type SplitDirection, type Session, detectPaneNumber } from '@kurimats/shared'
 import { createAndSpawnSession, cleanupSession } from '../services/session-lifecycle.js'
 import {
   genId,
@@ -154,9 +154,7 @@ export function createWorkspacesRouter(
       )
 
       // persistent develop worktree を確保（ローカルリポジトリのみ）
-      const paneNumber = process.env.PANE_NUMBER != null
-        ? parseInt(process.env.PANE_NUMBER, 10)
-        : null
+      const paneNumber = detectPaneNumber()
       if (paneNumber != null) {
         ensurePersistentDevelop(worktreeService, devInstanceManager, repoPath, sshHost, paneNumber)
 

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -58,10 +58,9 @@ interface PtySession {
 }
 
 import { PLAYWRIGHT_PORT_BASE, calculatePort } from '../utils/ports.js'
-/** ペイン番号（環境変数から取得、0=develop, N=paneN, null=未設定） */
-const PANE_NUMBER = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+import { detectPaneNumber } from '@kurimats/shared'
+/** ペイン番号（環境変数 or worktreeパスから自動検出） */
+const PANE_NUMBER = detectPaneNumber()
 
 /**
  * PTYに渡す環境変数を組み立てる

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -8,6 +8,7 @@ import { loadBoardLayoutState, loadLegacyLayout, saveBoardLayoutState, saveLegac
 import { mapCmuxWorkspaceRow, mapFeedbackRow, mapProjectRow, mapSessionRow, mapSshPresetRow, mapStartupTemplateRow } from './session-store-mappers.js'
 import { runSessionStoreMigrations } from './session-store-migrations.js'
 import { findFirstLeafId } from '../utils/pane-tree.js'
+import { detectPaneNumber } from '@kurimats/shared'
 
 /**
  * PANE_NUMBERに応じたDBパスを算出
@@ -17,9 +18,7 @@ import { findFirstLeafId } from '../utils/pane-tree.js'
  */
 function getDefaultDbPath(): string {
   const baseDir = path.join(homedir(), '.kurimats')
-  const paneNumber = process.env.PANE_NUMBER != null
-    ? parseInt(process.env.PANE_NUMBER, 10)
-    : null
+  const paneNumber = detectPaneNumber()
   if (paneNumber === null) return path.join(baseDir, 'sessions.db')
   if (paneNumber === 0) return path.join(baseDir, 'sessions-dev.db')
   return path.join(baseDir, `sessions-pane${paneNumber}.db`)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js'
 export * from './protocol.js'
+export * from './pane-detect.js'

--- a/packages/shared/src/pane-detect.ts
+++ b/packages/shared/src/pane-detect.ts
@@ -1,0 +1,38 @@
+/**
+ * worktreeパス名からペイン番号を自動検出する
+ *
+ * 検出優先順位:
+ * 1. PANE_NUMBER 環境変数（明示的設定を尊重）
+ * 2. CWDパスから `-paneN` パターンを抽出
+ * 3. どちらも該当しない → null
+ */
+
+const PANE_PATTERN = /-pane(\d+)(?:\/|$)/
+
+/**
+ * パス文字列からペイン番号を抽出する（純粋関数）
+ * @returns ペイン番号 or null
+ */
+export function extractPaneNumber(dirPath: string): number | null {
+  const match = dirPath.match(PANE_PATTERN)
+  return match ? parseInt(match[1], 10) : null
+}
+
+/**
+ * 環境変数 → CWDパス の優先順位でペイン番号を検出する
+ * @param env - process.env（テスト時に差し替え可能）
+ * @param cwd - カレントディレクトリ（テスト時に差し替え可能）
+ * @returns ペイン番号 or null
+ */
+export function detectPaneNumber(
+  env: Record<string, string | undefined> = process.env,
+  cwd: string = process.cwd(),
+): number | null {
+  // 1. 環境変数が明示的に設定されていれば優先（空文字列・非数値はスキップ）
+  if (env.PANE_NUMBER != null && env.PANE_NUMBER !== '') {
+    const n = parseInt(env.PANE_NUMBER, 10)
+    if (!isNaN(n)) return n
+  }
+  // 2. CWDのworktreeパスから推定
+  return extractPaneNumber(cwd)
+}


### PR DESCRIPTION
closes #203

## Summary
- worktreeパス名（`-pane3` 等）から PANE_NUMBER を自動検出する `detectPaneNumber()` を `shared` に追加
- サーバー・クライアント6箇所の重複パースロジックを1関数に集約（DRY）
- 空文字列・非数値の環境変数に対するガードを追加（Codexレビュー指摘）

## Test plan
- [x] `pane-detect.test.ts` — 9テスト全パス
- [x] server全体 — 326テスト全パス
- [ ] pane3 worktreeで `PANE_NUMBER` 未設定のまま `npm run dev` → Server:14003, Client:5183 で起動確認
- [ ] `PANE_NUMBER=2` 明示設定 → 環境変数優先で Server:14002 確認
- [ ] 通常ディレクトリ（worktree外）→ 従来フォールバック確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)