### PR TITLE
release: develop → main デプロイ (closes #211)

### DIFF
--- a/packages/client/src/__tests__/favorites-layout.test.ts
+++ b/packages/client/src/__tests__/favorites-layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLayoutStore } from '../stores/layout-store'
+
+describe('お気に入りレイアウト切替', () => {
+  beforeEach(() => {
+    const store = useLayoutStore.getState()
+    // 初期状態にリセット
+    useLayoutStore.setState({
+      mode: '2x2',
+      panels: [
+        { sessionId: 'a', position: 0 },
+        { sessionId: 'b', position: 1 },
+        { sessionId: 'c', position: 2 },
+        { sessionId: 'd', position: 3 },
+      ],
+      activePanelIndex: 0,
+      savedLayoutBeforeFavorites: null,
+      boardNodes: [
+        { sessionId: 'a', x: 0, y: 0, width: 520, height: 620 },
+        { sessionId: 'b', x: 600, y: 0, width: 520, height: 620 },
+        { sessionId: 'c', x: 0, y: 700, width: 520, height: 620 },
+        { sessionId: 'd', x: 600, y: 700, width: 520, height: 620 },
+      ],
+    })
+  })
+
+  it('showFavoritesOnly でお気に入りセッションだけのレイアウトに切り替わる', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x1')
+    expect(state.panels).toHaveLength(2)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[1].sessionId).toBe('c')
+    expect(state.activePanelIndex).toBe(0)
+  })
+
+  it('元のレイアウトが退避される', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+
+    const saved = useLayoutStore.getState().savedLayoutBeforeFavorites
+    expect(saved).not.toBeNull()
+    expect(saved!.mode).toBe('2x2')
+    expect(saved!.panels).toHaveLength(4)
+    expect(saved!.panels[0].sessionId).toBe('a')
+    expect(saved!.panels[3].sessionId).toBe('d')
+  })
+
+  it('restoreFromFavorites で元のレイアウトに復元される', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'c'])
+    useLayoutStore.getState().restoreFromFavorites()
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[3].sessionId).toBe('d')
+    expect(state.savedLayoutBeforeFavorites).toBeNull()
+  })
+
+  it('お気に入り1件なら1x1モードになる', () => {
+    useLayoutStore.getState().showFavoritesOnly(['b'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('1x1')
+    expect(state.panels).toHaveLength(1)
+    expect(state.panels[0].sessionId).toBe('b')
+  })
+
+  it('お気に入り3件なら2x2モードになる（4パネルのうち3つ使用）', () => {
+    useLayoutStore.getState().showFavoritesOnly(['a', 'b', 'c'])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+    expect(state.panels[0].sessionId).toBe('a')
+    expect(state.panels[1].sessionId).toBe('b')
+    expect(state.panels[2].sessionId).toBe('c')
+    expect(state.panels[3].sessionId).toBeNull()
+  })
+
+  it('お気に入り0件では何も起こらない', () => {
+    useLayoutStore.getState().showFavoritesOnly([])
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.savedLayoutBeforeFavorites).toBeNull()
+  })
+
+  it('退避データがない状態で restoreFromFavorites しても安全', () => {
+    useLayoutStore.getState().restoreFromFavorites()
+
+    const state = useLayoutStore.getState()
+    expect(state.mode).toBe('2x2')
+    expect(state.panels).toHaveLength(4)
+  })
+})

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
     fetchSessions,
     reconnectSession,
   } = useSessionStore()
-  const { addPanel, setActiveSession, boardNodes } = useLayoutStore()
+  const { addPanel, setActiveSession, boardNodes, showFavoritesOnly, restoreFromFavorites } = useLayoutStore()
   const { hosts, fetchHosts, connectHost, disconnectHost, fetchPresets } = useSshStore()
   const tabSyncMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -295,7 +295,16 @@ export function Sidebar() {
           collapsed={favoritesCollapsed}
           favoritesOnly={favoritesOnly}
           onToggleCollapsed={() => setFavoritesCollapsed((collapsed) => !collapsed)}
-          onToggleFavoritesOnly={() => setFavoritesOnly((enabled) => !enabled)}
+          onToggleFavoritesOnly={() => {
+            const next = !favoritesOnly
+            setFavoritesOnly(next)
+            if (next) {
+              const ids = favoriteSessions.map(s => s.id)
+              showFavoritesOnly(ids)
+            } else {
+              restoreFromFavorites()
+            }
+          }}
           renderSession={renderSessionItem}
         />
 

--- a/packages/client/src/stores/layout-store.ts
+++ b/packages/client/src/stores/layout-store.ts
@@ -38,6 +38,13 @@ import {
 } from './layout-store.utils'
 import { layoutApi } from '../lib/api'
 
+/** お気に入りフィルタ適用前のレイアウト退避データ */
+interface SavedLayoutSnapshot {
+  mode: LayoutMode
+  panels: LayoutPanel[]
+  activePanelIndex: number
+}
+
 interface LayoutState {
   mode: LayoutMode
   panels: LayoutPanel[]
@@ -49,6 +56,7 @@ interface LayoutState {
   fileTiles: FileTilePosition[]
   activeSessionId: string | null
   viewport: { x: number; y: number; zoom: number }
+  savedLayoutBeforeFavorites: SavedLayoutSnapshot | null
   setMode: (mode: LayoutMode) => void
   assignSession: (panelIndex: number, sessionId: string) => void
   removeSession: (sessionId: string) => void
@@ -72,6 +80,8 @@ interface LayoutState {
   removeFileTile: (id: string) => void
   updateFileTilePosition: (id: string, x: number, y: number) => void
   updateFileTileSize: (id: string, width: number, height: number) => void
+  showFavoritesOnly: (favoriteSessionIds: string[]) => void
+  restoreFromFavorites: () => void
 }
 
 const savedState = readSavedLayout()
@@ -111,6 +121,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   fileTiles: savedBoardState?.fileTiles ?? [],
   activeSessionId: null,
   viewport: savedBoardState?.viewport ?? DEFAULT_VIEWPORT,
+  savedLayoutBeforeFavorites: null,
 
   setMode: (mode) => {
     const count = panelCountForMode(mode)
@@ -420,6 +431,59 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       fileTiles: get().fileTiles.map((tile) => (tile.id === id ? { ...tile, width, height } : tile)),
     })
     persistCurrentBoardState(get)
+  },
+
+  showFavoritesOnly: (favoriteSessionIds) => {
+    if (favoriteSessionIds.length === 0) {
+      return
+    }
+
+    const state = get()
+    // 現在のレイアウトを退避
+    set({
+      savedLayoutBeforeFavorites: {
+        mode: state.mode,
+        panels: [...state.panels],
+        activePanelIndex: state.activePanelIndex,
+      },
+    })
+
+    // セッション数に応じた最適モードを決定
+    const count = favoriteSessionIds.length
+    const targetMode = MODE_PROGRESSION.find(m => panelCountForMode(m) >= count)
+      ?? MODE_PROGRESSION[MODE_PROGRESSION.length - 1]
+    const panelCount = panelCountForMode(targetMode)
+
+    // お気に入りセッションで均等にパネルを構築
+    const panels: LayoutPanel[] = Array.from({ length: panelCount }, (_, i) => ({
+      sessionId: favoriteSessionIds[i] ?? null,
+      position: i,
+    }))
+
+    // ボードに未追加のセッションがあれば追加
+    for (const sessionId of favoriteSessionIds) {
+      if (!get().boardNodes.some(node => node.sessionId === sessionId)) {
+        get().addBoardNode(sessionId)
+      }
+    }
+
+    set({ mode: targetMode, panels, activePanelIndex: 0 })
+    persistCurrentLayoutState(get)
+  },
+
+  restoreFromFavorites: () => {
+    const saved = get().savedLayoutBeforeFavorites
+    if (!saved) {
+      return
+    }
+
+    set({
+      mode: saved.mode,
+      panels: saved.panels,
+      activePanelIndex: saved.activePanelIndex,
+      savedLayoutBeforeFavorites: null,
+    })
+    persistCurrentLayoutState(get)
   },
 }))
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,12 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { detectPaneNumber } from '@kurimats/shared'
 
-// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
-// 設定時は既存env変数より優先。未設定時のみSERVER_PORT/CLIENT_PORTにフォールバック
-const paneNumber = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+// PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+const paneNumber = detectPaneNumber()
 const serverPort = paneNumber != null
   ? String(14000 + paneNumber)
   : (process.env.SERVER_PORT || '3001')

--- a/packages/server/src/__tests__/pane-detect.test.ts
+++ b/packages/server/src/__tests__/pane-detect.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { extractPaneNumber, detectPaneNumber } from '@kurimats/shared'
+
+describe('extractPaneNumber', () => {
+  it('worktreeパスから pane 番号を抽出する', () => {
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane3')).toBe(3)
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane1')).toBe(1)
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane10')).toBe(10)
+  })
+
+  it('パスの途中に -paneN がある場合も抽出する', () => {
+    expect(extractPaneNumber('/Users/user/repo/.kurimats-worktrees/repo-pane2/subdir')).toBe(2)
+  })
+
+  it('-paneN パターンがなければ null を返す', () => {
+    expect(extractPaneNumber('/Users/user/repo')).toBeNull()
+    expect(extractPaneNumber('/Users/user/Documents/kurimats-emulator')).toBeNull()
+  })
+
+  it('"pane" が含まれても -paneN 形式でなければ null を返す', () => {
+    expect(extractPaneNumber('/Users/user/pane3/repo')).toBeNull()
+    expect(extractPaneNumber('/Users/user/repo/panels')).toBeNull()
+  })
+})
+
+describe('detectPaneNumber', () => {
+  it('環境変数 PANE_NUMBER が設定されていれば優先する', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: '2' }, '/some/path')).toBe(2)
+    expect(detectPaneNumber({ PANE_NUMBER: '0' }, '/some/path-pane5')).toBe(0)
+  })
+
+  it('環境変数がなければ CWD パスから検出する', () => {
+    expect(detectPaneNumber({}, '/Users/user/repo/.kurimats-worktrees/repo-pane3')).toBe(3)
+  })
+
+  it('どちらも該当しなければ null を返す', () => {
+    expect(detectPaneNumber({}, '/Users/user/repo')).toBeNull()
+  })
+
+  it('PANE_NUMBER が空文字列の場合は CWD にフォールバックする', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: '' }, '/path/repo-pane1')).toBe(1)
+    expect(detectPaneNumber({ PANE_NUMBER: '' }, '/path/repo')).toBeNull()
+  })
+
+  it('PANE_NUMBER が非数値の場合は CWD にフォールバックする', () => {
+    expect(detectPaneNumber({ PANE_NUMBER: 'abc' }, '/path/repo-pane2')).toBe(2)
+    expect(detectPaneNumber({ PANE_NUMBER: 'abc' }, '/path/repo')).toBeNull()
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,12 +27,10 @@ import { CanvasStore } from './services/canvas-store.js'
 import { SERVER_PORT_BASE, calculatePort } from './utils/ports.js'
 import { runStartupTasks } from './startup.js'
 import { acquireLock, registerLockCleanup } from './services/leader-lock.js'
+import { detectPaneNumber } from '@kurimats/shared'
 
-// PANE_NUMBERからポートを自動算出（develop=0, paneN=N）
-// 設定時は既存PORT環境変数より優先。未設定時のみPORTにフォールバック
-const PANE_NUMBER = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+// PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+const PANE_NUMBER = detectPaneNumber()
 const PORT = PANE_NUMBER != null
   ? calculatePort(SERVER_PORT_BASE, PANE_NUMBER)
   : parseInt(process.env.PORT || '3001', 10)

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -5,7 +5,7 @@ import type { SshManager } from '../services/ssh-manager.js'
 import { WorktreeService } from '../services/worktree-service.js'
 import type { DevInstanceManager } from '../services/dev-instance-manager.js'
 import type { SessionDevBindingService } from '../services/session-dev-binding-service.js'
-import type { PaneNode, PaneLeaf, SplitDirection, Session } from '@kurimats/shared'
+import { type PaneNode, type PaneLeaf, type SplitDirection, type Session, detectPaneNumber } from '@kurimats/shared'
 import { createAndSpawnSession, cleanupSession } from '../services/session-lifecycle.js'
 import {
   genId,
@@ -154,9 +154,7 @@ export function createWorkspacesRouter(
       )
 
       // persistent develop worktree を確保（ローカルリポジトリのみ）
-      const paneNumber = process.env.PANE_NUMBER != null
-        ? parseInt(process.env.PANE_NUMBER, 10)
-        : null
+      const paneNumber = detectPaneNumber()
       if (paneNumber != null) {
         ensurePersistentDevelop(worktreeService, devInstanceManager, repoPath, sshHost, paneNumber)
 

--- a/packages/server/src/routes/workspaces.ts
+++ b/packages/server/src/routes/workspaces.ts
@@ -221,7 +221,7 @@ export function createWorkspacesRouter(
           name: sessionName,
           repoPath: effectiveRepoPath,
           sshHost: effectiveSshHost,
-          useWorktree: !isRemotePane, // リモートの場合はworktree不要
+          useWorktree: false, // ペイン分割時はworktreeを作成しない
           workspaceId: workspace.id,
         },
       )

--- a/packages/server/src/services/pty-manager.ts
+++ b/packages/server/src/services/pty-manager.ts
@@ -58,10 +58,9 @@ interface PtySession {
 }
 
 import { PLAYWRIGHT_PORT_BASE, calculatePort } from '../utils/ports.js'
-/** ペイン番号（環境変数から取得、0=develop, N=paneN, null=未設定） */
-const PANE_NUMBER = process.env.PANE_NUMBER != null
-  ? parseInt(process.env.PANE_NUMBER, 10)
-  : null
+import { detectPaneNumber } from '@kurimats/shared'
+/** ペイン番号（環境変数 or worktreeパスから自動検出） */
+const PANE_NUMBER = detectPaneNumber()
 
 /**
  * PTYに渡す環境変数を組み立てる

--- a/packages/server/src/services/session-store.ts
+++ b/packages/server/src/services/session-store.ts
@@ -8,6 +8,7 @@ import { loadBoardLayoutState, loadLegacyLayout, saveBoardLayoutState, saveLegac
 import { mapCmuxWorkspaceRow, mapFeedbackRow, mapProjectRow, mapSessionRow, mapSshPresetRow, mapStartupTemplateRow } from './session-store-mappers.js'
 import { runSessionStoreMigrations } from './session-store-migrations.js'
 import { findFirstLeafId } from '../utils/pane-tree.js'
+import { detectPaneNumber } from '@kurimats/shared'
 
 /**
  * PANE_NUMBERに応じたDBパスを算出
@@ -17,9 +18,7 @@ import { findFirstLeafId } from '../utils/pane-tree.js'
  */
 function getDefaultDbPath(): string {
   const baseDir = path.join(homedir(), '.kurimats')
-  const paneNumber = process.env.PANE_NUMBER != null
-    ? parseInt(process.env.PANE_NUMBER, 10)
-    : null
+  const paneNumber = detectPaneNumber()
   if (paneNumber === null) return path.join(baseDir, 'sessions.db')
   if (paneNumber === 0) return path.join(baseDir, 'sessions-dev.db')
   return path.join(baseDir, `sessions-pane${paneNumber}.db`)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js'
 export * from './protocol.js'
+export * from './pane-detect.js'

--- a/packages/shared/src/pane-detect.ts
+++ b/packages/shared/src/pane-detect.ts
@@ -1,0 +1,38 @@
+/**
+ * worktreeパス名からペイン番号を自動検出する
+ *
+ * 検出優先順位:
+ * 1. PANE_NUMBER 環境変数（明示的設定を尊重）
+ * 2. CWDパスから `-paneN` パターンを抽出
+ * 3. どちらも該当しない → null
+ */
+
+const PANE_PATTERN = /-pane(\d+)(?:\/|$)/
+
+/**
+ * パス文字列からペイン番号を抽出する（純粋関数）
+ * @returns ペイン番号 or null
+ */
+export function extractPaneNumber(dirPath: string): number | null {
+  const match = dirPath.match(PANE_PATTERN)
+  return match ? parseInt(match[1], 10) : null
+}
+
+/**
+ * 環境変数 → CWDパス の優先順位でペイン番号を検出する
+ * @param env - process.env（テスト時に差し替え可能）
+ * @param cwd - カレントディレクトリ（テスト時に差し替え可能）
+ * @returns ペイン番号 or null
+ */
+export function detectPaneNumber(
+  env: Record<string, string | undefined> = process.env,
+  cwd: string = process.cwd(),
+): number | null {
+  // 1. 環境変数が明示的に設定されていれば優先（空文字列・非数値はスキップ）
+  if (env.PANE_NUMBER != null && env.PANE_NUMBER !== '') {
+    const n = parseInt(env.PANE_NUMBER, 10)
+    if (!isNaN(n)) return n
+  }
+  // 2. CWDのworktreeパスから推定
+  return extractPaneNumber(cwd)
+}


### PR DESCRIPTION
closes #211

## 主な変更

### 新機能
- Resource HUD（リソース監視ダッシュボード）
- PlaywrightRunner（pane単位の自動テスト実行）
- DevInstanceManager + SessionDevBindingService
- ProcessSupervisor + ensurePersistentDevelopWorktree
- DevInstance / SlotAssignment 型・ストア
- LeaderLock（重複起動防止の二層ロック）
- StartupGuard tri-state
- PaneToolbar ファイルツリーボタン
- Claude Code --dangerously-skip-permissions 付与
- worktreeパスからPANE_NUMBERを自動検出

### バグ修正
- ワークスペース切替時のターミナル破損修正
- ペイン分割時のセッション同期修正
- PaneToolbar視認性改善（WCAG対応）
- ターミナルmac風キーバインド対応
- PTYのCMUX_*環境変数リーク修正
- フィードバックボタン問題修正

### リファクタリング
- ペイン分割時のworktree自動作成を廃止
- Playwright MCP を launchd 常駐方式に移行

## 動作確認

- [ ] CIビルド正常完了
- [ ] DMGインストール・起動確認
- [ ] API応答確認
- [ ] Playwrightで基本操作検証