### PR TITLE
release: develop → main デプロイ (closes #211)

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { detectPaneNumber } from '@kurimats/shared'
 
 // PANE_NUMBERを自動検出（環境変数 → worktreeパス名 → null）
+// NOTE: @kurimats/shared を直接importするとCI環境でモジュール解決に失敗するためインライン化
+function detectPaneNumber(): number | null {
+  const envVal = process.env.PANE_NUMBER
+  if (envVal != null && envVal !== '') {
+    const n = parseInt(envVal, 10)
+    if (!isNaN(n)) return n
+  }
+  const match = process.cwd().match(/-pane(\d+)(?:\/|$)/)
+  return match ? parseInt(match[1], 10) : null
+}
+
 const paneNumber = detectPaneNumber()
 const serverPort = paneNumber != null
   ? String(14000 + paneNumber)


### PR DESCRIPTION
closes #211

## 主な変更

### 新機能
- Resource HUD（リソース監視ダッシュボード）
- PlaywrightRunner（pane単位の自動テスト実行）
- DevInstanceManager + SessionDevBindingService
- ProcessSupervisor + ensurePersistentDevelopWorktree
- LeaderLock（重複起動防止の二層ロック）
- StartupGuard tri-state
- PaneToolbar ファイルツリーボタン・視認性改善
- Claude Code --dangerously-skip-permissions 付与
- worktreeパスからPANE_NUMBERを自動検出

### バグ修正
- CIビルドのモジュール解決エラー修正
- ワークスペース切替時のターミナル破損修正
- ペイン分割時のセッション同期修正
- ターミナルmac風キーバインド対応
- PTYのCMUX_*環境変数リーク修正

### リファクタリング
- ペイン分割時のworktree自動作成を廃止
- Playwright MCP を launchd 常駐方式に移行

## 動作確認
- [ ] CIビルド成功
- [ ] DMGインストール・起動確認
- [ ] API応答確認