### PR TITLE
refactor: ペイン分割時のworktree自動作成を廃止

### DIFF
--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -221,7 +221,7 @@ export function createWorkspacesRouter(
           name: sessionName,
           repoPath: effectiveRepoPath,
           sshHost: effectiveSshHost,
-          useWorktree: !isRemotePane, // リモートの場合はworktree不要
+          useWorktree: false, // ペイン分割時はworktreeを作成しない
           workspaceId: workspace.id,
         },
       )


### PR DESCRIPTION
closes #207

## Summary

- ペイン分割（split-pane）時に useWorktree: !isRemotePane → useWorktree: false に変更
- ローカルペインでもworktreeを自動作成しなくなる
- クリーンアップロジックは worktreePath の null チェックが既に存在するため追加変更不要

## 動作確認

- [x] npx vitest run packages/server 全326テスト通過
- [ ] ペイン分割後にworktreeディレクトリが作成されないことを確認
- [ ] ペイン削除時にエラーが発生しないことを確認