### PR TITLE
fix(client): CIビルドのモジュール解決エラーを修正 (closes #213)

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { detectPaneNumber } from '@kurimats/shared'
 
 // PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+// NOTE: @kurimats/shared を直接importするとCI環境でモジュール解決に失敗するためインライン化
+function detectPaneNumber(): number | null {
+  const envVal = process.env.PANE_NUMBER
+  if (envVal != null && envVal !== '') {
+    const n = parseInt(envVal, 10)
+    if (!isNaN(n)) return n
+  }
+  const match = process.cwd().match(/-pane(\d+)(?:\/|$)/)
+  return match ? parseInt(match[1], 10) : null
+}
+
 const paneNumber = detectPaneNumber()
 const serverPort = paneNumber != null
   ? String(14000 + paneNumber)


### PR DESCRIPTION
closes #213

## Summary
- vite.config.tsの`@kurimats/shared`インポートをインライン化
- CI環境で`.js`拡張子のモジュール解決に失敗する問題を修正

## 動作確認
- [x] ローカル`npm run build:electron`成功
- [ ] CIビルド成功