### PR TITLE
fix(client): お気に入り★フィルタON時にペインレイアウトを切り替え (closes #205)

### DIFF
--- a/packages/client/src/__tests__/favorites-layout.test.ts
+++ b/packages/client/src/__tests__/favorites-layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLayoutStore } from '../stores/layout-store'
+
+describe('お気に入りレイアウト切替', () => {
+  beforeEach(() => {
+    const store = useLayoutStore.getState()
+    // 初期状態にリセット
+    useLayoutStore.setState({
+      mode: '2x2',
+      panels: [
+        { sessionId: 'a', position: 0 },
+        { sessionId: 'b', position: 1 },
+        { sessionId: 'c', position: 2 },
+        { sessionId: 'd', position: 3 },
+      ],
+      activePanelIndex: 0,
+      savedLayoutBeforeFavorites: null,
+      boardNodes: [
+        { sessionId: 'a', x: 0, y: 0, width: 520, height: 620 },
+        { sessionId: 'b', x: 600, y: 0, width: 520, height: 620 },
+        { sessionId: 'c', x: 0, y: 700, width: 520, height: 620 },
+        { sessionId: 'd', x: 600, y: 700, width: 520, height: 620 },
+      ],
+    })
+  })
+
+  it('showFavoritesOnly でお気に入りセッションだけのレイアウトに切り替わる', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x1')
+    expect(state.panels).toHaveLength(2)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[1].sessionId).toBe('c')
+    expect(state.activePanelIndex).toBe(0)
+  })
+
+  it('元のレイアウトが退避される', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+
+    const saved = useLayoutStore.getState().savedLayoutBeforeFavorites
+    expect(saved).not.toBeNull()
+    expect(saved!.mode).toBe('2x2')
+    expect(saved!.panels).toHaveLength(4)
+    expect(saved!.panels[0].sessionId).toBe('a')
+    expect(saved!.panels[3].sessionId).toBe('d')
+  })
+
+  it('restoreFromFavorites で元のレイアウトに復元される', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+    useLayoutStore.getState().restoreFromFavorites()
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[3].sessionId).toBe('d')
+    expect(state.savedLayoutBeforeFavorites).toBeNull()
+  })
+
+  it('お気に入り1件なら1x1モードになる', () => {
+    useLayoutStore.getState().showFavoritesOnly(['b'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('1x1')
+    expect(state.panels).toHaveLength(1)
+    expect(state.panels[0].sessionId).toBe('b')
+  })
+
+  it('お気に入り3件なら2x2モードになる（4パネルのうち3つ使用）', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'b', 'c'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[1].sessionId).toBe('b')
+    expect(state.panels[2].sessionId).toBe('c')
+    expect(state.panels[3].sessionId).toBeNull()
+  })
+
+  it('お気に入り0件では何も起こらない', () => {
+    useLayoutStore.getState().showFavoritesOnly([])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.savedLayoutBeforeFavorites).toBeNull()
+  })
+
+  it('退避データがない状態で restoreFromFavorites しても安全', () => {
+    useLayoutStore.getState().restoreFromFavorites()
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+  })
+})

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
     fetchSessions,
     reconnectSession,
   } = useSessionStore()
-  const { addPanel, setActiveSession, boardNodes } = useLayoutStore()
+  const { addPanel, setActiveSession, boardNodes, showFavoritesOnly, restoreFromFavorites } = useLayoutStore()
   const { hosts, fetchHosts, connectHost, disconnectHost, fetchPresets } = useSshStore()
   const tabSyncMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -295,7 +295,16 @@ export function Sidebar() {
           collapsed={favoritesCollapsed}
           favoritesOnly={favoritesOnly}
           onToggleCollapsed={() => setFavoritesCollapsed((collapsed) => !collapsed)}
-          onToggleFavoritesOnly={() => setFavoritesOnly((enabled) => !enabled)}
+          onToggleFavoritesOnly={() => {
+            const next = !favoritesOnly
+            setFavoritesOnly(next)
+            if (next) {
+              const ids = favoriteSessions.map(s => s.id)
+              showFavoritesOnly(ids)
+            } else {
+              restoreFromFavorites()
+            }
+          }}
           renderSession={renderSessionItem}
         />
 

--- a/packages/client/src/stores/layout-store.ts
+++ b/packages/client/src/stores/layout-store.ts
@@ -38,6 +38,13 @@ import {
 } from './layout-store.utils'
 import { layoutApi } from '../lib/api'
 
+/** お気に入りフィルタ適用前のレイアウト退避データ */
+interface SavedLayoutSnapshot {
+  mode: LayoutMode
+  panels: LayoutPanel[]
+  activePanelIndex: number
+}
+
 interface LayoutState {
   mode: LayoutMode
   panels: LayoutPanel[]
@@ -49,6 +56,7 @@ interface LayoutState {
   fileTiles: FileTilePosition[]
   activeSessionId: string | null
   viewport: { x: number; y: number; zoom: number }
+  savedLayoutBeforeFavorites: SavedLayoutSnapshot | null
   setMode: (mode: LayoutMode) => void
   assignSession: (panelIndex: number, sessionId: string) => void
   removeSession: (sessionId: string) => void
@@ -72,6 +80,8 @@ interface LayoutState {
   removeFileTile: (id: string) => void
   updateFileTilePosition: (id: string, x: number, y: number) => void
   updateFileTileSize: (id: string, width: number, height: number) => void
+  showFavoritesOnly: (favoriteSessionIds: string[]) => void
+  restoreFromFavorites: () => void
 }
 
 const savedState = readSavedLayout()
@@ -111,6 +121,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   fileTiles: savedBoardState?.fileTiles ?? [],
   activeSessionId: null,
   viewport: savedBoardState?.viewport ?? DEFAULT_VIEWPORT,
+  savedLayoutBeforeFavorites: null,
 
   setMode: (mode) => {
     const count = panelCountForMode(mode)
@@ -420,6 +431,59 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       fileTiles: get().fileTiles.map((tile) => (tile.id === id ? { ...tile, width, height } : tile)),
     })
     persistCurrentBoardState(get)
+  },
+
+  showFavoritesOnly: (favoriteSessionIds) => {
+    if (favoriteSessionIds.length === 0) {
+      return
+    }
+
+    const state = get()
+    // 現在のレイアウトを退避
+    set({
+      savedLayoutBeforeFavorites: {
+        mode: state.mode,
+        panels: [...state.panels],
+        activePanelIndex: state.activePanelIndex,
+      },
+    })
+
+    // セッション数に応じた最適モードを決定
+    const count = favoriteSessionIds.length
+    const targetMode = MODE_PROGRESSION.find(m => panelCountForMode(m) >= count)
+      ?? MODE_PROGRESSION[MODE_PROGRESSION.length - 1]
+    const panelCount = panelCountForMode(targetMode)
+
+    // お気に入りセッションで均等にパネルを構築
+    const panels: LayoutPanel[] = Array.from({ length: panelCount }, (_, i) => ({
+      sessionId: favoriteSessionIds[i] ?? null,
+      position: i,
+    }))
+
+    // ボードに未追加のセッションがあれば追加
+    for (const sessionId of favoriteSessionIds) {
+      if (!get().boardNodes.some(node => node.sessionId === sessionId)) {
+        get().addBoardNode(sessionId)
+      }
+    }
+
+    set({ mode: targetMode, panels, activePanelIndex: 0 })
+    persistCurrentLayoutState(get)
+  },
+
+  restoreFromFavorites: () => {
+    const saved = get().savedLayoutBeforeFavorites
+    if (!saved) {
+      return
+    }
+
+    set({
+      mode: saved.mode,
+      panels: saved.panels,
+      activePanelIndex: saved.activePanelIndex,
+      savedLayoutBeforeFavorites: null,
+    })
+    persistCurrentLayoutState(get)
   },
 }))
 


### PR DESCRIPTION
Closes #205

## Summary
- ★フィルタON時にお気に入りセッションだけを均等ペイン分割表示
- ★フィルタOFF時に元のレイアウトに復元
- layout-storeにshowFavoritesOnly/restoreFromFavoritesを追加
- テスト追加済み